### PR TITLE
Feature: Upgrade stitches

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,15 +104,15 @@
     "react": "^16.8.0"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "^0.0.4",
+    "@radix-ui/react-checkbox": "^0.0.8",
     "@radix-ui/react-icons": "^1.0.1",
-    "@radix-ui/react-progress": "^0.0.5",
-    "@radix-ui/react-radio-group": "^0.0.5",
-    "@radix-ui/react-visually-hidden": "^0.0.5",
+    "@radix-ui/react-progress": "^0.0.6",
+    "@radix-ui/react-radio-group": "^0.0.9",
+    "@radix-ui/react-visually-hidden": "^0.0.6",
     "@stitches/react": "^0.1.0",
     "@types/react": "^17.0.2",
     "@types/resize-observer-browser": "^0.1.5",
-    "react-hook-form": "^6.15.4",
+    "react-hook-form": "^6.15.5",
     "react-player": "^2.9.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -104,16 +104,17 @@
     "react": "^16.8.0"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "^0.0.8",
+    "@radix-ui/react-checkbox": "^0.0.4",
     "@radix-ui/react-icons": "^1.0.1",
-    "@radix-ui/react-progress": "^0.0.6",
-    "@radix-ui/react-radio-group": "0.0.5",
-    "@radix-ui/react-visually-hidden": "^0.0.6",
+    "@radix-ui/react-progress": "^0.0.5",
+    "@radix-ui/react-radio-group": "^0.0.5",
+    "@radix-ui/react-visually-hidden": "^0.0.5",
     "@stitches/react": "^0.1.0",
     "@types/react": "^17.0.2",
     "@types/resize-observer-browser": "^0.1.5",
-    "react-hook-form": "^6.15.5",
-    "react-player": "^2.9.0"
+    "react-hook-form": "^6.15.4",
+    "react-player": "^2.9.0",
+    "rollup-plugin-url": "^3.0.1"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@radix-ui/react-checkbox": "^0.0.8",
     "@radix-ui/react-icons": "^1.0.1",
     "@radix-ui/react-progress": "^0.0.6",
-    "@radix-ui/react-radio-group": "^0.0.9",
+    "@radix-ui/react-radio-group": "0.0.5",
     "@radix-ui/react-visually-hidden": "^0.0.6",
     "@stitches/react": "^0.1.0",
     "@types/react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -109,12 +109,11 @@
     "@radix-ui/react-progress": "^0.0.5",
     "@radix-ui/react-radio-group": "^0.0.5",
     "@radix-ui/react-visually-hidden": "^0.0.5",
-    "@stitches/react": "0.1.0-canary.5",
+    "@stitches/react": "^0.1.0",
     "@types/react": "^17.0.2",
     "@types/resize-observer-browser": "^0.1.5",
     "react-hook-form": "^6.15.4",
-    "react-player": "^2.9.0",
-    "rollup-plugin-url": "^3.0.1"
+    "react-player": "^2.9.0"
   },
   "husky": {
     "hooks": {

--- a/src/components/box/__snapshots__/Box.test.tsx.snap
+++ b/src/components/box/__snapshots__/Box.test.tsx.snap
@@ -1,18 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Box component renders 1`] = `
-.sx03kze6obnf--css {
+.sx03kze-6obnf {
   margin: auto;
-}
-
-.sx03kze6obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <div
-    class="sx03kze sx03kze6obnf--css"
+    class="sx03kze sx03kze-6obnf"
   >
     BOX
   </div>

--- a/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`Checkbox component renders a checkbox 1`] = `
     <button
       aria-checked="false"
       class="sxj3m6q"
+      data-radix-checkbox=""
       data-state="unchecked"
       role="checkbox"
       title="test"

--- a/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Checkbox component renders a checkbox 1`] = `
 .sxj3m6q {
+  -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
   border: none;

--- a/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`Checkbox component renders a checkbox 1`] = `
     <button
       aria-checked="false"
       class="sxj3m6q"
-      data-radix-checkbox=""
       data-state="unchecked"
       role="checkbox"
       title="test"

--- a/src/components/flex/__snapshots__/Flex.test.tsx.snap
+++ b/src/components/flex/__snapshots__/Flex.test.tsx.snap
@@ -5,18 +5,15 @@ exports[`Flex component renders 1`] = `
   display: flex;
 }
 
-.sx2cs536obnf--css {
+.sx2cs53-6obnf {
   margin: auto;
-}
-
-.sx2cs536obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <div
-    class="sx2cs53 sx2cs536obnf--css"
+    class="sx2cs53 sx2cs53-6obnf"
   >
     FLEX
   </div>

--- a/src/components/grid/__snapshots__/Grid.test.tsx.snap
+++ b/src/components/grid/__snapshots__/Grid.test.tsx.snap
@@ -5,18 +5,15 @@ exports[`Grid component renders 1`] = `
   display: grid;
 }
 
