### PR TITLE
Fix: Optional `as` for `Button` and `Link`

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -145,7 +145,7 @@ type ButtonProps = Override<
   StitchesVariants<typeof StyledButton> & {
     isLoading?: boolean
     onClick?: () => void
-    as: React.ComponentType | React.ElementType
+    as?: React.ComponentType | React.ElementType
   }
 >
 

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -34,7 +34,7 @@ const StyledLink = styled('a', {
 
 type LinkProps = Override<
   React.ComponentProps<typeof StyledLink>,
-  { as: React.ComponentType | React.ElementType }
+  { as?: React.ComponentType | React.ElementType }
 >
 
 export const Link: React.FC<LinkProps> = React.forwardRef(


### PR DESCRIPTION
These should be optional to allow standard component rendering e.g. `<Link href="http://hello.com">Hello</Link>`