### PR TITLE
fix: svg import issues and Icon prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "@radix-ui/react-radio-group": "^0.0.5",
     "@stitches/react": "0.1.0-canary.5",
     "@types/react": "^17.0.2",
-    "@types/resize-observer-browser": "^0.1.5"
+    "@types/resize-observer-browser": "^0.1.5",
+    "rollup-plugin-url": "^3.0.1"
   },
   "husky": {
     "hooks": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import typescript from '@rollup/plugin-typescript'
 import svgr from '@svgr/rollup'
 import bundleSize from 'rollup-plugin-bundle-size'
 import { terser } from 'rollup-plugin-terser'
+import url from 'rollup-plugin-url'
 
 import pkg from './package.json'
 
@@ -24,7 +25,8 @@ export default {
     commonjs(),
     resolve(),
     isProduction && terser(),
+    svgr(),
     typescript(),
-    svgr()
+    url()
   ]
 }

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -28,14 +28,14 @@ type IconProps = Override<
 export const Icon: React.FC<IconProps> = ({
   is: SVG,
   size = 'sm',
-  as, // prevent as from being included in ...reaminingProps and overwriting as={SVG} on line 29
+
   ...remainingProps
 }) => (
   <StyledIcon
-    as={SVG}
     size={size}
     viewBox="0 0 24 24"
     aria-hidden="true"
     {...remainingProps}
+    as={SVG}
   />
 )

--- a/src/components/icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/Icon.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`Icon component renders an icon 1`] = `
   <svg
     aria-hidden="true"
     class="sx5zewo sx5zewo2cbmr--size-sm"
-    data-file-name="SvgCheck"
     title="check"
     viewBox="0 0 24 24"
   />

--- a/src/components/icon/svg/index.ts
+++ b/src/components/icon/svg/index.ts
@@ -1,3 +1,2 @@
-import Check from './check.svg'
-import Home from './home.svg'
-export { Check, Home }
+export { ReactComponent as Check } from './check.svg'
+export { ReactComponent as Home } from './home.svg'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     },
     "declaration": true // output d.ts files
   },
-  "include": ["./src/"],
-  "exclude": ["./src/**/*.test.*"],
-  "files": ["types/global.d.ts"]
+  "include": ["./src/", "types/global.d.ts"],
+  "exclude": ["./src/**/*.test.*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7701,6 +7701,11 @@ mime@^2.3.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.0.tgz#2b4af934401779806ee98026bb42e8c1ae1876b1"
   integrity sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==
 
+mime@^2.4.4:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
+  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -9610,6 +9615,14 @@ rollup-plugin-terser@^7.0.2:
     jest-worker "^26.2.1"
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
+
+rollup-plugin-url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-url/-/rollup-plugin-url-3.0.1.tgz#6362fd31d7ce6d078dc5adffbd844f080de61bd7"
+  integrity sha512-fQVrxlW335snHfPqZ7a0JIkkYEIrLeFobpAxRMQnyv7xQeJOY1yOd84STIdCaLYPoGzwOq8waOdGipNH181kzg==
+  dependencies:
+    mime "^2.4.4"
+    rollup-pluginutils "^2.8.2"
 
 rollup-pluginutils@^2.8.2:
   version "2.8.2"


### PR DESCRIPTION
Fixes problems with importing SVGs as React components and with passing them to the `Icon` component's `is` prop.