### PR TITLE
Minor docs update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Adding `live` will render the code and adds the ability to live edit
 Combine either of the two previous attributes with `center` to center the component within the preview
 
 ````md
-```jsx preview center
+```jsx preview
 <Button />
 ```
 ````

--- a/src/components/box/Box.mdx
+++ b/src/components/box/Box.mdx
@@ -7,7 +7,7 @@ category: Layout
 
 Many other components are composed of `Box`, for example, this card:
 
-```jsx live center
+```jsx live
 <Box
   as="article"
   css={{
@@ -41,7 +41,7 @@ Many other components are composed of `Box`, for example, this card:
 
 Avoid rendering any of these elements directly in our components — `Box` has all the same flexibility, but with the addition of the powerful `css` prop and various styling utilities based on our themes.
 
-```jsx live center
+```jsx live
 <Box
   css={{
     bg: '$tertiary500',

--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -2,12 +2,12 @@
 title: Button
 component: Button
 description: The Button component is a light wrapper around an HTML button element.
-category: General
+category: Navigation
 ---
 
 It adds default styling and the `css` prop. By default `primary` theme is displayed with a `solid` appearance.
 
-```jsx live center
+```jsx live
 <Button>Hello world</Button>
 ```
 
@@ -15,7 +15,7 @@ It adds default styling and the `css` prop. By default `primary` theme is displa
 
 These are the available `themes` for the `Button` component: `Primary` (default), `Secondary`, `Tertiary`, `Success`, `Warning`, `Danger`
 
-```jsx preview center
+```jsx preview
 <>
   <Button>Primary</Button>
   <Button theme="secondary">Secondary</Button>
@@ -30,7 +30,7 @@ These are the available `themes` for the `Button` component: `Primary` (default)
 
 There two options for the `appearance` property: `solid` and `outline`. These are the available `outline` variations for the `primary`, `secondary` and `tertiary` themes.
 
-```jsx preview center
+```jsx preview
 <>
   <Button appearance="outline">Primary</Button>
   <Button appearance="outline" theme="secondary">
@@ -46,7 +46,7 @@ There two options for the `appearance` property: `solid` and `outline`. These ar
 
 Each variation has an `disabled` stated, by setting the `disabled` property.
 
-```jsx preview center
+```jsx preview
 <>
   <Button disabled>Disabled button</Button>
   <Button theme="success" disabled>
@@ -65,6 +65,6 @@ Each variation has an `disabled` stated, by setting the `disabled` property.
 
 When using a button to request data or fire an action that has a potential delay, including a loading state to the button can be a useful indicator that stuff is happening. The `isLoading` prop must be a boolean value to activate the loading state.
 
-```jsx live center
+```jsx live
 <Button isLoading> Hello world</Button>
 ```

--- a/src/components/checkbox/Checkbox.mdx
+++ b/src/components/checkbox/Checkbox.mdx
@@ -10,6 +10,6 @@ it's normally best to the `CheckboxField` component, which combines a `Checkbox`
 displays validation errors. Alternatively, use this `Checkbox` component to compose other field components
 with more specific requirements.
 
-```jsx preview center
+```jsx preview
 <Checkbox />
 ```

