### PR TITLE
Fix: Password field visibility

### DIFF
--- a/src/components/password-field/PasswordField.tsx
+++ b/src/components/password-field/PasswordField.tsx
@@ -61,7 +61,10 @@ export const PasswordField: React.FC<PasswordFieldProps> = ({
 
       <Input
         type={isPasswordVisible ? 'text' : 'password'}
-        css={{ mb: '$1', pr: 24 }} // input padding to offset the exact size of the icon
+        css={{
+          mb: '$1',
+          pr: '$sizes$2'
+        }}
         autoComplete="current-password"
         name={name}
         id={name}
@@ -70,10 +73,15 @@ export const PasswordField: React.FC<PasswordFieldProps> = ({
         {...remainingProps}
       />
       <InvisibleButton
-        onClick={togglePasswordVisibility}
         aria-label={isPasswordVisible ? hidePasswordText : showPasswordText}
+        onClick={togglePasswordVisibility}
+        onMouseDown={(e) => e.preventDefault()} // prevent focus being lost from password input
+        type="button"
       >
-        <Icon is={isPasswordVisible ? Eye : EyeOff} />
+        <Icon
+          css={{ color: '$tonal700' }}
+          is={isPasswordVisible ? Eye : EyeOff}
+        />
       </InvisibleButton>
       {error && <ValidationError>{error}</ValidationError>}
     </Box>
@@ -88,6 +96,7 @@ const InvisibleButton = styled('button', {
   background: 'none',
   cursor: 'pointer',
   position: 'absolute',
-  bottom: 16,
-  right: 8
+  bottom: 0,
+  right: 0,
+  size: '$2'
 })

--- a/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -32,6 +32,10 @@ exports[`Password component renders a password field 1`] = `
   width: 16px;
 }
 
+.sx5zewoowpu6--css {
+  color: var(--colors-tonal700);
+}
+
 .sxfigyv {
   appearance: none;
   border: 1px solid var(--colors-tonal500);
@@ -64,12 +68,12 @@ exports[`Password component renders a password field 1`] = `
   cursor: not-allowed;
 }
 
-.sxfigyvz27vu--css {
+.sxfigyv7f5rf--css {
   margin-bottom: var(--space-1);
 }
 
-.sxfigyvz27vu--css {
-  padding-right: 24px;
+.sxfigyv7f5rf--css {
+  padding-right: var(--sizes-2);
 }
 
 .sxhmjku {
@@ -85,14 +89,16 @@ exports[`Password component renders a password field 1`] = `
   font-size: var(--fontSizes-md);
 }
 
-.sxwioxk {
+.sxitja5 {
   border: none;
   padding: 0;
   background: none;
   cursor: pointer;
   position: absolute;
-  bottom: 16px;
-  right: 8px;
+  bottom: 0;
+  right: 0;
+  height: var(--sizes-2);
+  width: var(--sizes-2);
 }
 
 <div>
@@ -111,18 +117,19 @@ exports[`Password component renders a password field 1`] = `
     </div>
     <input
       autocomplete="current-password"
-      class="sxfigyv sxfigyvz27vu--css"
+      class="sxfigyv sxfigyv7f5rf--css"
       id="password"
       name="password"
       type="password"
     />
     <button
       aria-label="Show password"
-      class="sxwioxk"
+      class="sxitja5"
+      type="button"
     >
       <svg
         aria-hidden="true"
-        class="sx5zewo sx5zewo2cbmr--size-sm"
+        class="sx5zewo sx5zewo2cbmr--size-sm sx5zewoowpu6--css"
         viewBox="0 0 24 24"
       />
     </button>


### PR DESCRIPTION
- Tweak icon size to increase the hit area, knock back the color a bit to a dark grey, use `size` scale values
- Ensure focus is retained on input
- Ensure form is not submitted on click of icon

https://user-images.githubusercontent.com/3226804/110348482-9d89cb80-8029-11eb-9b7a-930cf62dda60.mov

