### PR TITLE
Feat: polymorphic button

### DIFF
--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -65,6 +65,19 @@ describe(`Button component`, () => {
     expect(handleClick).toHaveBeenCalled()
   })
 
+  it.only('is polymorphic', async () => {
+    render(
+      <Button as="a" href="https://app.atomlearning.co.uk">
+        BUTTON
+      </Button>
+    )
+
+    const link = screen.getByRole('link')
+
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://app.atomlearning.co.uk')
+  })
+
   describe('Loading state', () => {
     it('renders a loading button', async () => {
       const { container } = render(

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import { Loader } from '~/components/loader'
 import { styled } from '~/stitches'
+import { Override } from '~/utilities'
 
 const getButtonOutlineVariant = (baseColor: string, interactColor: string) => ({
   boxShadow: 'inset 0 0 0 2px',
@@ -139,11 +140,14 @@ const StyledButton = styled('button', {
   ]
 })
 
-type ButtonProps = React.ComponentPropsWithoutRef<typeof StyledButton> &
+type ButtonProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledButton>,
   StitchesVariants<typeof StyledButton> & {
     isLoading?: boolean
-    onClick: () => void
+    onClick?: () => void
+    as: React.ComponentType | React.ElementType
   }
+>
 
 export const Button: React.FC<ButtonProps> = ({
   theme = 'primary',
@@ -151,7 +155,7 @@ export const Button: React.FC<ButtonProps> = ({
   isLoading = false,
   type = 'button',
   children,
-  onClick,
+  onClick = undefined,
   ...rest
 }) => {
   // Note: button is not disabled when loading for accessibility purposes.
@@ -169,7 +173,7 @@ export const Button: React.FC<ButtonProps> = ({
       className={isLoading ? 'isLoading' : ''}
       theme={theme}
       appearance={appearance}
-      onClick={() => handleClick(onClick)}
+      onClick={onClick ? () => handleClick(onClick) : undefined}
       type={type}
       {...rest}
     >

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -155,7 +155,7 @@ export const Button: React.FC<ButtonProps> = ({
   isLoading = false,
   type = 'button',
   children,
-  onClick = undefined,
+  onClick,
   ...rest
 }) => {
   // Note: button is not disabled when loading for accessibility purposes.

--- a/src/components/link/Link.test.tsx
+++ b/src/components/link/Link.test.tsx
@@ -26,4 +26,10 @@ describe(`Link component`, () => {
     expect(container).toMatchSnapshot()
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('is polymorphic', async () => {
+    render(<Link as="button">See more</Link>)
+
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
 })

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { styled } from '~/stitches'
+import { Override } from '~/utilities'
 
 const StyledLink = styled('a', {
   color: '$primary500',
@@ -31,7 +32,10 @@ const StyledLink = styled('a', {
   }
 })
 
-type LinkProps = React.ComponentProps<typeof StyledLink>
+type LinkProps = Override<
+  React.ComponentProps<typeof StyledLink>,
+  { as: React.ComponentType | React.ElementType }
+>
 
 export const Link: React.FC<LinkProps> = React.forwardRef(
   ({ size = 'md', ...rest }, ref) => (


### PR DESCRIPTION
Makes `Button` polymorphic by overriding its `as` prop to accept `React.ElementType` | `React.ComponentType`.

This allows us to wrap `Button` with logic to render as an `a` or `react-router` `Link` in `seahorse`, but is probably over-permissive. We should revisit this as we get more experience with realistic requirements and hopefully we can narrow the scope of the `as` prop.

I also updated the `onClick` behaviour so that no function is called at all if no `onClick` is passed. This is to ensure that the click handler in `Button` doesn't get in the way of the default behaviour of an `a`.