--- a/src/components/icon/Icon.mdx
+++ b/src/components/icon/Icon.mdx
@@ -11,7 +11,7 @@ Make sure any SVGs added to the library have been optimised, for example with [S
 
 ## Sizes
 
-```jsx live center
+```jsx live
 <Icon is={Check} size="sm" />
 ```
 

--- a/src/components/image/Image.mdx
+++ b/src/components/image/Image.mdx
@@ -6,6 +6,6 @@ category: Media
 
 The `Image` component renders an `img` element with basic styling to stop it from overflowing its parent element or expanding beyond its natural size and distorting.
 
-```jsx preview center
+```jsx preview
 <Image src="http://placekitten.com/280/120" alt="Cats having a nice time" />
 ```

--- a/src/components/input-field/InputField.mdx
+++ b/src/components/input-field/InputField.mdx
@@ -13,7 +13,7 @@ In addition to text `Label` (required) and a validation error (optional), `Input
 Err on the side of using consistent form fields, but if you really need something with different styling then consider composing your own field from the
 `Input`, `Label` and `ValidationError` components.
 
-```jsx live center
+```jsx live
 <InputField
   name="Email address"
   label="Email address"

--- a/src/components/input/Input.mdx
+++ b/src/components/input/Input.mdx
@@ -13,7 +13,7 @@ it might be worth adding a new one.
 `Input` accepts a subset of the `types` that an HTML `input` element because we have more specialised
 components for the others (e.g. `Checkbox`, `Radio`).
 
-```jsx live center
+```jsx live
 <Input placeholder="Placeholder text" css={{ width: 300 }} />
 ```
 

--- a/src/components/label/Label.mdx
+++ b/src/components/label/Label.mdx
@@ -15,11 +15,11 @@ For accessibility purposes the component needs either to have the `htmlFor` prop
 
 ## Sizes
 
-```jsx preview center
+```jsx preview
 <Label size="sm">A small label</Label>
 ```
 
-```jsx preview center
+```jsx preview
 <Label>A normal label</Label>
 ```
 
@@ -27,6 +27,6 @@ For accessibility purposes the component needs either to have the `htmlFor` prop
 
 To denote a required field, the `required` prop will add an `*` suffix to the label text.
 
-```jsx preview center
+```jsx preview
 <Label required>A normal label</Label>
 ```

--- a/src/components/link/Link.mdx
+++ b/src/components/link/Link.mdx
@@ -7,6 +7,6 @@ category: Navigation
 
 It adds default styling and the `css` prop.
 
-```jsx preview center
+```jsx preview
 <Link href="http://example.com/">I'm a link</Link>
 ```

--- a/src/components/list/List.mdx
+++ b/src/components/list/List.mdx
@@ -7,7 +7,7 @@ category: Content
 
 `List` renders a `ul` and accepts a `theme` prop to change the color of the bullets.
 
-```jsx live center
+```jsx live
 <List>
   <List.Item>Item 1</List.Item>
   <List.Item>Item 2</List.Item>

--- a/src/components/loader/Loader.mdx
+++ b/src/components/loader/Loader.mdx
@@ -7,7 +7,7 @@ category: Feedback
 
 Render a `Loader` to show that content is loading or that a user's action is in progress.
 
-```jsx preview center
+```jsx preview
 <Loader size="sm"/>
 <Loader />
 <Loader size="lg"/>

--- a/src/components/password-field/PasswordField.mdx
+++ b/src/components/password-field/PasswordField.mdx
@@ -11,6 +11,6 @@ category: Forms
 
 In addition to the regular `InputField` props and functionality, `PasswordField` accepts an optional `forgotPasswordURL` prop which will be used to render a link to a password reset page. It also provides the ability for the user to toggle visibility of their password.
 
-```jsx live center
+```jsx live
 <PasswordField placeholder="Your password" css={{ width: 300 }} />
 ```

--- a/src/components/popover/Popover.mdx
+++ b/src/components/popover/Popover.mdx
@@ -7,7 +7,7 @@ category: Surfaces
 
 The `Popover` can display any type of element as a trigger and has the popover hidden by default.
 
-```jsx live center
+```jsx live
 <Popover aria-label="Password hints" content="Here is some content">
   <Button>Click me</Button>
 </Popover>
@@ -17,19 +17,21 @@ The `Popover` can display any type of element as a trigger and has the popover h
 
 Has 3 different `align` variants: `center` (default), `left` and `right`:
 
-```jsx live center
-<Popover aria-label="Password hints" content="Hello World"/>
-<Popover aria-label="Password hints" align="left" content="Hello World"/>
-<Popover aria-label="Password hints" align="right" content="Hello World"/>
+````jsx live
+<>
+  <Popover aria-label="Password hints" content="Hello World"/>
+  <Popover aria-label="Password hints" align="left" content="Hello World"/>
+  <Popover aria-label="Password hints" align="right" content="Hello World"/>
+</>
 ```
 
 Also, it can be defaulted to open by setting the `defaultOpen` prop.
 
-```jsx live center
+```jsx live
 <Popover aria-label="Password hints" content="Here is some content" defaultOpen>
   <Button>Click me</Button>
 </Popover>
-```
+````
 
 ## Accessibility
 

--- a/src/components/progress-bar/ProgressBar.mdx
+++ b/src/components/progress-bar/ProgressBar.mdx
@@ -10,7 +10,7 @@ category: Feedback
 A `ProgressBar` needs to be associated with a label for accessibility purposes, therefore the component `id` needs to be set. If a label is not available, please add an `aria-label` to ensure that the component remains accessible.
 For more examples, please read [aria-progressbar-name](https://dequeuniversity.com/rules/axe/4.1/aria-progressbar-name?application=axeAPI)
 
-```jsx live center
+```jsx live
 <ProgressBar value={20} aria-label="Completion rate" />
 ```
 
@@ -18,7 +18,7 @@ For more examples, please read [aria-progressbar-name](https://dequeuniversity.c
 
 These are the available `themes` for this component: `Primary` (default), `Secondary`, `Tertiary`, `Success`, `Warning`, `Danger`
 
-```jsx preview center
+```jsx preview
 <>
   <ProgressBar value={20} />
   <ProgressBar theme="secondary" value={20} aria-label="Completion rate" />
@@ -33,7 +33,7 @@ These are the available `themes` for this component: `Primary` (default), `Secon
 
 There two options for the `appearance` property: `solid` and `outline(default)`. These are the available `outline` variations for all the `themes`.
 
-```jsx preview center
+```jsx preview
 <>
   <ProgressBar appearance="solid" value={20} aria-label="Completion rate" />
   <ProgressBar

--- a/src/components/select/Select.mdx
+++ b/src/components/select/Select.mdx
@@ -9,7 +9,7 @@ It adds default styling and the `css` prop.
 
 A `Select` needs to be associated with a label for accessibility purposes, so rather than using the `Select` component directly in a UI, consider using a `SelectField`, which provides a `Label` and displays validation errors. Use this `Select` to compose more complex `Field` type components.
 
-```jsx preview center
+```jsx preview
 <Select
   options={[
     { value: 1, label: 'Apples' },
@@ -27,7 +27,7 @@ For accessibility purposes the component needs to have the `id` prop set, to lin
 
 The component can display a default option without a value by passing the `defaultOption` property.
 
-```jsx preview center
+```jsx preview
 <Select
   aria-label="select number"
   defaultOption="Please select a number:"
@@ -43,7 +43,7 @@ The component can display a default option without a value by passing the `defau
 
 The component has a `disabled` state, by setting the `disabled` property.
 
-```jsx preview center
+```jsx preview
 <Select
   aria-label="can't select fruits"
   disabled
@@ -59,7 +59,7 @@ The component has a `disabled` state, by setting the `disabled` property.
 
 The component can show an option as `disabled`, by setting the `disabled` property on the option.
 
-```jsx preview center
+```jsx preview
 <Select
   aria-label="select fruits"
   options={[

--- a/src/components/text/Text.mdx
+++ b/src/components/text/Text.mdx
@@ -7,16 +7,16 @@ category: Content
 
 ## Sizes
 
-```jsx preview center
+```jsx preview
 <Text size="sm">
   Anything smaller than body text. E.g. "forgot your password?" prompts
 </Text>
 ```
 
-```jsx preview center
+```jsx preview
 <Text>Body text. Most text in the app will use this. </Text>
 ```
 
-```jsx preview center
+```jsx preview
 <Text size="lg">Large, non-heading text. E.g. a drop quote in an article</Text>
 ```

--- a/src/components/textarea/Textarea.mdx
+++ b/src/components/textarea/Textarea.mdx
@@ -10,6 +10,6 @@ it's normally best to use a `field` component, which combines an `Textarea` with
 displays validation errors. If none of the existing field components suit your needs,
 it might be worth adding a new one.
 
-```jsx live center
+```jsx live
 <Textarea placeholder="Placeholder text" css={{ width: 300 }} />
 ```

--- a/src/components/validation-error/ValidationError.mdx
+++ b/src/components/validation-error/ValidationError.mdx
@@ -7,6 +7,6 @@ category: Forms
 
 `ValidationError` just adds styling to our `Text` component. Use it when composing form field components so that our error messages are always consistent.
 
-```jsx preview center
+```jsx preview
 <ValidationError>Email address is a required field</ValidationError>
 ```

--- a/src/components/video/Video.mdx
+++ b/src/components/video/Video.mdx
@@ -7,12 +7,12 @@ category: Media
 
 The `Video` component supports playing Vimeo hosted videos by setting the externalId.
 
-```jsx preview center
+```jsx preview
 <Video externalId="1084537" />
 ```
 
 This component makes the video responsive by having a default ratio of `16:9`. However, this can be overriden by setting the `ratio` prop.
 
-```jsx preview center
+```jsx preview
 <Video externalId="1084537" ratio={2 / 3} />
 ```


### PR DESCRIPTION
- Removing `center` option as all previews now center
- Changed one or two categories (all tbc just conforming to our current structure)