### PR TITLE
Fix: Layout component types

### DIFF
--- a/src/components/box/Box.tsx
+++ b/src/components/box/Box.tsx
@@ -1,13 +1,5 @@
-import * as React from 'react'
-
 import { styled } from '~/stitches'
 
-export const StyledBox = styled('div', {})
-
-// wrapping the stitches component in a React.FC prevents a TS error
-// when passing custom components as children
-export const Box: React.FC<React.ComponentPropsWithoutRef<typeof StyledBox>> = (
-  props
-) => <StyledBox {...props} />
+export const Box = styled('div', {})
 
 Box.displayName = 'Box'

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -1,13 +1,5 @@
-import * as React from 'react'
-
 import { styled } from '~/stitches'
 
-const StyledFlex = styled('div', { display: 'flex' })
-
-// wrapping the stitches component in a React.FC prevents a TS error
-// when passing custom components as children
-export const Flex: React.FC<
-  React.ComponentPropsWithoutRef<typeof StyledFlex>
-> = (props) => <StyledFlex {...props} />
+export const Flex = styled('div', { display: 'flex' })
 
 Flex.displayName = 'Flex'


### PR DESCRIPTION
- Remove custom component export to retain `as` types