-.sxsxxpi6obnf--css {
+.sxsxxpi-6obnf {
   margin: auto;
-}
-
-.sxsxxpi6obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <div
-    class="sxsxxpi sxsxxpi6obnf--css"
+    class="sxsxxpi sxsxxpi-6obnf"
   >
     GRID
   </div>

--- a/src/components/heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/heading/__snapshots__/Heading.test.tsx.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Heading component renders a heading 1`] = `
-.sxq0ena {
+.sx1v0v7 {
   color: var(--colors-tonal-900);
   font-family: var(--fonts-sans);
   font-weight: 700;
   margin: 0;
 }
 
-.sxq0enar3xir--size-md {
+.sx1v0v7r3xir--size-md {
   font-size: var(--fontSizes-xl);
   line-height: 1.42;
 }
 
-.sxq0enar3xir--size-md::before {
+.sx1v0v7r3xir--size-md::before {
   content: '';
   margin-bottom: -0.3506em;
   display: table;
 }
 
-.sxq0enar3xir--size-md::after {
+.sx1v0v7r3xir--size-md::after {
   content: '';
   margin-top: -0.3506em;
   display: table;
@@ -27,7 +27,7 @@ exports[`Heading component renders a heading 1`] = `
 
 <div>
   <h2
-    class="sxq0ena sxq0enar3xir--size-md"
+    class="sx1v0v7 sx1v0v7r3xir--size-md"
   >
     HEADING
   </h2>

--- a/src/components/icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/Icon.test.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Icon component renders an icon 1`] = `
-.sx5zewo {
+.sxxem7p {
   color: currentcolor;
   display: inline-block;
   vertical-align: middle;
 }
 
-.sx5zewo2cbmr--size-sm {
+.sxxem7p2cbmr--size-sm {
   height: 16px;
   width: 16px;
 }
@@ -15,7 +15,7 @@ exports[`Icon component renders an icon 1`] = `
 <div>
   <svg
     aria-hidden="true"
-    class="sx5zewo sx5zewo2cbmr--size-sm"
+    class="sxxem7p sxxem7p2cbmr--size-sm"
     title="check"
     viewBox="0 0 24 24"
   />

--- a/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -1,16 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InputField component renders a field with a  number input 1`] = `
-.sx03kze6obnf--css {
+.sx03kze-6obnf {
   margin: auto;
-}
-
-.sx03kze6obnf--css {
   height: 100px;
   width: 100px;
 }
 
-.sxfigyv {
+.sx1up9i {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--colors-tonal500);
   border-radius: var(--radii-0);
@@ -24,25 +22,22 @@ exports[`InputField component renders a field with a  number input 1`] = `
   height: var(--sizes-2);
   width: 100%;
   padding: var(--space-3);
-}
-
-.sxfigyv {
   transition: all 100ms ease-out;
 }
 
-.sxfigyv:focus {
+.sx1up9i:focus {
   border-color: var(--colors-primary900);
   box-shadow: inset 0 0 0 1px var(--colors-primary900);
   outline: none;
 }
 
-.sxfigyv[disabled] {
+.sx1up9i[disabled] {
   background-color: var(--colors-tonal300);
   color: var(--colors-tonal700);
   cursor: not-allowed;
 }
 
-.sxdpjit {
+.sxd964z {
   color: var(--colors-secondary300);
   display: block;
   font-family: var(--fonts-sans);
@@ -50,39 +45,39 @@ exports[`InputField component renders a field with a  number input 1`] = `
   margin: 0;
 }
 
-.sxdpjitjqqvr--size-md {
+.sxd964zjqqvr--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sxdpjitjqqvr--size-md::before {
+.sxd964zjqqvr--size-md::before {
   content: '';
   margin-bottom: -0.4489em;
   display: table;
 }
 
-.sxdpjitjqqvr--size-md::after {
+.sxd964zjqqvr--size-md::after {
   content: '';
   margin-top: -0.4489em;
   display: table;
 }
 
-.sxdpjitb2uuy--css {
+.sxd964z-b2uuy {
   margin-bottom: var(--space-2);
 }
 
 <div>
   <div
-    class="sx03kze sx03kze6obnf--css"
+    class="sx03kze sx03kze-6obnf"
   >
     <label
-      class="sxdpjit sxdpjitjqqvr--size-md sxdpjitb2uuy--css"
+      class="sxd964z sxd964zjqqvr--size-md sxd964z-b2uuy"
       for="INPUT FIELD"
     >
       INPUT FIELD
     </label>
     <input
-      class="sxfigyv"
+      class="sx1up9i"
       id="INPUT FIELD"
       inputmode="numeric"
       name="INPUT FIELD"
@@ -95,16 +90,14 @@ exports[`InputField component renders a field with a  number input 1`] = `
 `;
 
 exports[`InputField component renders a field with a text input 1`] = `
-.sx03kze6obnf--css {
+.sx03kze-6obnf {
   margin: auto;
-}
-
-.sx03kze6obnf--css {
   height: 100px;
   width: 100px;
 }
 
-.sxfigyv {
+.sx1up9i {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--colors-tonal500);
   border-radius: var(--radii-0);
@@ -118,25 +111,22 @@ exports[`InputField component renders a field with a text input 1`] = `
   height: var(--sizes-2);
   width: 100%;
   padding: var(--space-3);
-}
-
-.sxfigyv {
   transition: all 100ms ease-out;
 }
 
-.sxfigyv:focus {
+.sx1up9i:focus {
   border-color: var(--colors-primary900);
   box-shadow: inset 0 0 0 1px var(--colors-primary900);
   outline: none;
 }
 
-.sxfigyv[disabled] {
+.sx1up9i[disabled] {
   background-color: var(--colors-tonal300);
   color: var(--colors-tonal700);
   cursor: not-allowed;
 }
 
-.sxdpjit {
+.sxd964z {
   color: var(--colors-secondary300);
   display: block;
   font-family: var(--fonts-sans);
@@ -144,39 +134,39 @@ exports[`InputField component renders a field with a text input 1`] = `
   margin: 0;
 }
 
-.sxdpjitjqqvr--size-md {
+.sxd964zjqqvr--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sxdpjitjqqvr--size-md::before {
+.sxd964zjqqvr--size-md::before {
   content: '';
   margin-bottom: -0.4489em;
   display: table;
 }
 
-.sxdpjitjqqvr--size-md::after {
+.sxd964zjqqvr--size-md::after {
   content: '';
   margin-top: -0.4489em;
   display: table;
 }
 
-.sxdpjitb2uuy--css {
+.sxd964z-b2uuy {
   margin-bottom: var(--space-2);
 }
 
 <div>
   <div
-    class="sx03kze sx03kze6obnf--css"
+    class="sx03kze sx03kze-6obnf"
   >
     <label
-      class="sxdpjit sxdpjitjqqvr--size-md sxdpjitb2uuy--css"
+      class="sxd964z sxd964zjqqvr--size-md sxd964z-b2uuy"
       for="INPUT FIELD"
     >
       INPUT FIELD
     </label>
     <input
-      class="sxfigyv"
+      class="sx1up9i"
       id="INPUT FIELD"
       name="INPUT FIELD"
       placeholder="INPUT FIELD"

--- a/src/components/input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/input/__snapshots__/Input.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Input component renders a number input 1`] = `
-.sxfigyv {
+.sx1up9i {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--colors-tonal500);
   border-radius: var(--radii-0);
@@ -15,36 +16,30 @@ exports[`Input component renders a number input 1`] = `
   height: var(--sizes-2);
   width: 100%;
   padding: var(--space-3);
-}
-
-.sxfigyv {
   transition: all 100ms ease-out;
 }
 
-.sxfigyv:focus {
+.sx1up9i:focus {
   border-color: var(--colors-primary900);
   box-shadow: inset 0 0 0 1px var(--colors-primary900);
   outline: none;
 }
 
-.sxfigyv[disabled] {
+.sx1up9i[disabled] {
   background-color: var(--colors-tonal300);
   color: var(--colors-tonal700);
   cursor: not-allowed;
 }
 
-.sxfigyv6obnf--css {
+.sx1up9i-6obnf {
   margin: auto;
-}
-
-.sxfigyv6obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <input
-    class="sxfigyv sxfigyv6obnf--css"
+    class="sx1up9i sx1up9i-6obnf"
     inputmode="numeric"
     pattern="[0-9]*"
     placeholder="001"
@@ -54,7 +49,8 @@ exports[`Input component renders a number input 1`] = `
 `;
 
 exports[`Input component renders a text input 1`] = `
-.sxfigyv {
+.sx1up9i {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--colors-tonal500);
   border-radius: var(--radii-0);
@@ -68,36 +64,30 @@ exports[`Input component renders a text input 1`] = `
   height: var(--sizes-2);
   width: 100%;
   padding: var(--space-3);
-}
-
-.sxfigyv {
   transition: all 100ms ease-out;
 }
 
-.sxfigyv:focus {
+.sx1up9i:focus {
   border-color: var(--colors-primary900);
   box-shadow: inset 0 0 0 1px var(--colors-primary900);
   outline: none;
 }
 
-.sxfigyv[disabled] {
+.sx1up9i[disabled] {
   background-color: var(--colors-tonal300);
   color: var(--colors-tonal700);
   cursor: not-allowed;
 }
 
-.sxfigyv6obnf--css {
+.sx1up9i-6obnf {
   margin: auto;
-}
-
-.sxfigyv6obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <input
-    class="sxfigyv sxfigyv6obnf--css"
+    class="sx1up9i sx1up9i-6obnf"
     placeholder="INPUT"
     type="text"
   />

--- a/src/components/label/__snapshots__/Label.test.tsx.snap
+++ b/src/components/label/__snapshots__/Label.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Label component renders a label 1`] = `
-.sxdpjit {
+.sxd964z {
   color: var(--colors-secondary300);
   display: block;
   font-family: var(--fonts-sans);
@@ -9,18 +9,18 @@ exports[`Label component renders a label 1`] = `
   margin: 0;
 }
 
-.sxdpjitjqqvr--size-md {
+.sxd964zjqqvr--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sxdpjitjqqvr--size-md::before {
+.sxd964zjqqvr--size-md::before {
   content: '';
   margin-bottom: -0.4489em;
   display: table;
 }
 
-.sxdpjitjqqvr--size-md::after {
+.sxd964zjqqvr--size-md::after {
   content: '';
   margin-top: -0.4489em;
   display: table;
@@ -28,7 +28,7 @@ exports[`Label component renders a label 1`] = `
 
 <div>
   <label
-    class="sxdpjit sxdpjitjqqvr--size-md"
+    class="sxd964z sxd964zjqqvr--size-md"
   >
     TEXT
   </label>

--- a/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -1,32 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Link component renders an anchor 1`] = `
-.sx4uyeb {
+.sxqc8p4 {
   color: var(--colors-primary500);
   font-family: var(--fonts-sans);
   text-decoration: none;
   cursor: pointer;
 }
 
-.sx4uyeb:focus,
-.sx4uyeb:hover {
+.sxqc8p4:focus,
+.sxqc8p4:hover {
   color: var(--colors-primary900);
   text-decoration: underline;
 }
 
-.sx4uyeb:active,
-.sx4uyeb:visited {
+.sxqc8p4:active,
+.sxqc8p4:visited {
   color: var(--colors-primary500);
 }
 
-.sx4uyeb5dbgn--size-md {
+.sxqc8p45dbgn--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
 <div>
   <a
-    class="sx4uyeb sx4uyeb5dbgn--size-md"
+    class="sxqc8p4 sxqc8p45dbgn--size-md"
     href="https://google.com/"
   >
     GOOGLE
@@ -35,37 +35,37 @@ exports[`Link component renders an anchor 1`] = `
 `;
 
 exports[`Link component renders an large anchor 1`] = `
-.sx4uyeb {
+.sxqc8p4 {
   color: var(--colors-primary500);
   font-family: var(--fonts-sans);
   text-decoration: none;
   cursor: pointer;
 }
 
-.sx4uyeb:focus,
-.sx4uyeb:hover {
+.sxqc8p4:focus,
+.sxqc8p4:hover {
   color: var(--colors-primary900);
   text-decoration: underline;
 }
 
-.sx4uyeb:active,
-.sx4uyeb:visited {
+.sxqc8p4:active,
+.sxqc8p4:visited {
   color: var(--colors-primary500);
 }
 
-.sx4uyeb5dbgn--size-md {
+.sxqc8p45dbgn--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sx4uyebn3mo2--size-lg {
+.sxqc8p4n3mo2--size-lg {
   font-size: var(--fontSizes-lg);
   line-height: 1.52;
 }
 
 <div>
   <a
-    class="sx4uyeb sx4uyebn3mo2--size-lg"
+    class="sxqc8p4 sxqc8p4n3mo2--size-lg"
     href="https://google.com/"
   >
     GOOGLE

--- a/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/src/components/list/__snapshots__/List.test.tsx.snap
@@ -1,40 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`List component renders a list 1`] = `
-.sxlegl2 {
+.sxs9lri {
   font-family: var(--fonts-sans);
   padding-left: var(--space-3);
 }
 
-.sxlegl2 .sx03kze {
+.sxs9lri .sx03kze {
   padding-left: var(--space-2);
 }
 
-.sxlegl2 .sx03kze::marker {
+.sxs9lri .sx03kze::marker {
   content: "•";
   font-weight: bold;
 }
 
-.sxlegl2 .sx03kze:not(:last-child) {
+.sxs9lri .sx03kze:not(:last-child) {
   margin-bottom: var(--space-2);
 }
 
-.sxlegl2k6wac--theme-tonal .sx03kze::marker {
+.sxs9lrik6wac--theme-tonal .sx03kze::marker {
   color: var(--colors-tonal900);
 }
 
-.sxlegl2jqqvr--size-md {
+.sxs9lrijqqvr--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sxlegl2jqqvr--size-md::before {
+.sxs9lrijqqvr--size-md::before {
   content: '';
   margin-bottom: -0.4489em;
   display: table;
 }
 
-.sxlegl2jqqvr--size-md::after {
+.sxs9lrijqqvr--size-md::after {
   content: '';
   margin-top: -0.4489em;
   display: table;
@@ -42,7 +42,7 @@ exports[`List component renders a list 1`] = `
 
 <div>
   <ul
-    class="sxlegl2 sxlegl2k6wac--theme-tonal sxlegl2jqqvr--size-md"
+    class="sxs9lri sxs9lrik6wac--theme-tonal sxs9lrijqqvr--size-md"
   >
     <li
       class="sx03kze"

--- a/src/components/loader/__snapshots__/Loader.test.tsx.snap
+++ b/src/components/loader/__snapshots__/Loader.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Loader component renders a loader 1`] = `
     role="alert"
   >
     <span
+      data-radix-visually-hidden=""
       style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; word-wrap: normal;"
     >
       Content is loading

--- a/src/components/loader/__snapshots__/Loader.test.tsx.snap
+++ b/src/components/loader/__snapshots__/Loader.test.tsx.snap
@@ -27,11 +27,11 @@ exports[`Loader component renders a loader 1`] = `
   display: flex;
 }
 
-.sx2cs5323as4--css {
+.sx2cs53-23as4 {
   justify-content: center;
 }
 
-.sx0yv19 {
+.sx4m3y2 {
   animation-name: sxwho2l;
   animation-duration: 1s;
   animation-fill-mode: both;
@@ -41,31 +41,28 @@ exports[`Loader component renders a loader 1`] = `
   border-radius: 100%;
 }
 
-.sx0yv19:nth-child(1) {
+.sx4m3y2:nth-child(1) {
   animation-delay: -300ms;
 }
 
-.sx0yv19:nth-child(2) {
+.sx4m3y2:nth-child(2) {
   animation-delay: -150ms;
 }
 
-.sx0yv19:nth-child(3) {
+.sx4m3y2:nth-child(3) {
   animation-delay: 0;
 }
 
-.sx0yv194btw3--size-md {
+.sx4m3y24btw3--size-md {
   height: 6px;
   width: 6px;
-}
-
-.sx0yv194btw3--size-md {
   margin-left: 2px;
   margin-right: 2px;
 }
 
 <div>
   <div
-    class="sx2cs53 sx2cs5323as4--css"
+    class="sx2cs53 sx2cs53-23as4"
     role="alert"
   >
     <span
@@ -75,13 +72,13 @@ exports[`Loader component renders a loader 1`] = `
       Content is loading
     </span>
     <div
-      class="sx0yv19 sx0yv194btw3--size-md"
+      class="sx4m3y2 sx4m3y24btw3--size-md"
     />
     <div
-      class="sx0yv19 sx0yv194btw3--size-md"
+      class="sx4m3y2 sx4m3y24btw3--size-md"
     />
     <div
-      class="sx0yv19 sx0yv194btw3--size-md"
+      class="sx4m3y2 sx4m3y24btw3--size-md"
     />
   </div>
 </div>

--- a/src/components/loader/__snapshots__/Loader.test.tsx.snap
+++ b/src/components/loader/__snapshots__/Loader.test.tsx.snap
@@ -66,7 +66,6 @@ exports[`Loader component renders a loader 1`] = `
     role="alert"
   >
     <span
-      data-radix-visually-hidden=""
       style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; word-wrap: normal;"
     >
       Content is loading

--- a/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -1,17 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Password component renders a password field 1`] = `
-.sx03kzer6kvz--css {
+.sx03kze-r6kvz {
   position: relative;
   margin: auto;
-}
-
-.sx03kzer6kvz--css {
   height: 100px;
   width: 100px;
 }
 
-.sx03kze2v396--css {
+.sx03kze-2v396 {
   position: relative;
 }
 
@@ -19,28 +16,29 @@ exports[`Password component renders a password field 1`] = `
   display: flex;
 }
 
-.sx2cs53re4mk--css {
+.sx2cs53-re4mk {
   justify-content: space-between;
   align-items: center;
   margin-bottom: var(--space-2);
 }
 
-.sx5zewo {
+.sxxem7p {
   color: currentcolor;
   display: inline-block;
   vertical-align: middle;
 }
 
-.sx5zewo2cbmr--size-sm {
+.sxxem7p2cbmr--size-sm {
   height: 16px;
   width: 16px;
 }
 
-.sx5zewoowpu6--css {
+.sxxem7p-owpu6 {
   color: var(--colors-tonal700);
 }
 
-.sxfigyv {
+.sx1up9i {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--colors-tonal500);
   border-radius: var(--radii-0);
@@ -54,29 +52,26 @@ exports[`Password component renders a password field 1`] = `
   height: var(--sizes-2);
   width: 100%;
   padding: var(--space-3);
-}
-
-.sxfigyv {
   transition: all 100ms ease-out;
 }
 
-.sxfigyv:focus {
+.sx1up9i:focus {
   border-color: var(--colors-primary900);
   box-shadow: inset 0 0 0 1px var(--colors-primary900);
   outline: none;
 }
 
-.sxfigyv[disabled] {
+.sx1up9i[disabled] {
   background-color: var(--colors-tonal300);
   color: var(--colors-tonal700);
   cursor: not-allowed;
 }
 
-.sxfigyvm8e5u--css {
+.sx1up9i-m8e5u {
   padding-right: var(--sizes-2);
 }
 
-.sxdpjit {
+.sxd964z {
   color: var(--colors-secondary300);
   display: block;
   font-family: var(--fonts-sans);
@@ -84,18 +79,18 @@ exports[`Password component renders a password field 1`] = `
   margin: 0;
 }
 
-.sxdpjitjqqvr--size-md {
+.sxd964zjqqvr--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sxdpjitjqqvr--size-md::before {
+.sxd964zjqqvr--size-md::before {
   content: '';
   margin-bottom: -0.4489em;
   display: table;
 }
 
-.sxdpjitjqqvr--size-md::after {
+.sxd964zjqqvr--size-md::after {
   content: '';
   margin-top: -0.4489em;
   display: table;
@@ -115,24 +110,24 @@ exports[`Password component renders a password field 1`] = `
 
 <div>
   <div
-    class="sx03kze sx03kzer6kvz--css"
+    class="sx03kze sx03kze-r6kvz"
   >
     <div
-      class="sx2cs53 sx2cs53re4mk--css"
+      class="sx2cs53 sx2cs53-re4mk"
     >
       <label
-        class="sxdpjit sxdpjitjqqvr--size-md"
+        class="sxd964z sxd964zjqqvr--size-md"
         for="password"
       >
         Password
       </label>
     </div>
     <div
-      class="sx03kze sx03kze2v396--css"
+      class="sx03kze sx03kze-2v396"
     >
       <input
         autocomplete="current-password"
-        class="sxfigyv sxfigyvm8e5u--css"
+        class="sx1up9i sx1up9i-m8e5u"
         id="password"
         name="password"
         type="password"
@@ -144,7 +139,7 @@ exports[`Password component renders a password field 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="sx5zewo sx5zewo2cbmr--size-sm sx5zewoowpu6--css"
+          class="sxxem7p sxxem7p2cbmr--size-sm sxxem7p-owpu6"
           viewBox="0 0 24 24"
         />
       </button>

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -3,35 +3,32 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 import { Override } from '~/utilities/types'
 
+const trianglePseudoElementStyles = {
+  borderStyle: 'solid',
+  borderColor: 'transparent',
+  content: '""',
+  height: 0,
+  pointerEvents: 'none',
+  position: 'absolute',
+  top: '100%',
+  width: 0
+}
+
 const getTriangle = (position) => {
   const size = 8
   const border = '$tonal400'
 
   return {
+    // Combined pseduo-selectors '&::after, &::before' doesn't work in stitches
     '&::after': {
-      // Pseudo-classes need to be separated ($::after, $::before: doesn't work in stitches work)
-      borderStyle: 'solid',
-      borderColor: 'transparent',
-      content: "''", //  quotes need to be escapted as a stitches workaround for pseudoclasses
-      height: 0,
-      pointerEvents: 'none',
-      position: 'absolute',
-      top: '100%',
-      width: 0,
+      ...trianglePseudoElementStyles,
       borderTopColor: 'white',
       borderWidth: size,
       ml: -size,
       ...position
     },
     '&::before': {
-      borderStyle: 'solid',
-      borderColor: 'transparent',
-      content: "''",
-      height: 0,
-      pointerEvents: 'none',
-      position: 'absolute',
-      top: '100%',
-      width: 0,
+      ...trianglePseudoElementStyles,
       borderTopColor: border,
       borderWidth: size + 1,
       ml: -(size + 1),
@@ -89,9 +86,7 @@ const StyledPopoverContent = styled('div', {
 })
 
 type PopoverProps = Override<
-  React.ComponentPropsWithRef<
-    typeof StyledPopoverContent & typeof StyledPopover
-  >,
+  React.ComponentPropsWithRef<typeof StyledPopover>,
   {
     id?: string
     content: string

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -6,7 +6,7 @@ import { Override } from '~/utilities/types'
 const trianglePseudoElementStyles = {
   borderStyle: 'solid',
   borderColor: 'transparent',
-  content: '""',
+  content: "''",
   height: 0,
   pointerEvents: 'none',
   position: 'absolute',

--- a/src/components/popover/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/Popover.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Popover component doesn't open popover using the keypress with random k
   position: relative;
 }
 
-.sxc30pd {
+.sx52v9c {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -15,9 +15,6 @@ exports[`Popover component doesn't open popover using the keypress with random k
   min-width: 140px;
   max-width: 354px;
   padding: var(--space-3);
-}
-
-.sxc30pd {
   position: absolute;
   transition: all 150ms ease-in-out;
   width: max-content;
@@ -25,10 +22,10 @@ exports[`Popover component doesn't open popover using the keypress with random k
   visibility: hidden;
 }
 
-.sxc30pdpuxrx--align-center::after {
+.sx52v9cs9f83--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -37,16 +34,13 @@ exports[`Popover component doesn't open popover using the keypress with random k
   border-top-color: white;
   border-width: 8px;
   margin-left: -8px;
-}
-
-.sxc30pdpuxrx--align-center::after {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center::before {
+.sx52v9cs9f83--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -55,18 +49,15 @@ exports[`Popover component doesn't open popover using the keypress with random k
   border-top-color: var(--colors-tonal400);
   border-width: 9px;
   margin-left: -9px;
-}
-
-.sxc30pdpuxrx--align-center::before {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center {
+.sx52v9cs9f83--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sxc30pdx07u8--visibility-true {
+.sx52v9cx07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
@@ -90,7 +81,7 @@ exports[`Popover component doesn't open popover using the keypress with random k
     <div
       aria-hidden="true"
       aria-labelledby="popover-trigger-123"
-      class="sxc30pd sxc30pdpuxrx--align-center"
+      class="sx52v9c sx52v9cs9f83--align-center"
       role="tooltip"
     >
       Content
@@ -104,7 +95,7 @@ exports[`Popover component opens popover using the space key 1`] = `
   position: relative;
 }
 
-.sxc30pd {
+.sx52v9c {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -114,9 +105,6 @@ exports[`Popover component opens popover using the space key 1`] = `
   min-width: 140px;
   max-width: 354px;
   padding: var(--space-3);
-}
-
-.sxc30pd {
   position: absolute;
   transition: all 150ms ease-in-out;
   width: max-content;
@@ -124,10 +112,10 @@ exports[`Popover component opens popover using the space key 1`] = `
   visibility: hidden;
 }
 
-.sxc30pdpuxrx--align-center::after {
+.sx52v9cs9f83--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -136,16 +124,13 @@ exports[`Popover component opens popover using the space key 1`] = `
   border-top-color: white;
   border-width: 8px;
   margin-left: -8px;
-}
-
-.sxc30pdpuxrx--align-center::after {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center::before {
+.sx52v9cs9f83--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -154,18 +139,15 @@ exports[`Popover component opens popover using the space key 1`] = `
   border-top-color: var(--colors-tonal400);
   border-width: 9px;
   margin-left: -9px;
-}
-
-.sxc30pdpuxrx--align-center::before {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center {
+.sx52v9cs9f83--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sxc30pdx07u8--visibility-true {
+.sx52v9cx07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
@@ -189,7 +171,7 @@ exports[`Popover component opens popover using the space key 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="popover-trigger-123"
-      class="sxc30pd sxc30pdpuxrx--align-center"
+      class="sx52v9c sx52v9cs9f83--align-center"
       role="tooltip"
     >
       Content
@@ -203,7 +185,7 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   position: relative;
 }
 
-.sxc30pd {
+.sx52v9c {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -213,9 +195,6 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   min-width: 140px;
   max-width: 354px;
   padding: var(--space-3);
-}
-
-.sxc30pd {
   position: absolute;
   transition: all 150ms ease-in-out;
   width: max-content;
@@ -223,10 +202,10 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   visibility: hidden;
 }
 
-.sxc30pdpuxrx--align-center::after {
+.sx52v9cs9f83--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -235,16 +214,13 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   border-top-color: white;
   border-width: 8px;
   margin-left: -8px;
-}
-
-.sxc30pdpuxrx--align-center::after {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center::before {
+.sx52v9cs9f83--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -253,18 +229,15 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   border-top-color: var(--colors-tonal400);
   border-width: 9px;
   margin-left: -9px;
-}
-
-.sxc30pdpuxrx--align-center::before {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center {
+.sx52v9cs9f83--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sxc30pdx07u8--visibility-true {
+.sx52v9cx07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
@@ -288,7 +261,7 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
     <div
       aria-hidden="false"
       aria-labelledby="popover-trigger-123"
-      class="sxc30pd sxc30pdpuxrx--align-center sxc30pdx07u8--visibility-true"
+      class="sx52v9c sx52v9cs9f83--align-center sx52v9cx07u8--visibility-true"
       role="tooltip"
     >
       Content
@@ -302,7 +275,7 @@ exports[`Popover component renders as visible with left variant 1`] = `
   position: relative;
 }
 
-.sxc30pd {
+.sx52v9c {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -312,9 +285,6 @@ exports[`Popover component renders as visible with left variant 1`] = `
   min-width: 140px;
   max-width: 354px;
   padding: var(--space-3);
-}
-
-.sxc30pd {
   position: absolute;
   transition: all 150ms ease-in-out;
   width: max-content;
@@ -322,10 +292,10 @@ exports[`Popover component renders as visible with left variant 1`] = `
   visibility: hidden;
 }
 
-.sxc30pdpuxrx--align-center::after {
+.sx52v9cs9f83--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -334,16 +304,13 @@ exports[`Popover component renders as visible with left variant 1`] = `
   border-top-color: white;
   border-width: 8px;
   margin-left: -8px;
-}
-
-.sxc30pdpuxrx--align-center::after {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center::before {
+.sx52v9cs9f83--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -352,26 +319,23 @@ exports[`Popover component renders as visible with left variant 1`] = `
   border-top-color: var(--colors-tonal400);
   border-width: 9px;
   margin-left: -9px;
-}
-
-.sxc30pdpuxrx--align-center::before {
   left: 50%;
 }
 
-.sxc30pdpuxrx--align-center {
+.sx52v9cs9f83--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sxc30pdx07u8--visibility-true {
+.sx52v9cx07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
 
-.sxc30pd7rrb2--align-left::after {
+.sx52v9crtn4v--align-left::after {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -380,16 +344,13 @@ exports[`Popover component renders as visible with left variant 1`] = `
   border-top-color: white;
   border-width: 8px;
   margin-left: -8px;
-}
-
-.sxc30pd7rrb2--align-left::after {
   left: 40px;
 }
 
-.sxc30pd7rrb2--align-left::before {
+.sx52v9crtn4v--align-left::before {
   border-style: solid;
   border-color: transparent;
-  content: '';
+  content: "";
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -398,13 +359,10 @@ exports[`Popover component renders as visible with left variant 1`] = `
   border-top-color: var(--colors-tonal400);
   border-width: 9px;
   margin-left: -9px;
-}
-
-.sxc30pd7rrb2--align-left::before {
   left: 40px;
 }
 
-.sxc30pd7rrb2--align-left {
+.sx52v9crtn4v--align-left {
   left: 0;
   transform-origin: 60px bottom;
   transform: translate(-20px, var(--2)) scale(0.9);
@@ -425,7 +383,7 @@ exports[`Popover component renders as visible with left variant 1`] = `
     <div
       aria-hidden="false"
       aria-labelledby="popover-trigger-123"
-      class="sxc30pd sxc30pd7rrb2--align-left sxc30pdx07u8--visibility-true"
+      class="sx52v9c sx52v9crtn4v--align-left sx52v9cx07u8--visibility-true"
       role="tooltip"
     >
       Hello

--- a/src/components/popover/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/Popover.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Popover component doesn't open popover using the keypress with random k
   position: relative;
 }
 
-.sx52v9c {
+.sx9nlf7 {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -22,10 +22,10 @@ exports[`Popover component doesn't open popover using the keypress with random k
   visibility: hidden;
 }
 
-.sx52v9cs9f83--align-center::after {
+.sx9nlf7puxrx--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -37,10 +37,10 @@ exports[`Popover component doesn't open popover using the keypress with random k
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center::before {
+.sx9nlf7puxrx--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -52,12 +52,12 @@ exports[`Popover component doesn't open popover using the keypress with random k
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center {
+.sx9nlf7puxrx--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sx52v9cx07u8--visibility-true {
+.sx9nlf7x07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
@@ -81,7 +81,7 @@ exports[`Popover component doesn't open popover using the keypress with random k
     <div
       aria-hidden="true"
       aria-labelledby="popover-trigger-123"
-      class="sx52v9c sx52v9cs9f83--align-center"
+      class="sx9nlf7 sx9nlf7puxrx--align-center"
       role="tooltip"
     >
       Content
@@ -95,7 +95,7 @@ exports[`Popover component opens popover using the space key 1`] = `
   position: relative;
 }
 
-.sx52v9c {
+.sx9nlf7 {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -112,10 +112,10 @@ exports[`Popover component opens popover using the space key 1`] = `
   visibility: hidden;
 }
 
-.sx52v9cs9f83--align-center::after {
+.sx9nlf7puxrx--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -127,10 +127,10 @@ exports[`Popover component opens popover using the space key 1`] = `
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center::before {
+.sx9nlf7puxrx--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -142,12 +142,12 @@ exports[`Popover component opens popover using the space key 1`] = `
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center {
+.sx9nlf7puxrx--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sx52v9cx07u8--visibility-true {
+.sx9nlf7x07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
@@ -171,7 +171,7 @@ exports[`Popover component opens popover using the space key 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="popover-trigger-123"
-      class="sx52v9c sx52v9cs9f83--align-center"
+      class="sx9nlf7 sx9nlf7puxrx--align-center"
       role="tooltip"
     >
       Content
@@ -185,7 +185,7 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   position: relative;
 }
 
-.sx52v9c {
+.sx9nlf7 {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -202,10 +202,10 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   visibility: hidden;
 }
 
-.sx52v9cs9f83--align-center::after {
+.sx9nlf7puxrx--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -217,10 +217,10 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center::before {
+.sx9nlf7puxrx--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -232,12 +232,12 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center {
+.sx9nlf7puxrx--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sx52v9cx07u8--visibility-true {
+.sx9nlf7x07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
@@ -261,7 +261,7 @@ exports[`Popover component opens the popover once trigger is clicked 1`] = `
     <div
       aria-hidden="false"
       aria-labelledby="popover-trigger-123"
-      class="sx52v9c sx52v9cs9f83--align-center sx52v9cx07u8--visibility-true"
+      class="sx9nlf7 sx9nlf7puxrx--align-center sx9nlf7x07u8--visibility-true"
       role="tooltip"
     >
       Content
@@ -275,7 +275,7 @@ exports[`Popover component renders as visible with left variant 1`] = `
   position: relative;
 }
 
-.sx52v9c {
+.sx9nlf7 {
   box-shadow: var(--shadows-0);
   border-radius: var(--radii-1);
   background-color: white;
@@ -292,10 +292,10 @@ exports[`Popover component renders as visible with left variant 1`] = `
   visibility: hidden;
 }
 
-.sx52v9cs9f83--align-center::after {
+.sx9nlf7puxrx--align-center::after {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -307,10 +307,10 @@ exports[`Popover component renders as visible with left variant 1`] = `
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center::before {
+.sx9nlf7puxrx--align-center::before {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -322,20 +322,20 @@ exports[`Popover component renders as visible with left variant 1`] = `
   left: 50%;
 }
 
-.sx52v9cs9f83--align-center {
+.sx9nlf7puxrx--align-center {
   transform-origin: center bottom;
   transform: translate(-50%, var(--2)) scale(0.9);
 }
 
-.sx52v9cx07u8--visibility-true {
+.sx9nlf7x07u8--visibility-true {
   opacity: 1;
   visibility: visible;
 }
 
-.sx52v9crtn4v--align-left::after {
+.sx9nlf77rrb2--align-left::after {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -347,10 +347,10 @@ exports[`Popover component renders as visible with left variant 1`] = `
   left: 40px;
 }
 
-.sx52v9crtn4v--align-left::before {
+.sx9nlf77rrb2--align-left::before {
   border-style: solid;
   border-color: transparent;
-  content: "";
+  content: '';
   height: 0;
   pointer-events: none;
   position: absolute;
@@ -362,7 +362,7 @@ exports[`Popover component renders as visible with left variant 1`] = `
   left: 40px;
 }
 
-.sx52v9crtn4v--align-left {
+.sx9nlf77rrb2--align-left {
   left: 0;
   transform-origin: 60px bottom;
   transform: translate(-20px, var(--2)) scale(0.9);
@@ -383,7 +383,7 @@ exports[`Popover component renders as visible with left variant 1`] = `
     <div
       aria-hidden="false"
       aria-labelledby="popover-trigger-123"
-      class="sx52v9c sx52v9crtn4v--align-left sx52v9cx07u8--visibility-true"
+      class="sx9nlf7 sx9nlf77rrb2--align-left sx9nlf7x07u8--visibility-true"
       role="tooltip"
     >
       Hello

--- a/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
@@ -29,14 +29,12 @@ exports[`ProgressBar component renders a progress bar using default props 1`] = 
     aria-valuemin="0"
     class="sxifhea sxifhea03kze--appearance-outline sxifhea03kze--theme-primary sxifhea4bknw--c2"
     data-max="100"
-    data-radix-progress=""
     data-state="indeterminate"
     role="progressbar"
   >
     <div
       class="sxypqsd"
       data-max="100"
-      data-radix-progress-indicator=""
       data-state="indeterminate"
       style="width: 50%;"
     />
@@ -84,14 +82,12 @@ exports[`ProgressBar component renders a solid progress bar 1`] = `
     aria-valuemin="0"
     class="sxifhea sxifhea03kze--appearance-solid sxifhea03kze--theme-primary sxifheamrg77--c2"
     data-max="100"
-    data-radix-progress=""
     data-state="indeterminate"
     role="progressbar"
   >
     <div
       class="sxypqsd"
       data-max="100"
-      data-radix-progress-indicator=""
       data-state="indeterminate"
       style="width: 50%;"
     />

--- a/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProgressBar component renders a progress bar using default props 1`] = `
-.sxg17rf {
+.sxifhea {
   border-radius: 25px;
   height: 12px;
   position: relative;
@@ -9,7 +9,7 @@ exports[`ProgressBar component renders a progress bar using default props 1`] = 
   width: 100%;
 }
 
-.sxg17rf4bknw--comp {
+.sxifhea4bknw--c2 {
   border: 1px solid var(--colors-tonal400);
   background: white;
   color: var(--colors-primary500);
@@ -27,7 +27,7 @@ exports[`ProgressBar component renders a progress bar using default props 1`] = 
     aria-label="label"
     aria-valuemax="100"
     aria-valuemin="0"
-    class="sxg17rf sxg17rf4bknw--comp sxg17rf03kze--appearance-outline sxg17rf03kze--theme-primary"
+    class="sxifhea sxifhea03kze--appearance-outline sxifhea03kze--theme-primary sxifhea4bknw--c2"
     data-max="100"
     data-radix-progress=""
     data-state="indeterminate"
@@ -45,7 +45,7 @@ exports[`ProgressBar component renders a progress bar using default props 1`] = 
 `;
 
 exports[`ProgressBar component renders a solid progress bar 1`] = `
-.sxg17rf {
+.sxifhea {
   border-radius: 25px;
   height: 12px;
   position: relative;
@@ -53,19 +53,19 @@ exports[`ProgressBar component renders a solid progress bar 1`] = `
   width: 100%;
 }
 
-.sxg17rf4bknw--comp {
+.sxifhea4bknw--c2 {
   border: 1px solid var(--colors-tonal400);
   background: white;
   color: var(--colors-primary500);
 }
 
-.sxg17rf4qfa7--comp {
+.sxifhea4qfa7--c2 {
   border: 1px solid var(--colors-tonal400);
   background: white;
   color: var(--colors-secondary500);
 }
 
-.sxg17rfmrg77--comp {
+.sxifheamrg77--c2 {
   background: var(--colors-tonal300);
   color: var(--colors-primary500);
 }
@@ -82,7 +82,7 @@ exports[`ProgressBar component renders a solid progress bar 1`] = `
     aria-label="label"
     aria-valuemax="100"
     aria-valuemin="0"
-    class="sxg17rf sxg17rfmrg77--comp sxg17rf03kze--appearance-solid sxg17rf03kze--theme-primary"
+    class="sxifhea sxifhea03kze--appearance-solid sxifhea03kze--theme-primary sxifheamrg77--c2"
     data-max="100"
     data-radix-progress=""
     data-state="indeterminate"

--- a/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
@@ -29,12 +29,14 @@ exports[`ProgressBar component renders a progress bar using default props 1`] = 
     aria-valuemin="0"
     class="sxifhea sxifhea03kze--appearance-outline sxifhea03kze--theme-primary sxifhea4bknw--c2"
     data-max="100"
+    data-radix-progress=""
     data-state="indeterminate"
     role="progressbar"
   >
     <div
       class="sxypqsd"
       data-max="100"
+      data-radix-progress-indicator=""
       data-state="indeterminate"
       style="width: 50%;"
     />
@@ -82,12 +84,14 @@ exports[`ProgressBar component renders a solid progress bar 1`] = `
     aria-valuemin="0"
     class="sxifhea sxifhea03kze--appearance-solid sxifhea03kze--theme-primary sxifheamrg77--c2"
     data-max="100"
+    data-radix-progress=""
     data-state="indeterminate"
     role="progressbar"
   >
     <div
       class="sxypqsd"
       data-max="100"
+      data-radix-progress-indicator=""
       data-state="indeterminate"
       style="width: 50%;"
     />

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`Radio component renders a disabled radio 1`] = `
 <div>
   <div
     class="sx03kze"
+    data-radix-radio-group=""
     role="radiogroup"
   >
     <input
@@ -54,6 +55,7 @@ exports[`Radio component renders a disabled radio 1`] = `
       aria-label="disabled indicator"
       class="sx2kwe7"
       data-disabled=""
+      data-radix-radio-group-item=""
       data-state="unchecked"
       disabled=""
       role="radio"
@@ -106,6 +108,7 @@ exports[`Radio component renders a radio 1`] = `
 <div>
   <div
     class="sx03kze"
+    data-radix-radio-group=""
     role="radiogroup"
   >
     <input
@@ -117,7 +120,8 @@ exports[`Radio component renders a radio 1`] = `
       aria-checked="false"
       aria-label="indicator"
       class="sx2kwe7"
-      data-radix-roving-focus-group-id="radix-id-3792396957-1"
+      data-radix-radio-group-item=""
+      data-radix-roving-focus-group-1-item=""
       data-state="unchecked"
       role="radio"
       tabindex="0"

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Radio component renders a disabled radio 1`] = `
 .sx2kwe7 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
   padding: 0;
@@ -40,8 +41,8 @@ exports[`Radio component renders a disabled radio 1`] = `
 <div>
   <div
     class="sx03kze"
-    data-radix-radio-group=""
     role="radiogroup"
+    selector="radix-radio-group"
   >
     <input
       disabled=""
@@ -54,10 +55,10 @@ exports[`Radio component renders a disabled radio 1`] = `
       aria-label="disabled indicator"
       class="sx2kwe7"
       data-disabled=""
-      data-radix-radio-group-item=""
       data-state="unchecked"
       disabled=""
       role="radio"
+      selector="radix-radio-group-item"
       tabindex="-1"
       type="button"
       value="value"
@@ -68,6 +69,7 @@ exports[`Radio component renders a disabled radio 1`] = `
 
 exports[`Radio component renders a radio 1`] = `
 .sx2kwe7 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
   padding: 0;
@@ -106,8 +108,8 @@ exports[`Radio component renders a radio 1`] = `
 <div>
   <div
     class="sx03kze"
-    data-radix-radio-group=""
     role="radiogroup"
+    selector="radix-radio-group"
   >
     <input
       hidden=""
@@ -118,10 +120,10 @@ exports[`Radio component renders a radio 1`] = `
       aria-checked="false"
       aria-label="indicator"
       class="sx2kwe7"
-      data-radix-radio-group-item=""
       data-radix-roving-focus-group-1-item=""
       data-state="unchecked"
       role="radio"
+      selector="radix-radio-group-item"
       tabindex="0"
       type="button"
       value="value"

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`Radio component renders a disabled radio 1`] = `
   <div
     class="sx03kze"
     role="radiogroup"
-    selector="radix-radio-group"
   >
     <input
       disabled=""
@@ -58,7 +57,6 @@ exports[`Radio component renders a disabled radio 1`] = `
       data-state="unchecked"
       disabled=""
       role="radio"
-      selector="radix-radio-group-item"
       tabindex="-1"
       type="button"
       value="value"
@@ -109,7 +107,6 @@ exports[`Radio component renders a radio 1`] = `
   <div
     class="sx03kze"
     role="radiogroup"
-    selector="radix-radio-group"
   >
     <input
       hidden=""
@@ -120,10 +117,9 @@ exports[`Radio component renders a radio 1`] = `
       aria-checked="false"
       aria-label="indicator"
       class="sx2kwe7"
-      data-radix-roving-focus-group-1-item=""
+      data-radix-roving-focus-group-id="radix-id-3792396957-1"
       data-state="unchecked"
       role="radio"
-      selector="radix-radio-group-item"
       tabindex="0"
       type="button"
       value="value"

--- a/src/components/radio/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -4,8 +4,8 @@ exports[`RadioButtonGroup component renders an empty radio button group 1`] = `
 <div>
   <div
     class="sx03kze"
-    data-radix-radio-group=""
     role="radiogroup"
+    selector="radix-radio-group"
   />
 </div>
 `;

--- a/src/components/radio/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`RadioButtonGroup component renders an empty radio button group 1`] = `
 <div>
   <div
     class="sx03kze"
+    data-radix-radio-group=""
     role="radiogroup"
   />
 </div>

--- a/src/components/radio/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`RadioButtonGroup component renders an empty radio button group 1`] = `
   <div
     class="sx03kze"
     role="radiogroup"
-    selector="radix-radio-group"
   />
 </div>
 `;

--- a/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Select component renders a select with 3 options 1`] = `
 .sx1ewm2 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%231066b2%22%20d%3D%22M287%2069a18%2018%200%2000-13-5H18c-5%200-9%202-12%205a18%2018%200%2000-6%2013c0%205%202%2010%205%2013l128%20128c4%204%208%205%2013%205s9-1%2013-5L287%2095c4-3%205-8%205-13s-2-9-5-13z%22%2F%3E%3C%2Fsvg%3E);
@@ -19,14 +20,8 @@ exports[`Select component renders a select with 3 options 1`] = `
   line-height: 1.4;
   padding-left: var(--space-3);
   padding-right: var(--space-3);
-}
-
-.sx1ewm2 {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-}
-
-.sx1ewm2 {
   transition: all 75ms ease-out;
   width: 100%;
 }
@@ -78,6 +73,7 @@ exports[`Select component renders a select with 3 options 1`] = `
 
 exports[`Select component renders an disabled select 1`] = `
 .sx1ewm2 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%231066b2%22%20d%3D%22M287%2069a18%2018%200%2000-13-5H18c-5%200-9%202-12%205a18%2018%200%2000-6%2013c0%205%202%2010%205%2013l128%20128c4%204%208%205%2013%205s9-1%2013-5L287%2095c4-3%205-8%205-13s-2-9-5-13z%22%2F%3E%3C%2Fsvg%3E);
@@ -95,14 +91,8 @@ exports[`Select component renders an disabled select 1`] = `
   line-height: 1.4;
   padding-left: var(--space-3);
   padding-right: var(--space-3);
-}
-
-.sx1ewm2 {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-}
-
-.sx1ewm2 {
   transition: all 75ms ease-out;
   width: 100%;
 }
@@ -139,6 +129,7 @@ exports[`Select component renders an disabled select 1`] = `
 
 exports[`Select component renders select with a default option 1`] = `
 .sx1ewm2 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%231066b2%22%20d%3D%22M287%2069a18%2018%200%2000-13-5H18c-5%200-9%202-12%205a18%2018%200%2000-6%2013c0%205%202%2010%205%2013l128%20128c4%204%208%205%2013%205s9-1%2013-5L287%2095c4-3%205-8%205-13s-2-9-5-13z%22%2F%3E%3C%2Fsvg%3E);
@@ -156,14 +147,8 @@ exports[`Select component renders select with a default option 1`] = `
   line-height: 1.4;
   padding-left: var(--space-3);
   padding-right: var(--space-3);
-}
-
-.sx1ewm2 {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-}
-
-.sx1ewm2 {
   transition: all 75ms ease-out;
   width: 100%;
 }
@@ -218,6 +203,7 @@ exports[`Select component renders select with a default option 1`] = `
 
 exports[`Select component renders select with a disabled option 1`] = `
 .sx1ewm2 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%231066b2%22%20d%3D%22M287%2069a18%2018%200%2000-13-5H18c-5%200-9%202-12%205a18%2018%200%2000-6%2013c0%205%202%2010%205%2013l128%20128c4%204%208%205%2013%205s9-1%2013-5L287%2095c4-3%205-8%205-13s-2-9-5-13z%22%2F%3E%3C%2Fsvg%3E);
@@ -235,14 +221,8 @@ exports[`Select component renders select with a disabled option 1`] = `
   line-height: 1.4;
   padding-left: var(--space-3);
   padding-right: var(--space-3);
-}
-
-.sx1ewm2 {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-}
-
-.sx1ewm2 {
   transition: all 75ms ease-out;
   width: 100%;
 }
@@ -300,6 +280,7 @@ exports[`Select component renders select with a disabled option 1`] = `
 
 exports[`Select component renders select with no options 1`] = `
 .sx1ewm2 {
+  -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%231066b2%22%20d%3D%22M287%2069a18%2018%200%2000-13-5H18c-5%200-9%202-12%205a18%2018%200%2000-6%2013c0%205%202%2010%205%2013l128%20128c4%204%208%205%2013%205s9-1%2013-5L287%2095c4-3%205-8%205-13s-2-9-5-13z%22%2F%3E%3C%2Fsvg%3E);
@@ -317,14 +298,8 @@ exports[`Select component renders select with no options 1`] = `
   line-height: 1.4;
   padding-left: var(--space-3);
   padding-right: var(--space-3);
-}
-
-.sx1ewm2 {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-}
-
-.sx1ewm2 {
   transition: all 75ms ease-out;
   width: 100%;
 }

--- a/src/components/text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/text/__snapshots__/Text.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Text component renders some text 1`] = `
-.sxeds20 {
+.sxhod8r {
   color: var(--colors-tonal900);
   font-family: var(--fonts-sans);
   font-weight: 400;
@@ -9,18 +9,18 @@ exports[`Text component renders some text 1`] = `
   max-width: 60ch;
 }
 
-.sxeds20jqqvr--size-md {
+.sxhod8rjqqvr--size-md {
   font-size: var(--fontSizes-md);
   line-height: 1.625;
 }
 
-.sxeds20jqqvr--size-md::before {
+.sxhod8rjqqvr--size-md::before {
   content: '';
   margin-bottom: -0.4489em;
   display: table;
 }
 
-.sxeds20jqqvr--size-md::after {
+.sxhod8rjqqvr--size-md::after {
   content: '';
   margin-top: -0.4489em;
   display: table;
@@ -28,7 +28,7 @@ exports[`Text component renders some text 1`] = `
 
 <div>
   <p
-    class="sxeds20 sxeds20jqqvr--size-md"
+    class="sxhod8r sxhod8rjqqvr--size-md"
   >
     TEXT
   </p>

--- a/src/components/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/components/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Textarea component renders a textarea 1`] = `
 .sxb9vyw {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--colors-tonal500);
   border-radius: var(--radii-0);
@@ -15,14 +16,8 @@ exports[`Textarea component renders a textarea 1`] = `
   min-height: 100px;
   padding-left: var(--space-3);
   padding-right: var(--space-3);
-}
-
-.sxb9vyw {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-}
-
-.sxb9vyw {
   resize: vertical;
   transition: all 75ms ease-out;
   width: 100%;
@@ -39,18 +34,15 @@ exports[`Textarea component renders a textarea 1`] = `
   background-color: var(--colors-tonal300);
 }
 
-.sxb9vyw6obnf--css {
+.sxb9vyw-6obnf {
   margin: auto;
-}
-
-.sxb9vyw6obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <textarea
-    class="sxb9vyw sxb9vyw6obnf--css"
+    class="sxb9vyw sxb9vyw-6obnf"
     placeholder="DESCRIPTION"
   />
 </div>

--- a/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
+++ b/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ValidationError component renders a validation error 1`] = `
-.sxeds20 {
+.sxhod8r {
   color: var(--colors-tonal900);
   font-family: var(--fonts-sans);
   font-weight: 400;
@@ -9,18 +9,18 @@ exports[`ValidationError component renders a validation error 1`] = `
   max-width: 60ch;
 }
 
-.sxeds200nw35--size-sm {
+.sxhod8r0nw35--size-sm {
   font-size: var(--fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxeds2025jen--css {
+.sxhod8r-25jen {
   color: var(--colors-danger);
 }
 
 <div>
   <p
-    class="sxeds20 sxeds200nw35--size-sm sxeds2025jen--css"
+    class="sxhod8r sxhod8r0nw35--size-sm sxhod8r-25jen"
   >
     VALIDATION ERROR
   </p>

--- a/src/components/video/__snapshots__/Video.test.tsx.snap
+++ b/src/components/video/__snapshots__/Video.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video component renders a video with custom ratio (4:3) 1`] = `
-.sx03kzeqiz11--css {
+.sx03kze-qiz11 {
   position: relative;
   padding-top: 56.25%;
   overflow: hidden;
@@ -9,7 +9,7 @@ exports[`Video component renders a video with custom ratio (4:3) 1`] = `
   width: 100%;
 }
 
-.sx03kzeifq7y--css {
+.sx03kze-ifq7y {
   position: relative;
   padding-top: 75%;
   overflow: hidden;
@@ -17,7 +17,7 @@ exports[`Video component renders a video with custom ratio (4:3) 1`] = `
   width: 100%;
 }
 
-.sx03kzevtaup--css {
+.sx03kze-vtaup {
   position: absolute;
   top: 0;
   left: 0;
@@ -25,10 +25,10 @@ exports[`Video component renders a video with custom ratio (4:3) 1`] = `
 
 <div>
   <div
-    class="sx03kze sx03kzeifq7y--css"
+    class="sx03kze sx03kze-ifq7y"
   >
     <div
-      class="sx03kze sx03kzevtaup--css"
+      class="sx03kze sx03kze-vtaup"
       role="figure"
       style="width: 100%; height: 100%;"
     >
@@ -41,7 +41,7 @@ exports[`Video component renders a video with custom ratio (4:3) 1`] = `
 `;
 
 exports[`Video component renders a video with default ratio 1`] = `
-.sx03kzeqiz11--css {
+.sx03kze-qiz11 {
   position: relative;
   padding-top: 56.25%;
   overflow: hidden;
@@ -49,7 +49,7 @@ exports[`Video component renders a video with default ratio 1`] = `
   width: 100%;
 }
 
-.sx03kzevtaup--css {
+.sx03kze-vtaup {
   position: absolute;
   top: 0;
   left: 0;
@@ -57,10 +57,10 @@ exports[`Video component renders a video with default ratio 1`] = `
 
 <div>
   <div
-    class="sx03kze sx03kzeqiz11--css"
+    class="sx03kze sx03kze-qiz11"
   >
     <div
-      class="sx03kze sx03kzevtaup--css"
+      class="sx03kze sx03kze-vtaup"
       role="figure"
       style="width: 100%; height: 100%;"
     >

--- a/src/stitches.ts
+++ b/src/stitches.ts
@@ -2,7 +2,7 @@ import atomTheme from '@atom-learning/theme'
 import { createCss, StitchesCss } from '@stitches/react'
 
 type CSSValue = number | string
-type CSSBlob = { [key: string]: CSSValue }
+type CSSBlob = Record<string, CSSValue>
 
 // TODO: assess how intuitive the team finds these
 export const utils = {
@@ -71,19 +71,19 @@ export const utils = {
   }
 }
 
-export const conditions = {
-  sm: `@media (min-width: 550px)`,
-  md: `@media (min-width: 800px)`,
-  lg: `@media (min-width: 1100px)`,
-  xl: `@media (min-width: 1350px)`,
-  motion: `@media (prefers-reduced-motion)`,
-  hover: `@media (hover: hover)`
+export const media = {
+  sm: '(min-width: 550px)',
+  md: '(min-width: 800px)',
+  lg: '(min-width: 1100px)',
+  xl: '(min-width: 1350px)',
+  reducedMotion: '(prefers-reduced-motion)',
+  hover: '(hover: hover)'
 }
 
 const stitchesConfig = createCss({
   theme: atomTheme,
   utils,
-  conditions
+  media
 })
 
 export const {

--- a/src/stitches.ts
+++ b/src/stitches.ts
@@ -2,7 +2,7 @@ import atomTheme from '@atom-learning/theme'
 import { createCss, StitchesCss } from '@stitches/react'
 
 type CSSValue = number | string
-type CSSBlob = Record<string, CSSValue>
+type CSSBlob = { [key: string]: CSSValue }
 
 // TODO: assess how intuitive the team finds these
 export const utils = {

--- a/src/utilities/css-wrapper/__snapshots__/CSSWrapper.test.tsx.snap
+++ b/src/utilities/css-wrapper/__snapshots__/CSSWrapper.test.tsx.snap
@@ -9,18 +9,15 @@ exports[`CSSWrapper component doesn't render if not passed CSS blob 1`] = `
 `;
 
 exports[`CSSWrapper component renders if passed CSS blob 1`] = `
-.sx03kze6obnf--css {
+.sx03kze-6obnf {
   margin: auto;
-}
-
-.sx03kze6obnf--css {
   height: 100px;
   width: 100px;
 }
 
 <div>
   <div
-    class="sx03kze sx03kze6obnf--css"
+    class="sx03kze sx03kze-6obnf"
     data-testid="css-wrapper"
   >
     <p>

--- a/src/utilities/storybook.ts
+++ b/src/utilities/storybook.ts
@@ -1,5 +1,0 @@
-export const disableStitchesProps = {
-  ref: { table: { disable: true } },
-  as: { table: { disable: true } },
-  css: { table: { disable: true } }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "lib": ["es6", "dom"],
     "types": ["node", "jest"],
     "baseUrl": "./src",
+    "skipLibCheck": true,
     "paths": {
       "~/*": ["./*"] // allow imports from '~/components', but not '~'
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,11 +2129,6 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@radix-ui/number@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-0.0.1.tgz#07be7d2712aa26ed810fa185dfbc73abf70af6be"
-  integrity sha512-qkg9slhy28L8YFT12LpVg8YAHgzUfDtaiIU9cyPKOAsQwerx8BzzkBxAAn8rc9lb1Zi6hMpOrpt3CtOJ+o9b4g==
-
 "@radix-ui/primitive@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-0.0.1.tgz#402fe0e690d5ff970737689dbb5f24705d423889"
@@ -2173,6 +2168,16 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.0.1.tgz#f04627366a64c3ceab321258731dcb9515a31451"
   integrity sha512-b6ihKYxBV/4B6A49NBRMYdHVpyvavk8QakFMm+6JFwQqad4iSPbJt8aN4wOeLyEfG97rDf6hVR1YdOuA/x85dg==
 
+"@radix-ui/react-label@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.5.tgz#68d05c31ed5669190e09967026b8660a2f4cf736"
+  integrity sha512-zc249n6Ak3GMxvEwljgJ0HVMOUKV3J4eaN84YdijotTeSX04H7b/e2f54oFJuiboaPpvTu32AiwciRKt00reQg==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.5"
+    "@radix-ui/react-primitive" "0.0.4"
+    "@radix-ui/react-utils" "0.0.5"
+    "@radix-ui/utils" "0.0.3"
+
 "@radix-ui/react-label@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.6.tgz#bc9a3c9afbb9b21a478db4cfe5971d03e8dac0ca"
@@ -2183,10 +2188,23 @@
     "@radix-ui/react-polymorphic" "0.0.6"
     "@radix-ui/react-primitive" "0.0.5"
 
+"@radix-ui/react-polymorphic@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.5.tgz#7742695d5a47c732b3c5f627dfcd037c03f07f5b"
+  integrity sha512-XjAsBfFaa4FFYXZNPa9icHjDEqzvH+TVxQQwYJU2iY+6Ne1DhHXMLrGt/Vk0+BojMSPzg99NhjXROjQ4Fw30Hw==
+
 "@radix-ui/react-polymorphic@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.6.tgz#7cbadb346925d459984f540bab32403913f60ef0"
   integrity sha512-M6VVxOLII8bdnKIYK9qDH8kO8/sYJXunA0VcNKlGJvD95GuolwypXGi3gLIHCqlAozHMFJ5hzy/Vsy/rCU8Glw==
+
+"@radix-ui/react-presence@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.0.5.tgz#18661555b388f2d00db88921adf4a8b8e5369bb2"
+  integrity sha512-r2jpfsz3P15RXgz6EdoUfLhAZCiss95/CF2RYQhIRROWQ/cKfNc4FpnD1mQxYry/UULcZ8RZ4UcyBkxLzzbLnQ==
+  dependencies:
+    "@radix-ui/react-utils" "0.0.5"
+    "@xstate/fsm" "^1.5.1"
 
 "@radix-ui/react-presence@0.0.8":
   version "0.0.8"
@@ -2194,6 +2212,14 @@
   integrity sha512-898q/XFfXhTd5OGyC6bsBhqQYteT6l3YR1F5N0S4eW6BC/KEBxECuYYkFAcqMCtmc9mWzpRyA7esG27VL9fzNw==
   dependencies:
     "@radix-ui/react-compose-refs" "0.0.1"
+
+"@radix-ui/react-primitive@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.4.tgz#c4ff716e8f5a57358beb75a3d447fefcd72c7a1b"
+  integrity sha512-FRiGr6WJRQG7/9i7bUHiXmyS9hLsBrAbMbsaqapYR8VPYlJyAavkNi5sXBXUoWa/VJdeZPI8jUKe/CRZ2ye5Lw==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.5"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/react-primitive@0.0.5":
   version "0.0.5"
@@ -2218,31 +2244,26 @@
     "@radix-ui/react-polymorphic" "0.0.6"
     "@radix-ui/react-primitive" "0.0.5"
 
-"@radix-ui/react-radio-group@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-0.0.9.tgz#45ce9c93c2fca176323eb9d36c9ac56c08320d6a"
-  integrity sha512-8iIeVT27j1HV25DIYTkb+EAOUd+QEnfNXTfTrW+28qI0Yr6f7HTYIg3CgOlhYd6Ra5NITTG9jBb1nSQs6riKLg==
+"@radix-ui/react-radio-group@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-0.0.5.tgz#3c2d643cbec5e7d879ce6ce7621e1db60f180d20"
+  integrity sha512-AG/QBBE1wnlTNFQsyTUZ6nC/hVEZXWjOBQwMmzifd4EAucU0YL5uYP0yQ+C99tRt6nYfjdYfgv1Z+XfqZaVmIA==
   dependencies:
-    "@radix-ui/primitive" "0.0.1"
-    "@radix-ui/react-compose-refs" "0.0.1"
-    "@radix-ui/react-context" "0.0.1"
-    "@radix-ui/react-label" "0.0.6"
-    "@radix-ui/react-polymorphic" "0.0.6"
-    "@radix-ui/react-presence" "0.0.8"
-    "@radix-ui/react-primitive" "0.0.6"
-    "@radix-ui/react-roving-focus" "0.0.6"
-    "@radix-ui/react-use-callback-ref" "0.0.1"
-    "@radix-ui/react-use-controllable-state" "0.0.1"
+    "@radix-ui/react-label" "0.0.5"
+    "@radix-ui/react-polymorphic" "0.0.5"
+    "@radix-ui/react-presence" "0.0.5"
+    "@radix-ui/react-primitive" "0.0.4"
+    "@radix-ui/react-roving-focus" "0.0.5"
+    "@radix-ui/react-utils" "0.0.5"
+    "@radix-ui/utils" "0.0.3"
 
-"@radix-ui/react-roving-focus@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-0.0.6.tgz#806f1dce422e0738b737dc520e5c3fed187fcb67"
-  integrity sha512-Y5Ku+TGZW8LHvGUy4vQrSwI22XgYDPd3JZvxFmEh/d4YcJNSkLuPZOqPos7eoJzF6hQ95WvAEMbUgcuuBj7C3A==
+"@radix-ui/react-roving-focus@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-0.0.5.tgz#ce92310bb154421f16df3df84e266f42b9b375ba"
+  integrity sha512-+Esp3HJxoMGiTx0qn0DVAp2DTiEMpyMLLN2ijlr22dFSDihmVMQH1+VpHEZu6nhclkUx8o/3lXhrgxj6wSfILA==
   dependencies:
-    "@radix-ui/number" "0.0.1"
-    "@radix-ui/react-context" "0.0.1"
-    "@radix-ui/react-id" "0.0.1"
-    "@radix-ui/react-use-controllable-state" "0.0.1"
+    "@radix-ui/react-utils" "0.0.5"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/react-use-callback-ref@0.0.1":
   version "0.0.1"
@@ -2256,6 +2277,14 @@
   dependencies:
     "@radix-ui/react-use-callback-ref" "0.0.1"
 
+"@radix-ui/react-utils@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-utils/-/react-utils-0.0.5.tgz#d312d4b3d1d1adb25f1ef284b6d1d861c572bb85"
+  integrity sha512-OEPLfh8J6JH0Cqv3VrvI8NYQKX1nw0qVVNM14lYCgRGmAI49YrK51tcOIzqzdfuBkXLCX5QzrwK8//DjwoAbhQ==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.5"
+    "@radix-ui/utils" "0.0.3"
+
 "@radix-ui/react-visually-hidden@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.0.6.tgz#a22a8ecf7df8c353c0470d1c9168aac762a98ca0"
@@ -2263,6 +2292,11 @@
   dependencies:
     "@radix-ui/react-polymorphic" "0.0.6"
     "@radix-ui/react-primitive" "0.0.5"
+
+"@radix-ui/utils@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/utils/-/utils-0.0.3.tgz#f20dfa8a5681d778a579ad695fe68fe6a2c0ee88"
+  integrity sha512-ruWffd3JjN8r+j8+LOIzTNEHzJsFcHOiSnQfl8KeBs+sCHGQgaI9IaRWxsaNXgrOYgPdBlZCbYG3qsLww2WR+w==
 
 "@rollup/plugin-commonjs@^17.1.0":
   version "17.1.0"
@@ -2917,6 +2951,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xstate/fsm@^1.5.1":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.0.tgz#589cefcef426d5bf3d654edbca89e84e3b637c5f"
+  integrity sha512-YJpzKLPxMBUUQCTkjIbicsax6svTbPz5ykTkotIaa3kOoTnBJ4CWfC0cSQuMg7FAsfV2XWOuEsFq0dbmY7NtXg==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,17 +2357,17 @@
     webpack "^4.44.1"
     webpack-bundle-analyzer "^4.4.0"
 
-"@stitches/core@^0.1.0-canary.5":
-  version "0.1.0-canary.5"
-  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-0.1.0-canary.5.tgz#a0c32e33676606097c4841b3175cd1de7028e60f"
-  integrity sha512-WfAVbKUcqAfg3tzLyZ5JnU1pHCOgHFKbJMhKcvSc/sdQPrQTk6nFs/X3V/FipUNTHXN0Ycw4+zP/VUFGaIPpzg==
+"@stitches/core@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-0.1.0.tgz#9ee10f0eda36a6a7c0a6746aea32d41d41b6c9d2"
+  integrity sha512-3XX86Jc3iDtMEKEg9aCrRIaPOh2Qptp/5J1UH1rB5NtepCc6jXPqK0sxNNEQO6HZlv0AszycKEp8hW2KGL7Xng==
 
-"@stitches/react@0.1.0-canary.5":
-  version "0.1.0-canary.5"
-  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.1.0-canary.5.tgz#acc3fd2866c23a44d1cac03278ae64b2194ea0e3"
-  integrity sha512-t7JbvFVwIdgcJZWf+v+39U1JZ3me+mMC8MIJ9SiBP7Fbh6M6o2DpclnBeTsdAnSklIs9LRI938JUPa4fQ4ILiA==
+"@stitches/react@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.1.0.tgz#707ac79e8a5e7eae0c742bdbf2535fa9ec5439d8"
+  integrity sha512-IlbqC4bQ0iHgfpl9hcegy5QsXiZtsmQJukiB1p5eSQh133+irvS77cXFu/rHRCyBrXGr94nigJboGVmuG33ekQ==
   dependencies:
-    "@stitches/core" "^0.1.0-canary.5"
+    "@stitches/core" "^0.1.0"
 
 "@svgr/babel-plugin-add-jsx-attribute@^5.4.0":
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,145 +2129,140 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@radix-ui/react-checkbox@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-0.0.4.tgz#34a7796c8c5f0c27ec236f280ea1afcb8f526105"
-  integrity sha512-oAhp/b6+sn1YW9MnGuUsj86i9BowkCQkz4y4kOvs0hC++db6VcoEexvIpAcAcTbu8ts3aadkCLZ6W3CzF9ACOA==
+"@radix-ui/number@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-0.0.1.tgz#07be7d2712aa26ed810fa185dfbc73abf70af6be"
+  integrity sha512-qkg9slhy28L8YFT12LpVg8YAHgzUfDtaiIU9cyPKOAsQwerx8BzzkBxAAn8rc9lb1Zi6hMpOrpt3CtOJ+o9b4g==
+
+"@radix-ui/primitive@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-0.0.1.tgz#402fe0e690d5ff970737689dbb5f24705d423889"
+  integrity sha512-Z8R0kdAZui8eYTuGY5oQUA0SU4jYq43m4bZW6Dw0B35fUp+U3r+pCrkj0EADJAPv1UaKNskSv/lrfRdC7719Rg==
+
+"@radix-ui/react-checkbox@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-0.0.8.tgz#212c2afb59fe10af7e1caab29539143482749475"
+  integrity sha512-XMV+OQbyc02wouRqtnVHaEq6Bssh30nM4gqCBcl4ss5EDPO+3bTIrpw0m9ibMWkAqoV69PA4vH3ILaNzUJdK6g==
   dependencies:
-    "@radix-ui/react-label" "0.0.4"
-    "@radix-ui/react-polymorphic" "0.0.4"
-    "@radix-ui/react-presence" "0.0.4"
-    "@radix-ui/react-primitive" "0.0.3"
-    "@radix-ui/react-utils" "0.0.4"
-    "@radix-ui/utils" "0.0.3"
+    "@radix-ui/primitive" "0.0.1"
+    "@radix-ui/react-compose-refs" "0.0.1"
+    "@radix-ui/react-context" "0.0.1"
+    "@radix-ui/react-label" "0.0.6"
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-presence" "0.0.8"
+    "@radix-ui/react-primitive" "0.0.6"
+    "@radix-ui/react-use-controllable-state" "0.0.1"
+
+"@radix-ui/react-compose-refs@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-0.0.1.tgz#b615382fe6c838b6e8dc6d6ae0b504d141e46d8b"
+  integrity sha512-Am9lwUHns7zx9bYwDWQcXoLQu5mCp/uIourc15LDVNJHFT3fBhXsbTCSJrt2JQv2AfYtVM+4gR2OfdIBjlkE8w==
+
+"@radix-ui/react-context@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-0.0.1.tgz#23524f0d605fe12ee806f6e1e3834d41988c7d3d"
+  integrity sha512-oNm8xrhzbCKu/Y6E80x+mbzNlF4v34avfTqj9ZvHQzRhTKAhlgGT7JRXT3aeV7vZj4M1ofsaj/b57pYPx+GKXw==
 
 "@radix-ui/react-icons@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.0.1.tgz#37de40b8b4f3a8197ac1d29d04870e4a68f5c5b1"
   integrity sha512-EKEB7aL4FaQyK77ff8hhl+XSIUE8wQ56pHh9XnJpuwXbYSDiYELQtbS+YNFo7KJJUDre6RVFmibc223SoUxozA==
 
-"@radix-ui/react-label@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.4.tgz#70af1710083bd170b1838f70bbe0069d9e7f85ef"
-  integrity sha512-aaLpMdX5Nnlr9duJ5cowbCT/DU2SH4flznhH0awRy31h057ZCvbyRwZ1hFt+WWf4/Zn4cOrIstRe537OykRNmw==
-  dependencies:
-    "@radix-ui/react-polymorphic" "0.0.4"
-    "@radix-ui/react-primitive" "0.0.3"
-    "@radix-ui/react-utils" "0.0.4"
-    "@radix-ui/utils" "0.0.3"
+"@radix-ui/react-id@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.0.1.tgz#f04627366a64c3ceab321258731dcb9515a31451"
+  integrity sha512-b6ihKYxBV/4B6A49NBRMYdHVpyvavk8QakFMm+6JFwQqad4iSPbJt8aN4wOeLyEfG97rDf6hVR1YdOuA/x85dg==
 
-"@radix-ui/react-label@0.0.5":
+"@radix-ui/react-label@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.6.tgz#bc9a3c9afbb9b21a478db4cfe5971d03e8dac0ca"
+  integrity sha512-Fqd3ABPbU+uVIsLutcKgbaf0SMyIUlCmHTCHKYm946+dzuD7Apd4OodZTBQsiuSy/RGK8iD2k1YIXJleWUjlsA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "0.0.1"
+    "@radix-ui/react-id" "0.0.1"
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.5"
+
+"@radix-ui/react-polymorphic@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.6.tgz#7cbadb346925d459984f540bab32403913f60ef0"
+  integrity sha512-M6VVxOLII8bdnKIYK9qDH8kO8/sYJXunA0VcNKlGJvD95GuolwypXGi3gLIHCqlAozHMFJ5hzy/Vsy/rCU8Glw==
+
+"@radix-ui/react-presence@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.0.8.tgz#05a5eea07a8d443773c8a2ef057b5cdfbed6884c"
+  integrity sha512-898q/XFfXhTd5OGyC6bsBhqQYteT6l3YR1F5N0S4eW6BC/KEBxECuYYkFAcqMCtmc9mWzpRyA7esG27VL9fzNw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "0.0.1"
+
+"@radix-ui/react-primitive@0.0.5":
   version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-0.0.5.tgz#68d05c31ed5669190e09967026b8660a2f4cf736"
-  integrity sha512-zc249n6Ak3GMxvEwljgJ0HVMOUKV3J4eaN84YdijotTeSX04H7b/e2f54oFJuiboaPpvTu32AiwciRKt00reQg==
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.5.tgz#2e56cf75ada56258458957ae930771e502f151b9"
+  integrity sha512-zZacpav02cmljSaBfuc/jTqJdsZmVSQsp9Eh03v6ksS/6sGmLga46cwztDzb2by/x2izodke5NdHrVOUNAMbeA==
   dependencies:
-    "@radix-ui/react-polymorphic" "0.0.5"
-    "@radix-ui/react-primitive" "0.0.4"
-    "@radix-ui/react-utils" "0.0.5"
-    "@radix-ui/utils" "0.0.3"
+    "@radix-ui/react-polymorphic" "0.0.6"
 
-"@radix-ui/react-polymorphic@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.4.tgz#15ae4d971054c4598141f384e56b98b4f952a23c"
-  integrity sha512-VmMdYtv2GFMPUfZflO2cqB4s1Ge0BfsbrgALk16mZhNsRLwLyUKDlSgFT0SBMqcYRQKKfto0cRpZFHEJseicbg==
-
-"@radix-ui/react-polymorphic@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.5.tgz#7742695d5a47c732b3c5f627dfcd037c03f07f5b"
-  integrity sha512-XjAsBfFaa4FFYXZNPa9icHjDEqzvH+TVxQQwYJU2iY+6Ne1DhHXMLrGt/Vk0+BojMSPzg99NhjXROjQ4Fw30Hw==
-
-"@radix-ui/react-presence@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.0.4.tgz#f557942065293bbc081f6e3e4230282560e95f82"
-  integrity sha512-6Cb5AZSb4pgXfNhdjBSCVZ4ib3Z8X6oxwZNLMyHNyCIltokNNl9WqMTO5jcXi/RqpFm8sBqQNZtCwnk59LhFEg==
+"@radix-ui/react-primitive@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.6.tgz#fa26d8fe60e7a0a66b35f8c485c603d3d948be83"
+  integrity sha512-Z3NuzZvTXF36y/HnUTuWUqbLstH41LD/kDGtn5Cz6lwzvy9Mc3rMHwnIXGjXZe8MqvZ9+FxGO4p0+2cpdc+oXg==
   dependencies:
-    "@radix-ui/react-utils" "0.0.4"
-    "@xstate/fsm" "^1.5.1"
+    "@radix-ui/react-polymorphic" "0.0.6"
 
-"@radix-ui/react-presence@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.0.5.tgz#18661555b388f2d00db88921adf4a8b8e5369bb2"
-  integrity sha512-r2jpfsz3P15RXgz6EdoUfLhAZCiss95/CF2RYQhIRROWQ/cKfNc4FpnD1mQxYry/UULcZ8RZ4UcyBkxLzzbLnQ==
+"@radix-ui/react-progress@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-0.0.6.tgz#2c2d4d7e8ce46d39db23553039ec70ea9cf15747"
+  integrity sha512-KD+cy5HI0WzRzygUY5nzgF8Iy3M/S18eT243KJXhhLET7+pYXG9C9DsRraMrWd3vsNe9ApIzcW117YwFd9bcrA==
   dependencies:
-    "@radix-ui/react-utils" "0.0.5"
-    "@xstate/fsm" "^1.5.1"
+    "@radix-ui/react-context" "0.0.1"
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.5"
 
-"@radix-ui/react-primitive@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.3.tgz#208501ee0fceeb7595594529fab17d40cf224b09"
-  integrity sha512-pAn9ZgOayQJelWY7NThIrOy1qF18AX9vErnT0tDRaTK5YSsRHljTjSD14Mj2A0S/oYp2sGU/dT6n5ERO6iOLjg==
+"@radix-ui/react-radio-group@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-0.0.9.tgz#45ce9c93c2fca176323eb9d36c9ac56c08320d6a"
+  integrity sha512-8iIeVT27j1HV25DIYTkb+EAOUd+QEnfNXTfTrW+28qI0Yr6f7HTYIg3CgOlhYd6Ra5NITTG9jBb1nSQs6riKLg==
   dependencies:
-    "@radix-ui/react-polymorphic" "0.0.4"
-    "@radix-ui/utils" "0.0.3"
+    "@radix-ui/primitive" "0.0.1"
+    "@radix-ui/react-compose-refs" "0.0.1"
+    "@radix-ui/react-context" "0.0.1"
+    "@radix-ui/react-label" "0.0.6"
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-presence" "0.0.8"
+    "@radix-ui/react-primitive" "0.0.6"
+    "@radix-ui/react-roving-focus" "0.0.6"
+    "@radix-ui/react-use-callback-ref" "0.0.1"
+    "@radix-ui/react-use-controllable-state" "0.0.1"
 
-"@radix-ui/react-primitive@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.0.4.tgz#c4ff716e8f5a57358beb75a3d447fefcd72c7a1b"
-  integrity sha512-FRiGr6WJRQG7/9i7bUHiXmyS9hLsBrAbMbsaqapYR8VPYlJyAavkNi5sXBXUoWa/VJdeZPI8jUKe/CRZ2ye5Lw==
+"@radix-ui/react-roving-focus@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-0.0.6.tgz#806f1dce422e0738b737dc520e5c3fed187fcb67"
+  integrity sha512-Y5Ku+TGZW8LHvGUy4vQrSwI22XgYDPd3JZvxFmEh/d4YcJNSkLuPZOqPos7eoJzF6hQ95WvAEMbUgcuuBj7C3A==
   dependencies:
-    "@radix-ui/react-polymorphic" "0.0.5"
-    "@radix-ui/utils" "0.0.3"
+    "@radix-ui/number" "0.0.1"
+    "@radix-ui/react-context" "0.0.1"
+    "@radix-ui/react-id" "0.0.1"
+    "@radix-ui/react-use-controllable-state" "0.0.1"
 
-"@radix-ui/react-progress@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-0.0.5.tgz#75e1a2060e4130388deab9fb8a1fb531daa632a2"
-  integrity sha512-5WzGdu/+KrKO9ps2B0+gP/hvd2dfrQ9Ouk2nTHKImQL6Zcom0s1dFGBz1IKfsZgslYbuSN6Rd85oGuI5ZyqWbg==
+"@radix-ui/react-use-callback-ref@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.0.1.tgz#70c8fd7d6a146bf65860ae7d4915985aacc53acc"
+  integrity sha512-WNqLyGlHuxfghIPuKH1/1q/NNc+W2ve2S823syefD78btShmR6LJqpUXinn9X7uK7ih/pB3UySMmbTv9CWrb9A==
+
+"@radix-ui/react-use-controllable-state@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.0.1.tgz#e31ae3d52ce7db5bdae215008fe81f7eda701440"
+  integrity sha512-xWirTCesup7uyt7jDRkQDQbjKzlNq7B4y+FhHFjRF5ZThSVICdR30O4IXhfAs3gH0Of/6yLR+RnGPOwEui1bqQ==
   dependencies:
-    "@radix-ui/react-polymorphic" "0.0.5"
-    "@radix-ui/react-primitive" "0.0.4"
-    "@radix-ui/react-utils" "0.0.5"
-    "@radix-ui/utils" "0.0.3"
+    "@radix-ui/react-use-callback-ref" "0.0.1"
 
-"@radix-ui/react-radio-group@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-0.0.5.tgz#3c2d643cbec5e7d879ce6ce7621e1db60f180d20"
-  integrity sha512-AG/QBBE1wnlTNFQsyTUZ6nC/hVEZXWjOBQwMmzifd4EAucU0YL5uYP0yQ+C99tRt6nYfjdYfgv1Z+XfqZaVmIA==
+"@radix-ui/react-visually-hidden@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.0.6.tgz#a22a8ecf7df8c353c0470d1c9168aac762a98ca0"
+  integrity sha512-2nsYMHBDot50fCSH1pi/Cu27Z/D3HQigqqcXrbCeCzVb2nmI5BWi6hxScNzDr+4KBB1qZ9OfUqGttLJrPwkM5A==
   dependencies:
-    "@radix-ui/react-label" "0.0.5"
-    "@radix-ui/react-polymorphic" "0.0.5"
-    "@radix-ui/react-presence" "0.0.5"
-    "@radix-ui/react-primitive" "0.0.4"
-    "@radix-ui/react-roving-focus" "0.0.5"
-    "@radix-ui/react-utils" "0.0.5"
-    "@radix-ui/utils" "0.0.3"
-
-"@radix-ui/react-roving-focus@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-0.0.5.tgz#ce92310bb154421f16df3df84e266f42b9b375ba"
-  integrity sha512-+Esp3HJxoMGiTx0qn0DVAp2DTiEMpyMLLN2ijlr22dFSDihmVMQH1+VpHEZu6nhclkUx8o/3lXhrgxj6wSfILA==
-  dependencies:
-    "@radix-ui/react-utils" "0.0.5"
-    "@radix-ui/utils" "0.0.3"
-
-"@radix-ui/react-utils@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-utils/-/react-utils-0.0.4.tgz#4834cac08088163e0e738c3017fecab406236185"
-  integrity sha512-HqC9OJJjoDun7LNqwYzVX9gYaH5yGhdNtaBRPoSt8wywh+Kv0iU6lDP5H7w7j+6TzZCHH8XEzRbmOSowzlpGAA==
-  dependencies:
-    "@radix-ui/react-polymorphic" "0.0.4"
-    "@radix-ui/utils" "0.0.3"
-
-"@radix-ui/react-utils@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@radix-ui/react-utils/-/react-utils-0.0.5.tgz#d312d4b3d1d1adb25f1ef284b6d1d861c572bb85"
-  integrity sha512-OEPLfh8J6JH0Cqv3VrvI8NYQKX1nw0qVVNM14lYCgRGmAI49YrK51tcOIzqzdfuBkXLCX5QzrwK8//DjwoAbhQ==
-  dependencies:
-    "@radix-ui/react-polymorphic" "0.0.5"
-    "@radix-ui/utils" "0.0.3"
-
-"@radix-ui/react-visually-hidden@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.0.5.tgz#9e04587d070d36ba942c337523a23b3b9d296af7"
-  integrity sha512-8T8asSbt96IurSamS3uF+g2dc5vNieYCbHKloBn2dGq6yrr92RCxW1p0q5lX8IG9zDQq+shOPPq7wof1OPMv8Q==
-  dependencies:
-    "@radix-ui/react-polymorphic" "0.0.5"
-    "@radix-ui/react-primitive" "0.0.4"
-    "@radix-ui/utils" "0.0.3"
-
-"@radix-ui/utils@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/utils/-/utils-0.0.3.tgz#f20dfa8a5681d778a579ad695fe68fe6a2c0ee88"
-  integrity sha512-ruWffd3JjN8r+j8+LOIzTNEHzJsFcHOiSnQfl8KeBs+sCHGQgaI9IaRWxsaNXgrOYgPdBlZCbYG3qsLww2WR+w==
+    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-primitive" "0.0.5"
 
 "@rollup/plugin-commonjs@^17.1.0":
   version "17.1.0"
@@ -2922,11 +2917,6 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
-
-"@xstate/fsm@^1.5.1":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.0.tgz#589cefcef426d5bf3d654edbca89e84e3b637c5f"
-  integrity sha512-YJpzKLPxMBUUQCTkjIbicsax6svTbPz5ykTkotIaa3kOoTnBJ4CWfC0cSQuMg7FAsfV2XWOuEsFq0dbmY7NtXg==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -9368,10 +9358,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-hook-form@^6.15.4:
-  version "6.15.4"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.4.tgz#328003e1ccc096cd158899ffe7e3b33735a9b024"
-  integrity sha512-K+Sw33DtTMengs8OdqFJI3glzNl1wBzSefD/ksQw/hJf9CnOHQAU6qy82eOrh0IRNt2G53sjr7qnnw1JDjvx1w==
+react-hook-form@^6.15.5:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.5.tgz#c2578f9ce6a6df7b33015587d40cd880dc13e2db"
+  integrity sha512-so2jEPYKdVk1olMo+HQ9D9n1hVzaPPFO4wsjgSeZ964R7q7CHsYRbVF0PGBi83FcycA5482WHflasdwLIUVENg==
 
 react-is@^16.8.1:
   version "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,48 +2129,36 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@radix-ui/primitive@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-0.0.1.tgz#402fe0e690d5ff970737689dbb5f24705d423889"
-  integrity sha512-Z8R0kdAZui8eYTuGY5oQUA0SU4jYq43m4bZW6Dw0B35fUp+U3r+pCrkj0EADJAPv1UaKNskSv/lrfRdC7719Rg==
-
-"@radix-ui/react-checkbox@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-0.0.8.tgz#212c2afb59fe10af7e1caab29539143482749475"
-  integrity sha512-XMV+OQbyc02wouRqtnVHaEq6Bssh30nM4gqCBcl4ss5EDPO+3bTIrpw0m9ibMWkAqoV69PA4vH3ILaNzUJdK6g==
+"@radix-ui/react-checkbox@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-0.0.4.tgz#34a7796c8c5f0c27ec236f280ea1afcb8f526105"
+  integrity sha512-oAhp/b6+sn1YW9MnGuUsj86i9BowkCQkz4y4kOvs0hC++db6VcoEexvIpAcAcTbu8ts3aadkCLZ6W3CzF9ACOA==
   dependencies:
-    "@radix-ui/primitive" "0.0.1"
-    "@radix-ui/react-compose-refs" "0.0.1"
-    "@radix-ui/react-context" "0.0.1"
-    "@radix-ui/react-label" "0.0.6"
-    "@radix-ui/react-polymorphic" "0.0.6"
-    "@radix-ui/react-presence" "0.0.8"
-    "@radix-ui/react-primitive" "0.0.6"
-    "@radix-ui/react-use-controllable-state" "0.0.1"
-
-"@radix-ui/react-compose-refs@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-0.0.1.tgz#b615382fe6c838b6e8dc6d6ae0b504d141e46d8b"
-  integrity sha512-Am9lwUHns7zx9bYwDWQcXoLQu5mCp/uIourc15LDVNJHFT3fBhXsbTCSJrt2JQv2AfYtVM+4gR2OfdIBjlkE8w==
-
-"@radix-ui/react-context@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-0.0.1.tgz#23524f0d605fe12ee806f6e1e3834d41988c7d3d"
-  integrity sha512-oNm8xrhzbCKu/Y6E80x+mbzNlF4v34avfTqj9ZvHQzRhTKAhlgGT7JRXT3aeV7vZj4M1ofsaj/b57pYPx+GKXw==
+    "@radix-ui/react-label" "0.0.4"
+    "@radix-ui/react-polymorphic" "0.0.4"
+    "@radix-ui/react-presence" "0.0.4"
+    "@radix-ui/react-primitive" "0.0.3"
+    "@radix-ui/react-utils" "0.0.4"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/react-icons@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.0.1.tgz#37de40b8b4f3a8197ac1d29d04870e4a68f5c5b1"
   integrity sha512-EKEB7aL4FaQyK77ff8hhl+XSIUE8wQ56pHh9XnJpuwXbYSDiYELQtbS+YNFo7KJJUDre6RVFmibc223SoUxozA==
 
-"@radix-ui/react-id@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.0.1.tgz#f04627366a64c3ceab321258731dcb9515a31451"
-  integrity sha512-b6ihKYxBV/4B6A49NBRMYdHVpyvavk8QakFMm+6JFwQqad4iSPbJt8aN4wOeLyEfG97rDf6hVR1YdOuA/x85dg==
+"@radix-ui/react-label@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.4.tgz#70af1710083bd170b1838f70bbe0069d9e7f85ef"
+  integrity sha512-aaLpMdX5Nnlr9duJ5cowbCT/DU2SH4flznhH0awRy31h057ZCvbyRwZ1hFt+WWf4/Zn4cOrIstRe537OykRNmw==
+  dependencies:
+    "@radix-ui/react-polymorphic" "0.0.4"
+    "@radix-ui/react-primitive" "0.0.3"
+    "@radix-ui/react-utils" "0.0.4"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/react-label@0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.5.tgz#68d05c31ed5669190e09967026b8660a2f4cf736"
+  resolved "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-0.0.5.tgz#68d05c31ed5669190e09967026b8660a2f4cf736"
   integrity sha512-zc249n6Ak3GMxvEwljgJ0HVMOUKV3J4eaN84YdijotTeSX04H7b/e2f54oFJuiboaPpvTu32AiwciRKt00reQg==
   dependencies:
     "@radix-ui/react-polymorphic" "0.0.5"
@@ -2178,75 +2166,61 @@
     "@radix-ui/react-utils" "0.0.5"
     "@radix-ui/utils" "0.0.3"
 
-"@radix-ui/react-label@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-0.0.6.tgz#bc9a3c9afbb9b21a478db4cfe5971d03e8dac0ca"
-  integrity sha512-Fqd3ABPbU+uVIsLutcKgbaf0SMyIUlCmHTCHKYm946+dzuD7Apd4OodZTBQsiuSy/RGK8iD2k1YIXJleWUjlsA==
-  dependencies:
-    "@radix-ui/react-compose-refs" "0.0.1"
-    "@radix-ui/react-id" "0.0.1"
-    "@radix-ui/react-polymorphic" "0.0.6"
-    "@radix-ui/react-primitive" "0.0.5"
+"@radix-ui/react-polymorphic@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.4.tgz#15ae4d971054c4598141f384e56b98b4f952a23c"
+  integrity sha512-VmMdYtv2GFMPUfZflO2cqB4s1Ge0BfsbrgALk16mZhNsRLwLyUKDlSgFT0SBMqcYRQKKfto0cRpZFHEJseicbg==
 
 "@radix-ui/react-polymorphic@0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.5.tgz#7742695d5a47c732b3c5f627dfcd037c03f07f5b"
+  resolved "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.5.tgz#7742695d5a47c732b3c5f627dfcd037c03f07f5b"
   integrity sha512-XjAsBfFaa4FFYXZNPa9icHjDEqzvH+TVxQQwYJU2iY+6Ne1DhHXMLrGt/Vk0+BojMSPzg99NhjXROjQ4Fw30Hw==
 
-"@radix-ui/react-polymorphic@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.6.tgz#7cbadb346925d459984f540bab32403913f60ef0"
-  integrity sha512-M6VVxOLII8bdnKIYK9qDH8kO8/sYJXunA0VcNKlGJvD95GuolwypXGi3gLIHCqlAozHMFJ5hzy/Vsy/rCU8Glw==
+"@radix-ui/react-presence@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.0.4.tgz#f557942065293bbc081f6e3e4230282560e95f82"
+  integrity sha512-6Cb5AZSb4pgXfNhdjBSCVZ4ib3Z8X6oxwZNLMyHNyCIltokNNl9WqMTO5jcXi/RqpFm8sBqQNZtCwnk59LhFEg==
+  dependencies:
+    "@radix-ui/react-utils" "0.0.4"
+    "@xstate/fsm" "^1.5.1"
 
 "@radix-ui/react-presence@0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.0.5.tgz#18661555b388f2d00db88921adf4a8b8e5369bb2"
+  resolved "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.0.5.tgz#18661555b388f2d00db88921adf4a8b8e5369bb2"
   integrity sha512-r2jpfsz3P15RXgz6EdoUfLhAZCiss95/CF2RYQhIRROWQ/cKfNc4FpnD1mQxYry/UULcZ8RZ4UcyBkxLzzbLnQ==
   dependencies:
     "@radix-ui/react-utils" "0.0.5"
     "@xstate/fsm" "^1.5.1"
 
-"@radix-ui/react-presence@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.0.8.tgz#05a5eea07a8d443773c8a2ef057b5cdfbed6884c"
-  integrity sha512-898q/XFfXhTd5OGyC6bsBhqQYteT6l3YR1F5N0S4eW6BC/KEBxECuYYkFAcqMCtmc9mWzpRyA7esG27VL9fzNw==
+"@radix-ui/react-primitive@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.3.tgz#208501ee0fceeb7595594529fab17d40cf224b09"
+  integrity sha512-pAn9ZgOayQJelWY7NThIrOy1qF18AX9vErnT0tDRaTK5YSsRHljTjSD14Mj2A0S/oYp2sGU/dT6n5ERO6iOLjg==
   dependencies:
-    "@radix-ui/react-compose-refs" "0.0.1"
+    "@radix-ui/react-polymorphic" "0.0.4"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/react-primitive@0.0.4":
   version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.4.tgz#c4ff716e8f5a57358beb75a3d447fefcd72c7a1b"
+  resolved "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.0.4.tgz#c4ff716e8f5a57358beb75a3d447fefcd72c7a1b"
   integrity sha512-FRiGr6WJRQG7/9i7bUHiXmyS9hLsBrAbMbsaqapYR8VPYlJyAavkNi5sXBXUoWa/VJdeZPI8jUKe/CRZ2ye5Lw==
   dependencies:
     "@radix-ui/react-polymorphic" "0.0.5"
     "@radix-ui/utils" "0.0.3"
 
-"@radix-ui/react-primitive@0.0.5":
+"@radix-ui/react-progress@^0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.5.tgz#2e56cf75ada56258458957ae930771e502f151b9"
-  integrity sha512-zZacpav02cmljSaBfuc/jTqJdsZmVSQsp9Eh03v6ksS/6sGmLga46cwztDzb2by/x2izodke5NdHrVOUNAMbeA==
+  resolved "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-0.0.5.tgz#75e1a2060e4130388deab9fb8a1fb531daa632a2"
+  integrity sha512-5WzGdu/+KrKO9ps2B0+gP/hvd2dfrQ9Ouk2nTHKImQL6Zcom0s1dFGBz1IKfsZgslYbuSN6Rd85oGuI5ZyqWbg==
   dependencies:
-    "@radix-ui/react-polymorphic" "0.0.6"
+    "@radix-ui/react-polymorphic" "0.0.5"
+    "@radix-ui/react-primitive" "0.0.4"
+    "@radix-ui/react-utils" "0.0.5"
+    "@radix-ui/utils" "0.0.3"
 
-"@radix-ui/react-primitive@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.6.tgz#fa26d8fe60e7a0a66b35f8c485c603d3d948be83"
-  integrity sha512-Z3NuzZvTXF36y/HnUTuWUqbLstH41LD/kDGtn5Cz6lwzvy9Mc3rMHwnIXGjXZe8MqvZ9+FxGO4p0+2cpdc+oXg==
-  dependencies:
-    "@radix-ui/react-polymorphic" "0.0.6"
-
-"@radix-ui/react-progress@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-0.0.6.tgz#2c2d4d7e8ce46d39db23553039ec70ea9cf15747"
-  integrity sha512-KD+cy5HI0WzRzygUY5nzgF8Iy3M/S18eT243KJXhhLET7+pYXG9C9DsRraMrWd3vsNe9ApIzcW117YwFd9bcrA==
-  dependencies:
-    "@radix-ui/react-context" "0.0.1"
-    "@radix-ui/react-polymorphic" "0.0.6"
-    "@radix-ui/react-primitive" "0.0.5"
-
-"@radix-ui/react-radio-group@0.0.5":
+"@radix-ui/react-radio-group@^0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-0.0.5.tgz#3c2d643cbec5e7d879ce6ce7621e1db60f180d20"
+  resolved "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-0.0.5.tgz#3c2d643cbec5e7d879ce6ce7621e1db60f180d20"
   integrity sha512-AG/QBBE1wnlTNFQsyTUZ6nC/hVEZXWjOBQwMmzifd4EAucU0YL5uYP0yQ+C99tRt6nYfjdYfgv1Z+XfqZaVmIA==
   dependencies:
     "@radix-ui/react-label" "0.0.5"
@@ -2259,39 +2233,36 @@
 
 "@radix-ui/react-roving-focus@0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-0.0.5.tgz#ce92310bb154421f16df3df84e266f42b9b375ba"
+  resolved "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-0.0.5.tgz#ce92310bb154421f16df3df84e266f42b9b375ba"
   integrity sha512-+Esp3HJxoMGiTx0qn0DVAp2DTiEMpyMLLN2ijlr22dFSDihmVMQH1+VpHEZu6nhclkUx8o/3lXhrgxj6wSfILA==
   dependencies:
     "@radix-ui/react-utils" "0.0.5"
     "@radix-ui/utils" "0.0.3"
 
-"@radix-ui/react-use-callback-ref@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.0.1.tgz#70c8fd7d6a146bf65860ae7d4915985aacc53acc"
-  integrity sha512-WNqLyGlHuxfghIPuKH1/1q/NNc+W2ve2S823syefD78btShmR6LJqpUXinn9X7uK7ih/pB3UySMmbTv9CWrb9A==
-
-"@radix-ui/react-use-controllable-state@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.0.1.tgz#e31ae3d52ce7db5bdae215008fe81f7eda701440"
-  integrity sha512-xWirTCesup7uyt7jDRkQDQbjKzlNq7B4y+FhHFjRF5ZThSVICdR30O4IXhfAs3gH0Of/6yLR+RnGPOwEui1bqQ==
+"@radix-ui/react-utils@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-utils/-/react-utils-0.0.4.tgz#4834cac08088163e0e738c3017fecab406236185"
+  integrity sha512-HqC9OJJjoDun7LNqwYzVX9gYaH5yGhdNtaBRPoSt8wywh+Kv0iU6lDP5H7w7j+6TzZCHH8XEzRbmOSowzlpGAA==
   dependencies:
-    "@radix-ui/react-use-callback-ref" "0.0.1"
+    "@radix-ui/react-polymorphic" "0.0.4"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/react-utils@0.0.5":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-utils/-/react-utils-0.0.5.tgz#d312d4b3d1d1adb25f1ef284b6d1d861c572bb85"
+  resolved "https://registry.npmjs.org/@radix-ui/react-utils/-/react-utils-0.0.5.tgz#d312d4b3d1d1adb25f1ef284b6d1d861c572bb85"
   integrity sha512-OEPLfh8J6JH0Cqv3VrvI8NYQKX1nw0qVVNM14lYCgRGmAI49YrK51tcOIzqzdfuBkXLCX5QzrwK8//DjwoAbhQ==
   dependencies:
     "@radix-ui/react-polymorphic" "0.0.5"
     "@radix-ui/utils" "0.0.3"
 
-"@radix-ui/react-visually-hidden@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.0.6.tgz#a22a8ecf7df8c353c0470d1c9168aac762a98ca0"
-  integrity sha512-2nsYMHBDot50fCSH1pi/Cu27Z/D3HQigqqcXrbCeCzVb2nmI5BWi6hxScNzDr+4KBB1qZ9OfUqGttLJrPwkM5A==
+"@radix-ui/react-visually-hidden@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.0.5.tgz#9e04587d070d36ba942c337523a23b3b9d296af7"
+  integrity sha512-8T8asSbt96IurSamS3uF+g2dc5vNieYCbHKloBn2dGq6yrr92RCxW1p0q5lX8IG9zDQq+shOPPq7wof1OPMv8Q==
   dependencies:
-    "@radix-ui/react-polymorphic" "0.0.6"
-    "@radix-ui/react-primitive" "0.0.5"
+    "@radix-ui/react-polymorphic" "0.0.5"
+    "@radix-ui/react-primitive" "0.0.4"
+    "@radix-ui/utils" "0.0.3"
 
 "@radix-ui/utils@0.0.3":
   version "0.0.3"
@@ -9397,10 +9368,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-hook-form@^6.15.5:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.5.tgz#c2578f9ce6a6df7b33015587d40cd880dc13e2db"
-  integrity sha512-so2jEPYKdVk1olMo+HQ9D9n1hVzaPPFO4wsjgSeZ964R7q7CHsYRbVF0PGBi83FcycA5482WHflasdwLIUVENg==
+react-hook-form@^6.15.4:
+  version "6.15.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.4.tgz#328003e1ccc096cd158899ffe7e3b33735a9b024"
+  integrity sha512-K+Sw33DtTMengs8OdqFJI3glzNl1wBzSefD/ksQw/hJf9CnOHQAU6qy82eOrh0IRNt2G53sjr7qnnw1JDjvx1w==
 
 react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
- Upgrade stitches to latest beta (pretty sure this is the release candidate, aside from hotfixes)
- ~Upgraded Radix packages to include new hotfixes (aside from radiogroup which has an issue when testing)~
- Fixed a TS issue in `PopOver` (we didn't need to spread content and root types into the prop types)
- Removed a storybook utility
- Added `"skipLibCheck": true` to our TS config to bypass some internal TS errors within stitches

The snapshot changes seem to be:
- changed how classes are named
- some class duplication merged into a single selector
- prefixing `appearance`