### PR TITLE
Fix: Update @atom-learning/theme to beta 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   ],
   "devDependencies": {
-    "@atom-learning/theme": "0.1.0-beta.3",
+    "@atom-learning/theme": "0.1.0-beta.4",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
@@ -84,7 +84,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "@atom-learning/theme": "0.1.0-beta.0",
+    "@atom-learning/theme": "0.1.0-beta.4",
     "react": "^16.8.0"
   },
   "dependencies": {

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -39,7 +39,10 @@ type InputProps = Override<
   }
 >
 
-export const Input = ({ type, ...props }: InputProps): React.ReactElement => {
+export const Input: React.FC<InputProps> = ({
+  type,
+  ...props
+}): React.ReactElement => {
   if (type === 'number')
     return (
       <StyledInput

--- a/src/components/input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/input/__snapshots__/Input.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`Input component renders a number input 1`] = `
 
 <div>
   <input
-    class="_ffzcdL _SOQhS _jbMiSP _kSJetr _bVZaHo _Fgykb _fAMvjM _itFHCM _bxAjFr _dICIiI _dFXvMo _bKudwR _jClUIq _iyDEp _fsNLp _bWucow _fkMoMT _gCPJGA _gTvwgM _hxITlq _fVdSKi _cvjZAR _cmjVcV _jQbljM _eSAGHE _dFQJLr _fYMrRD _iGHkTP _oIZSq _dIHnma _fcMdVB _ejjNCC _kjfgpN _jpQaAF _eaYTuA _dmGTUL _kKqLFw _dyCacD _jDatdc _iSyhvT _cqAMVP _fsZzKT _cuMEHZ _fQdilh _atDza _eSQMtF scid-hAotP"
+    class="_ffzcdL _SOQhS _jbMiSP _kSJetr _bVZaHo _Fgykb _fAMvjM _itFHCM _bxAjFr _dICIiI _dFXvMo _bKudwR _jClUIq _iyDEp _fsNLp _bWucow _fkMoMT _gCPJGA _gTvwgM _hxITlq _fVdSKi _cvjZAR _cmjVcV _jQbljM _eSAGHE _dFQJLr _fYMrRD _iGHkTP _oIZSq _dIHnma _fcMdVB _ejjNCC _kjfgpN _jpQaAF _eaYTuA _dmGTUL _kKqLFw _dyCacD _jDatdc _iSyhvT _cqAMVP _fsZzKT _cuMEHZ _fQdilh _atDza _eSQMtF scid-dDAfww"
     inputmode="numeric"
     pattern="[0-9]*"
     placeholder="001"
@@ -383,7 +383,7 @@ exports[`Input component renders a text input 1`] = `
 
 <div>
   <input
-    class="_ffzcdL _SOQhS _jbMiSP _kSJetr _bVZaHo _Fgykb _fAMvjM _itFHCM _bxAjFr _dICIiI _dFXvMo _bKudwR _jClUIq _iyDEp _fsNLp _bWucow _fkMoMT _gCPJGA _gTvwgM _hxITlq _fVdSKi _cvjZAR _cmjVcV _jQbljM _eSAGHE _dFQJLr _fYMrRD _iGHkTP _oIZSq _dIHnma _fcMdVB _ejjNCC _kjfgpN _jpQaAF _eaYTuA _dmGTUL _kKqLFw _dyCacD _jDatdc _iSyhvT _cqAMVP _fsZzKT _cuMEHZ _fQdilh _atDza _eSQMtF scid-hAotP"
+    class="_ffzcdL _SOQhS _jbMiSP _kSJetr _bVZaHo _Fgykb _fAMvjM _itFHCM _bxAjFr _dICIiI _dFXvMo _bKudwR _jClUIq _iyDEp _fsNLp _bWucow _fkMoMT _gCPJGA _gTvwgM _hxITlq _fVdSKi _cvjZAR _cmjVcV _jQbljM _eSAGHE _dFQJLr _fYMrRD _iGHkTP _oIZSq _dIHnma _fcMdVB _ejjNCC _kjfgpN _jpQaAF _eaYTuA _dmGTUL _kKqLFw _dyCacD _jDatdc _iSyhvT _cqAMVP _fsZzKT _cuMEHZ _fQdilh _atDza _eSQMtF scid-dDAfww"
     placeholder="INPUT"
     type="text"
   />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
     "outDir": "./dist/", // path to output directory
     "sourceMap": true, // allow sourcemap support
     "strictNullChecks": true, // enable strict null checks as a best practice
-    "module": "es6", // specify module code generation
+    "module": "ESNext", // specify module code generation
     "jsx": "react", // use typescript to transpile jsx to js
-    "target": "es6", // specify ECMAScript target version
+    "target": "esnext", // specify ECMAScript target version
     "allowJs": true, // allow a partial TypeScript and JavaScript codebase
     "moduleResolution": "node",
     "lib": ["es6", "dom"],
@@ -15,5 +15,6 @@
       "~/*": ["./*"] // allow imports from '~/components', but not '~'
     }
   },
-  "include": ["./src/", "./jest-setup.ts"]
+  "include": ["./src/", "./jest-setup.ts"],
+  "exclude": ["./src/**/*.test.*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@atom-learning/theme@0.1.0-beta.3":
-  version "0.1.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-0.1.0-beta.3.tgz#7bc6a31fb9eb219d78219b90cc1000cb9a880cf3"
-  integrity sha512-OX2WNdxBIM+jPUSxL+z0xGtWuVS6wLRXefyB0weJ/UKjnFY5BAdbblq4rUG85byD7Uat1+GniEnUwwhBL+IkPA==
+"@atom-learning/theme@0.1.0-beta.4":
+  version "0.1.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-0.1.0-beta.4.tgz#948e80dee8881bf82192b267627985b13312c315"
+  integrity sha512-AAA+DKs9hZpPLa1OHzl4sK1S87JubTyRDYCMm4hlWkad60JGgx331qww1nh340D2bg+e34g+HFuIm17Vx1kxzQ==
 
 "@babel/code-frame@7.8.3":
   version "7.8.3"


### PR DESCRIPTION
- Beta 4 exports the correct JS type, need to figure out why the snapshots update though, the ID should remain constant
- Had to update `Input` component to simplify the component type and remove test files from being type checked