### PR TITLE
Feature: set default button type

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -149,11 +149,13 @@ export const Button: React.FC<ButtonProps> = ({
   theme = 'primary',
   appearance = 'solid',
   isLoading = false,
+  type = 'button',
   children,
   onClick,
   ...rest
 }) => {
-  // Note: button is not disabled when loading for accessibility purposes. Instead the clickAction is not fired and the button looks faded
+  // Note: button is not disabled when loading for accessibility purposes.
+  // Instead the clickAction is not fired and the button looks faded
   const handleClick = (callback) => {
     if (isLoading) {
       return
@@ -168,6 +170,7 @@ export const Button: React.FC<ButtonProps> = ({
       theme={theme}
       appearance={appearance}
       onClick={() => handleClick(onClick)}
+      type={type}
       {...rest}
     >
       {isLoading ? <Loader /> : children}

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -178,6 +178,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
 <div>
   <button
     class="sxcqr6b isLoading sxcqr6bxyrog--comp sxcqr6b03kze--theme-primary sxcqr6b03kze--appearance-solid"
+    type="button"
   >
     <div
       class="sx2cs53 sx2cs5323as4--css"
@@ -297,6 +298,7 @@ exports[`Button component renders a button 1`] = `
 <div>
   <button
     class="sxcqr6b  sxcqr6bxyrog--comp sxcqr6b03kze--theme-primary sxcqr6b03kze--appearance-solid"
+    type="button"
   >
     BUTTON
   </button>
@@ -420,6 +422,7 @@ exports[`Button component renders a disabled button 1`] = `
   <button
     class="sxcqr6b  sxcqr6bxyrog--comp sxcqr6b03kze--theme-primary sxcqr6b03kze--appearance-solid"
     disabled=""
+    type="button"
   >
     BUTTON
   </button>
@@ -565,6 +568,7 @@ exports[`Button component renders a disabled secondary outline button 1`] = `
   <button
     class="sxcqr6b  sxcqr6b08yia--comp sxcqr6b03kze--theme-secondary sxcqr6b03kze--appearance-outline"
     disabled=""
+    type="button"
   >
     BUTTON
   </button>
@@ -687,6 +691,7 @@ exports[`Button component renders a outline button 1`] = `
 <div>
   <button
     class="sxcqr6b  sxcqr6b8heda--comp sxcqr6b03kze--theme-primary sxcqr6b03kze--appearance-outline"
+    type="button"
   >
     BUTTON
   </button>

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -34,7 +34,9 @@ describe(`Form component`, () => {
           name="password"
           validation={{ required: 'Password is required' }}
         />
-        <Button onClick={jest.fn()}>Submit</Button>
+        <Button type="submit" onClick={jest.fn()}>
+          Submit
+        </Button>
       </Form>
     )
 


### PR DESCRIPTION
This removes the side-effect of a `Button` within a `Form` submitting the form, adding (requiring) a `type="submit"` to the `Button` makes this explicit.