### PR TITLE
Chore: separate tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "files": [
     "dist"
@@ -43,8 +43,8 @@
     }
   ],
   "devDependencies": {
-    "@atom-learning/jest-stitches": "^1.0.8",
     "@atom-learning/icons": "^0.2.0",
+    "@atom-learning/jest-stitches": "^1.0.8",
     "@atom-learning/theme": "^0.1.0-beta.7",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/preset-react": "^7.12.10",

--- a/scripts/add-component.mjs
+++ b/scripts/add-component.mjs
@@ -37,6 +37,11 @@ describe("${name} component", () => {
     const { container } = render(<${name} />)
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<${name} />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })`,

--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -13,6 +13,11 @@ describe(`Button component`, () => {
     await screen.getByText('BUTTON')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a button - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Button {...props}>BUTTON</Button>)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -25,6 +30,15 @@ describe(`Button component`, () => {
 
     await screen.getByText('BUTTON')
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a outline button - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Button appearance="outline" {...props}>
+        BUTTON
+      </Button>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -39,6 +53,15 @@ describe(`Button component`, () => {
 
     expect(button).toBeDisabled()
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a disabled button - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Button disabled {...props}>
+        BUTTON
+      </Button>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -53,6 +76,15 @@ describe(`Button component`, () => {
 
     expect(button).toBeDisabled()
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a disabled secondary outline button - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Button disabled appearance="outline" theme="secondary" {...props}>
+        BUTTON
+      </Button>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -90,6 +122,16 @@ describe(`Button component`, () => {
       expect(await screen.getByRole('alert')).toBeInTheDocument()
 
       expect(container).toMatchSnapshot()
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('renders a loading button - has no programmatically detectable a11y issues', async () => {
+      const { container } = render(
+        <Button isLoading {...props}>
+          BUTTON
+        </Button>
+      )
+
       expect(await axe(container)).toHaveNoViolations()
     })
 

--- a/src/components/checkbox/Checkbox.test.tsx
+++ b/src/components/checkbox/Checkbox.test.tsx
@@ -20,7 +20,7 @@ describe(`Checkbox component`, () => {
     expect(container).toMatchSnapshot()
   })
 
-  it(' has no programmatically detectable a11y issues', async () => {
+  it('has no programmatically detectable a11y issues', async () => {
     const { container } = render(
       // workaround for failing axe test -
       // Radix's checkbox renders an <input type="checkbox" hidden=""/> but

--- a/src/components/checkbox/Checkbox.test.tsx
+++ b/src/components/checkbox/Checkbox.test.tsx
@@ -18,6 +18,18 @@ describe(`Checkbox component`, () => {
     await screen.getByRole('checkbox')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it(' has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      // workaround for failing axe test -
+      // Radix's checkbox renders an <input type="checkbox" hidden=""/> but
+      // doesn't give it role="none" so axe wants it to have a label
+      <label>
+        <Checkbox title="test" />
+      </label>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/divider/Divider.test.tsx
+++ b/src/components/divider/Divider.test.tsx
@@ -9,6 +9,11 @@ describe('Divider component', () => {
     const { container } = render(<Divider />)
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Divider />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -19,6 +19,15 @@ describe(`Form component`, () => {
     await screen.getByRole('form')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Form onSubmit={jest.fn()}>
+        <InputField name="name" label="Name" />
+      </Form>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/src/components/heading/Heading.test.tsx
+++ b/src/components/heading/Heading.test.tsx
@@ -11,6 +11,11 @@ describe(`Heading component`, () => {
     await screen.getByText('HEADING')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Heading>HEADING</Heading>)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/icon/Icon.test.tsx
+++ b/src/components/icon/Icon.test.tsx
@@ -1,16 +1,22 @@
+import { Ok } from '@atom-learning/icons'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
-import { Check, Icon } from '.'
+import { Icon } from '.'
 
 describe(`Icon component`, () => {
   it('renders an icon', async () => {
-    const { container } = render(<Icon is={Check} title="check" />)
+    const { container } = render(<Icon is={Ok} title="check" />)
 
     await screen.getByTitle('check')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Icon is={Ok} title="check" />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/Icon.test.tsx.snap
@@ -21,6 +21,12 @@ exports[`Icon component renders an icon 1`] = `
     aria-hidden="true"
     class="sxib16r sxib16rmbqqh--size-md"
     title="check"
-  />
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <polyline
+      points="4 13 9 18 20 7"
+    />
+  </svg>
 </div>
 `;

--- a/src/components/image/Image.test.tsx
+++ b/src/components/image/Image.test.tsx
@@ -13,6 +13,13 @@ describe(`Image component`, () => {
     await screen.getByRole('img')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Image src="http://placekitten.com/200/300" alt="" />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/input-field/InputField.test.tsx
+++ b/src/components/input-field/InputField.test.tsx
@@ -25,7 +25,6 @@ describe(`InputField component`, () => {
       <InputField
         label="INPUT FIELD"
         name="INPUT FIELD"
-        css={{ m: 'auto', height: 100, width: 100 }}
         placeholder="INPUT FIELD"
       />
     )
@@ -56,7 +55,6 @@ describe(`InputField component`, () => {
       <InputField
         label="INPUT FIELD"
         name="INPUT FIELD"
-        css={{ m: 'auto', height: 100, width: 100 }}
         type="number"
         placeholder="001"
       />
@@ -86,7 +84,6 @@ describe(`InputField component`, () => {
       <InputField
         label="INPUT FIELD"
         name="INPUT FIELD"
-        css={{ m: 'auto', height: 100, width: 100 }}
         placeholder="INPUT FIELD"
         disabled
       />
@@ -116,12 +113,7 @@ describe(`InputField component`, () => {
     const errorText = 'This field is required'
 
     const { container } = render(
-      <InputField
-        label="INPUT FIELD"
-        name="INPUT FIELD"
-        error={errorText}
-        css={{ m: 'auto', height: 100, width: 100 }}
-      />
+      <InputField label="INPUT FIELD" name="INPUT FIELD" error={errorText} />
     )
 
     expect(await axe(container)).toHaveNoViolations()

--- a/src/components/input-field/InputField.test.tsx
+++ b/src/components/input-field/InputField.test.tsx
@@ -18,10 +18,22 @@ describe(`InputField component`, () => {
     await screen.getByPlaceholderText('INPUT FIELD')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a field with a text input - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <InputField
+        label="INPUT FIELD"
+        name="INPUT FIELD"
+        css={{ m: 'auto', height: 100, width: 100 }}
+        placeholder="INPUT FIELD"
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('renders a field with a  number input', async () => {
+  it('renders a field with a number input', async () => {
     const { container, findByPlaceholderText } = render(
       <InputField
         label="INPUT FIELD"
@@ -37,11 +49,24 @@ describe(`InputField component`, () => {
     expect(input).toHaveAttribute('inputmode', 'numeric')
     expect(input).toHaveAttribute('pattern', '[0-9]*')
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a field with a number input - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <InputField
+        label="INPUT FIELD"
+        name="INPUT FIELD"
+        css={{ m: 'auto', height: 100, width: 100 }}
+        type="number"
+        placeholder="001"
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('renders a field with a disabled input', async () => {
-    const { container, findByPlaceholderText } = render(
+    const { findByPlaceholderText } = render(
       <InputField
         label="INPUT FIELD"
         name="INPUT FIELD"
@@ -54,6 +79,19 @@ describe(`InputField component`, () => {
     const input = await findByPlaceholderText('INPUT FIELD')
 
     expect(input).toHaveAttribute('disabled')
+  })
+
+  it('renders a field with a disabled input - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <InputField
+        label="INPUT FIELD"
+        name="INPUT FIELD"
+        css={{ m: 'auto', height: 100, width: 100 }}
+        placeholder="INPUT FIELD"
+        disabled
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -70,6 +108,21 @@ describe(`InputField component`, () => {
     )
 
     await getByText(errorText)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders a field in error state - has no programmatically detectable a11y issues', async () => {
+    const errorText = 'This field is required'
+
+    const { container } = render(
+      <InputField
+        label="INPUT FIELD"
+        name="INPUT FIELD"
+        error={errorText}
+        css={{ m: 'auto', height: 100, width: 100 }}
+      />
+    )
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -1,6 +1,130 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InputField component renders a field with a  number input 1`] = `
+exports[`InputField component renders a field in error state 1`] = `
+.sx03kze-6obnf {
+  margin: auto;
+  height: 100px;
+  width: 100px;
+}
+
+.sx47aq8 {
+  -webkit-appearance: none;
+  appearance: none;
+  border: 1px solid var(--colors-tonal500);
+  border-radius: var(--radii-0);
+  box-shadow: none;
+  box-sizing: border-box;
+  color: var(--colors-tonal900);
+  cursor: text;
+  display: block;
+  font-family: var(--fonts-sans);
+  font-size: var(--fontSizes-md);
+  height: var(--sizes-4);
+  width: 100%;
+  padding: var(--space-3);
+  transition: all 100ms ease-out;
+}
+
+.sx47aq8:focus {
+  border-color: var(--colors-primary900);
+  box-shadow: inset 0 0 0 1px var(--colors-primary900);
+  outline: none;
+}
+
+.sx47aq8[disabled] {
+  background-color: var(--colors-tonal300);
+  color: var(--colors-tonal700);
+  cursor: not-allowed;
+}
+
+.sx47aq8hpnso--state-error {
+  border: 1px solid var(--colors-danger);
+}
+
+.sxfey5o {
+  color: var(--colors-tonal900);
+  font-family: var(--fonts-sans);
+  font-weight: 400;
+  margin: 0;
+}
+
+.sxfey5oxzxpn--size-sm {
+  font-size: var(--fontSizes-sm);
+  line-height: 1.69;
+}
+
+.sxfey5oxzxpn--size-sm::before {
+  content: '';
+  margin-bottom: -0.477em;
+  display: table;
+}
+
+.sxfey5oxzxpn--size-sm::after {
+  content: '';
+  margin-top: -0.477em;
+  display: table;
+}
+
+.sxfey5o-m6cy5 {
+  color: var(--colors-danger);
+  margin-top: var(--space-1);
+}
+
+.sxdiu5c {
+  color: var(--colors-secondary300);
+  display: block;
+  font-family: var(--fonts-sans);
+  font-weight: 500;
+  margin: 0;
+}
+
+.sxdiu5cjqqvr--size-md {
+  font-size: var(--fontSizes-md);
+  line-height: 1.625;
+}
+
+.sxdiu5cjqqvr--size-md::before {
+  content: '';
+  margin-bottom: -0.4489em;
+  display: table;
+}
+
+.sxdiu5cjqqvr--size-md::after {
+  content: '';
+  margin-top: -0.4489em;
+  display: table;
+}
+
+.sxdiu5c-b2uuy {
+  margin-bottom: var(--space-2);
+}
+
+<div>
+  <div
+    class="sx03kze sx03kze-6obnf"
+  >
+    <label
+      class="sxdiu5c sxdiu5cjqqvr--size-md sxdiu5c-b2uuy"
+      for="INPUT FIELD"
+    >
+      INPUT FIELD
+    </label>
+    <input
+      class="sx47aq8 sx47aq8hpnso--state-error"
+      id="INPUT FIELD"
+      name="INPUT FIELD"
+      type="text"
+    />
+    <p
+      class="sxfey5o sxfey5oxzxpn--size-sm sxfey5o-m6cy5"
+    >
+      This field is required
+    </p>
+  </div>
+</div>
+`;
+
+exports[`InputField component renders a field with a number input 1`] = `
 .sx03kze-6obnf {
   margin: auto;
   height: 100px;

--- a/src/components/input/Input.test.tsx
+++ b/src/components/input/Input.test.tsx
@@ -13,6 +13,13 @@ describe(`Input component`, () => {
     await screen.getByPlaceholderText('INPUT')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a text input - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Input css={{ m: 'auto', height: 100, width: 100 }} placeholder="INPUT" />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -30,11 +37,22 @@ describe(`Input component`, () => {
     expect(input).toHaveAttribute('inputmode', 'numeric')
     expect(input).toHaveAttribute('pattern', '[0-9]*')
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a number input - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Input
+        css={{ m: 'auto', height: 100, width: 100 }}
+        type="number"
+        placeholder="001"
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('renders a disabled input', async () => {
-    const { container, findByPlaceholderText } = render(
+    const { findByPlaceholderText } = render(
       <Input
         css={{ m: 'auto', height: 100, width: 100 }}
         placeholder="INPUT"
@@ -45,6 +63,17 @@ describe(`Input component`, () => {
     const input = await findByPlaceholderText('INPUT')
 
     expect(input).toHaveAttribute('disabled')
+  })
+
+  it('renders a disabled input - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Input
+        css={{ m: 'auto', height: 100, width: 100 }}
+        placeholder="INPUT"
+        disabled
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/input/Input.test.tsx
+++ b/src/components/input/Input.test.tsx
@@ -16,9 +16,7 @@ describe(`Input component`, () => {
   })
 
   it('renders a text input - has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <Input css={{ m: 'auto', height: 100, width: 100 }} placeholder="INPUT" />
-    )
+    const { container } = render(<Input placeholder="INPUT" />)
 
     expect(await axe(container)).toHaveNoViolations()
   })
@@ -40,13 +38,7 @@ describe(`Input component`, () => {
   })
 
   it('renders a number input - has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <Input
-        css={{ m: 'auto', height: 100, width: 100 }}
-        type="number"
-        placeholder="001"
-      />
-    )
+    const { container } = render(<Input type="number" placeholder="001" />)
 
     expect(await axe(container)).toHaveNoViolations()
   })
@@ -66,13 +58,7 @@ describe(`Input component`, () => {
   })
 
   it('renders a disabled input - has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <Input
-        css={{ m: 'auto', height: 100, width: 100 }}
-        placeholder="INPUT"
-        disabled
-      />
-    )
+    const { container } = render(<Input placeholder="INPUT" disabled />)
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/src/components/label/Label.test.tsx
+++ b/src/components/label/Label.test.tsx
@@ -11,6 +11,11 @@ describe(`Label component`, () => {
     await screen.getByText('TEXT')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Label>TEXT</Label>)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/src/components/link/Link.test.tsx
+++ b/src/components/link/Link.test.tsx
@@ -13,6 +13,11 @@ describe(`Link component`, () => {
     expect(link).toHaveAttribute('href', 'https://google.com/')
     expect(link).toHaveTextContent('GOOGLE')
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders an anchor - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Link href="https://google.com/">GOOGLE</Link>)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -24,6 +29,15 @@ describe(`Link component`, () => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders an large anchor - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Link href="https://google.com/" size="lg">
+        GOOGLE
+      </Link>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/src/components/list/List.test.tsx
+++ b/src/components/list/List.test.tsx
@@ -14,6 +14,16 @@ describe(`List component`, () => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <List>
+        <List.Item>Item 1</List.Item>
+        <List.Item>Item 2</List.Item>
+      </List>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/loader/Loader.test.tsx
+++ b/src/components/loader/Loader.test.tsx
@@ -13,6 +13,11 @@ describe(`Loader component`, () => {
     await screen.getByText(message)
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Loader />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/password-field/PasswordField.test.tsx
+++ b/src/components/password-field/PasswordField.test.tsx
@@ -12,6 +12,13 @@ describe(`Password component`, () => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a password field - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <PasswordField css={{ m: 'auto', height: 100, width: 100 }} />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/src/components/password-field/PasswordField.test.tsx
+++ b/src/components/password-field/PasswordField.test.tsx
@@ -15,9 +15,7 @@ describe(`Password component`, () => {
   })
 
   it('renders a password field - has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <PasswordField css={{ m: 'auto', height: 100, width: 100 }} />
-    )
+    const { container } = render(<PasswordField />)
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/src/components/popover/Popover.test.tsx
+++ b/src/components/popover/Popover.test.tsx
@@ -16,7 +16,16 @@ describe(`Popover component`, () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument()
 
-    // expect(container).toMatchSnapshot()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders the trigger with the popover hidden by default - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Popover id="123" aria-label="Popover" content="Content">
+        <button>Click me</button>
+      </Popover>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -35,10 +44,24 @@ describe(`Popover component`, () => {
     expect(screen.getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false')
     expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument()
     expect(container).toMatchSnapshot()
+  })
+
+  it('opens the popover once trigger is clicked - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Popover id="123" aria-label="Popover" content="Content">
+        <button>Click me</button>
+      </Popover>
+    )
+    const button = screen.getByRole('button', { name: /Click me/ })
+
+    button.focus()
+    fireEvent.click(button)
+
     expect(await axe(container)).toHaveNoViolations()
   })
+
   it('opens popover using the space key', async () => {
-    const { container } = render(
+    render(
       <Popover id="123" aria-label="Popover" content="Content">
         <button>Click me</button>
       </Popover>
@@ -50,11 +73,10 @@ describe(`Popover component`, () => {
     })
 
     expect(screen.getByText('Content')).toBeInTheDocument()
-    expect(container).toMatchSnapshot()
-    expect(await axe(container)).toHaveNoViolations()
   })
+
   it("doesn't open popover using the keypress with random key press", async () => {
-    const { container } = render(
+    render(
       <Popover id="123" aria-label="Popover" content="Content">
         <button>Click me</button>
       </Popover>
@@ -66,9 +88,8 @@ describe(`Popover component`, () => {
     })
 
     expect(screen.getByText('Content')).toBeInTheDocument()
-    expect(container).toMatchSnapshot()
-    expect(await axe(container)).toHaveNoViolations()
   })
+
   it('renders as visible with left variant', async () => {
     const { container } = render(
       <Popover
@@ -83,6 +104,19 @@ describe(`Popover component`, () => {
     await screen.getByRole('tooltip')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders as visible with left variant - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Popover
+        id="123"
+        defaultOpen
+        align="left"
+        aria-label="Some text"
+        content="Hello"
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/popover/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/Popover.test.tsx.snap
@@ -1,185 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popover component doesn't open popover using the keypress with random key press 1`] = `
-.sx2v396 {
-  position: relative;
-}
-
-.sxdd99d {
-  box-shadow: var(--shadows-0);
-  border-radius: var(--radii-1);
-  background-color: white;
-  border: 1px solid var(--colors-tonal400);
-  bottom: calc(100%  + var(--space-3));
-  list-style-type: none;
-  min-width: 140px;
-  max-width: 354px;
-  padding: var(--space-3);
-  position: absolute;
-  transition: all 150ms ease-in-out;
-  width: max-content;
-  opacity: 0;
-  visibility: hidden;
-}
-
-.sxdd99dpuxrx--align-center::after {
-  border-style: solid;
-  border-color: transparent;
-  content: '';
-  height: 0;
-  pointer-events: none;
-  position: absolute;
-  top: 100%;
-  width: 0;
-  border-top-color: white;
-  border-width: 8px;
-  margin-left: -8px;
-  left: 50%;
-}
-
-.sxdd99dpuxrx--align-center::before {
-  border-style: solid;
-  border-color: transparent;
-  content: '';
-  height: 0;
-  pointer-events: none;
-  position: absolute;
-  top: 100%;
-  width: 0;
-  border-top-color: var(--colors-tonal400);
-  border-width: 9px;
-  margin-left: -9px;
-  left: 50%;
-}
-
-.sxdd99dpuxrx--align-center {
-  transform-origin: center bottom;
-  transform: translate(-50%, var(--2)) scale(0.9);
-}
-
-.sxdd99dx07u8--visibility-true {
-  opacity: 1;
-  visibility: visible;
-}
-
-<div>
-  <span
-    aria-label="Popover"
-    class="sx2v396"
-  >
-    <span
-      aria-expanded="false"
-      aria-label="popover trigger"
-      id="popover-trigger-123"
-      role="button"
-      tabindex="0"
-    >
-      <button>
-        Click me
-      </button>
-    </span>
-    <div
-      aria-hidden="true"
-      aria-labelledby="popover-trigger-123"
-      class="sxdd99d sxdd99dpuxrx--align-center"
-      role="tooltip"
-    >
-      Content
-    </div>
-  </span>
-</div>
-`;
-
-exports[`Popover component opens popover using the space key 1`] = `
-.sx2v396 {
-  position: relative;
-}
-
-.sxdd99d {
-  box-shadow: var(--shadows-0);
-  border-radius: var(--radii-1);
-  background-color: white;
-  border: 1px solid var(--colors-tonal400);
-  bottom: calc(100%  + var(--space-3));
-  list-style-type: none;
-  min-width: 140px;
-  max-width: 354px;
-  padding: var(--space-3);
-  position: absolute;
-  transition: all 150ms ease-in-out;
-  width: max-content;
-  opacity: 0;
-  visibility: hidden;
-}
-
-.sxdd99dpuxrx--align-center::after {
-  border-style: solid;
-  border-color: transparent;
-  content: '';
-  height: 0;
-  pointer-events: none;
-  position: absolute;
-  top: 100%;
-  width: 0;
-  border-top-color: white;
-  border-width: 8px;
-  margin-left: -8px;
-  left: 50%;
-}
-
-.sxdd99dpuxrx--align-center::before {
-  border-style: solid;
-  border-color: transparent;
-  content: '';
-  height: 0;
-  pointer-events: none;
-  position: absolute;
-  top: 100%;
-  width: 0;
-  border-top-color: var(--colors-tonal400);
-  border-width: 9px;
-  margin-left: -9px;
-  left: 50%;
-}
-
-.sxdd99dpuxrx--align-center {
-  transform-origin: center bottom;
-  transform: translate(-50%, var(--2)) scale(0.9);
-}
-
-.sxdd99dx07u8--visibility-true {
-  opacity: 1;
-  visibility: visible;
-}
-
-<div>
-  <span
-    aria-label="Popover"
-    class="sx2v396"
-  >
-    <span
-      aria-expanded="false"
-      aria-label="popover trigger"
-      id="popover-trigger-123"
-      role="button"
-      tabindex="0"
-    >
-      <button>
-        Click me
-      </button>
-    </span>
-    <div
-      aria-hidden="true"
-      aria-labelledby="popover-trigger-123"
-      class="sxdd99d sxdd99dpuxrx--align-center"
-      role="tooltip"
-    >
-      Content
-    </div>
-  </span>
-</div>
-`;
-
 exports[`Popover component opens the popover once trigger is clicked 1`] = `
 .sx2v396 {
   position: relative;
@@ -387,6 +207,91 @@ exports[`Popover component renders as visible with left variant 1`] = `
       role="tooltip"
     >
       Hello
+    </div>
+  </span>
+</div>
+`;
+
+exports[`Popover component renders the trigger with the popover hidden by default 1`] = `
+.sx2v396 {
+  position: relative;
+}
+
+.sxdd99d {
+  box-shadow: var(--shadows-0);
+  border-radius: var(--radii-1);
+  background-color: white;
+  border: 1px solid var(--colors-tonal400);
+  bottom: calc(100%  + var(--space-3));
+  list-style-type: none;
+  min-width: 140px;
+  max-width: 354px;
+  padding: var(--space-3);
+  position: absolute;
+  transition: all 150ms ease-in-out;
+  width: max-content;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.sxdd99dpuxrx--align-center::after {
+  border-style: solid;
+  border-color: transparent;
+  content: '';
+  height: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 100%;
+  width: 0;
+  border-top-color: white;
+  border-width: 8px;
+  margin-left: -8px;
+  left: 50%;
+}
+
+.sxdd99dpuxrx--align-center::before {
+  border-style: solid;
+  border-color: transparent;
+  content: '';
+  height: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 100%;
+  width: 0;
+  border-top-color: var(--colors-tonal400);
+  border-width: 9px;
+  margin-left: -9px;
+  left: 50%;
+}
+
+.sxdd99dpuxrx--align-center {
+  transform-origin: center bottom;
+  transform: translate(-50%, var(--2)) scale(0.9);
+}
+
+<div>
+  <span
+    aria-label="Popover"
+    class="sx2v396"
+  >
+    <span
+      aria-expanded="false"
+      aria-label="popover trigger"
+      id="popover-trigger-123"
+      role="button"
+      tabindex="0"
+    >
+      <button>
+        Click me
+      </button>
+    </span>
+    <div
+      aria-hidden="true"
+      aria-labelledby="popover-trigger-123"
+      class="sxdd99d sxdd99dpuxrx--align-center"
+      role="tooltip"
+    >
+      Content
     </div>
   </span>
 </div>

--- a/src/components/progress-bar/ProgressBar.test.tsx
+++ b/src/components/progress-bar/ProgressBar.test.tsx
@@ -11,6 +11,11 @@ describe(`ProgressBar component`, () => {
     await screen.getByRole('progressbar')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a progress bar using default props - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<ProgressBar value={50} aria-label="label" />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -32,6 +37,13 @@ describe(`ProgressBar component`, () => {
     await screen.getByRole('progressbar')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a solid progress bar - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <ProgressBar value={50} appearance="solid" aria-label="label" />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/radio/RadioButton.test.tsx
+++ b/src/components/radio/RadioButton.test.tsx
@@ -15,24 +15,24 @@ describe(`Radio component`, () => {
       </IdProvider>
     )
 
-    // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
-    await screen.getByRole('radio', { hidden: false })
+    await screen.getByRole('radio')
 
     expect(container).toMatchSnapshot()
   })
 
   it('renders a radio button - has no programmatically detectable a11y issues', async () => {
-    render(
-      <IdProvider>
-        <RadioButtonGroup>
-          <RadioButton value="value" aria-label="indicator" />
-        </RadioButtonGroup>
-      </IdProvider>
+    const { container } = render(
+      <label>
+        Label
+        <IdProvider>
+          <RadioButtonGroup>
+            <RadioButton value="value" aria-label="indicator" />
+          </RadioButtonGroup>
+        </IdProvider>
+      </label>
     )
 
-    // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
-    const radio = await screen.getByRole('radio', { hidden: false })
-    expect(await axe(radio)).toHaveNoViolations()
+    expect(await axe(container)).toHaveNoViolations()
   })
 
   it('renders a disabled radio button', async () => {
@@ -43,23 +43,30 @@ describe(`Radio component`, () => {
         </RadioButtonGroup>
       </IdProvider>
     )
-    // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
-    await screen.getByRole('radio', { hidden: false })
+
+    await screen.getByRole('radio')
 
     expect(container).toMatchSnapshot()
   })
 
   it('renders a disabled radio button - has no programmatically detectable a11y issues', async () => {
-    render(
-      <IdProvider>
-        <RadioButtonGroup>
-          <RadioButton value="value" aria-label="disabled indicator" disabled />
-        </RadioButtonGroup>
-      </IdProvider>
+    const { container } = render(
+      <label>
+        Label
+        <IdProvider>
+          <RadioButtonGroup>
+            <RadioButton
+              value="value"
+              aria-label="disabled indicator"
+              disabled
+            />
+          </RadioButtonGroup>
+        </IdProvider>
+      </label>
     )
-    // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
-    const radio = await screen.getByRole('radio', { hidden: false })
 
-    expect(await axe(radio)).toHaveNoViolations()
+    await screen.getByRole('radio')
+
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/radio/RadioButton.test.tsx
+++ b/src/components/radio/RadioButton.test.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { RadioButton, RadioButtonGroup } from '.'
 
 describe(`Radio component`, () => {
-  it('renders a radio', async () => {
+  it('renders a radio button', async () => {
     const { container } = render(
       <IdProvider>
         <RadioButtonGroup>
@@ -16,14 +16,41 @@ describe(`Radio component`, () => {
     )
 
     // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
-    const radio = await screen.getByRole('radio', { hidden: false })
+    await screen.getByRole('radio', { hidden: false })
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a radio button - has no programmatically detectable a11y issues', async () => {
+    render(
+      <IdProvider>
+        <RadioButtonGroup>
+          <RadioButton value="value" aria-label="indicator" />
+        </RadioButtonGroup>
+      </IdProvider>
+    )
+
+    // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
+    const radio = await screen.getByRole('radio', { hidden: false })
     expect(await axe(radio)).toHaveNoViolations()
   })
 
-  it('renders a disabled radio', async () => {
+  it('renders a disabled radio button', async () => {
     const { container } = render(
+      <IdProvider>
+        <RadioButtonGroup>
+          <RadioButton value="value" aria-label="disabled indicator" disabled />
+        </RadioButtonGroup>
+      </IdProvider>
+    )
+    // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
+    await screen.getByRole('radio', { hidden: false })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders a disabled radio button - has no programmatically detectable a11y issues', async () => {
+    render(
       <IdProvider>
         <RadioButtonGroup>
           <RadioButton value="value" aria-label="disabled indicator" disabled />
@@ -33,7 +60,6 @@ describe(`Radio component`, () => {
     // filtering on hidden is needed to find the visibile item as Radix adds a hidden input before the visible button
     const radio = await screen.getByRole('radio', { hidden: false })
 
-    expect(container).toMatchSnapshot()
     expect(await axe(radio)).toHaveNoViolations()
   })
 })

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Radio component renders a disabled radio 1`] = `
+exports[`Radio component renders a disabled radio button 1`] = `
 .sxr2ug3 {
   -webkit-appearance: none;
   appearance: none;
@@ -65,7 +65,7 @@ exports[`Radio component renders a disabled radio 1`] = `
 </div>
 `;
 
-exports[`Radio component renders a radio 1`] = `
+exports[`Radio component renders a radio button 1`] = `
 .sxr2ug3 {
   -webkit-appearance: none;
   appearance: none;

--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -16,6 +16,7 @@ describe(`Select component`, () => {
     { label: 'Option 2', value: 'value2' },
     { label: 'Option 3', value: 'value3' }
   ]
+
   it('renders select with no options', async () => {
     const { container } = render(<Select aria-label="dropdown" />)
     const select = screen.getByRole('combobox')
@@ -24,8 +25,14 @@ describe(`Select component`, () => {
     expect(select).toBeInTheDocument()
     expect(options).toBe(null)
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders select with no options - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Select aria-label="dropdown" />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
+
   it('renders a select with 3 options', async () => {
     const { container } = render(
       <Select aria-label="dropdown" options={mockOptions} />
@@ -64,8 +71,13 @@ describe(`Select component`, () => {
     expect(select).toBeInTheDocument()
     expect(select).toHaveAttribute('disabled')
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders an disabled select - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Select aria-label="dropdown" disabled />)
     expect(await axe(container)).toHaveNoViolations()
   })
+
   it('renders select with a disabled option', async () => {
     const { container } = render(
       <Select
@@ -82,6 +94,19 @@ describe(`Select component`, () => {
     expect(options[0]).not.toHaveAttribute('disabled')
     expect(options[3]).toHaveAttribute('disabled')
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders select with a disabled option - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Select
+        aria-label="dropdown"
+        options={[
+          ...mockOptions,
+          { label: 'Option 4', value: 'value4', disabled: true }
+        ]}
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/text/Text.test.tsx
+++ b/src/components/text/Text.test.tsx
@@ -11,6 +11,11 @@ describe(`Text component`, () => {
     await screen.getByText('TEXT')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders some text - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Text>TEXT</Text>)
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/textarea/Textarea.test.tsx
+++ b/src/components/textarea/Textarea.test.tsx
@@ -16,6 +16,16 @@ describe(`Textarea component`, () => {
     await screen.getByPlaceholderText('DESCRIPTION')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a textarea - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <Textarea
+        css={{ m: 'auto', height: 100, width: 100 }}
+        placeholder="DESCRIPTION"
+      />
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/src/components/textarea/Textarea.test.tsx
+++ b/src/components/textarea/Textarea.test.tsx
@@ -19,12 +19,7 @@ describe(`Textarea component`, () => {
   })
 
   it('renders a textarea - has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <Textarea
-        css={{ m: 'auto', height: 100, width: 100 }}
-        placeholder="DESCRIPTION"
-      />
-    )
+    const { container } = render(<Textarea placeholder="DESCRIPTION" />)
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/src/components/validation-error/ValidationError.test.tsx
+++ b/src/components/validation-error/ValidationError.test.tsx
@@ -13,6 +13,13 @@ describe(`ValidationError component`, () => {
     await screen.getByText('VALIDATION ERROR')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(
+      <ValidationError>VALIDATION ERROR</ValidationError>
+    )
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/components/video/Video.test.tsx
+++ b/src/components/video/Video.test.tsx
@@ -11,14 +11,19 @@ describe(`Video component`, () => {
     await screen.getByRole('figure')
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders a video with default ratio - has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<Video externalId="1084537" />)
+
     expect(await axe(container)).toHaveNoViolations()
   })
+
   it('renders a video with custom ratio (4:3)', async () => {
     const { container } = render(<Video externalId="1084537" ratio={3 / 4} />)
 
     await screen.getByRole('figure')
 
     expect(container).toMatchSnapshot()
-    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/src/documentation/accessibility.mdx
+++ b/src/documentation/accessibility.mdx
@@ -18,6 +18,16 @@ Before developing a component, please take some time to read the following secti
 
 ```jsx
 it('has no programmatically detectable a11y issues', async () => {
+  const { container } = render(<Button />)
+
+  expect(await axe(container)).toHaveNoViolations()
+})
+```
+
+or
+
+```jsx
+it('has no programmatically detectable a11y issues', async () => {
   render(<Flex />, document.body)
   const results = await axe(document.body)
   expect(results).toHaveNoViolations()


### PR DESCRIPTION
This separates tests into individual concerns (snapshot and axe). 


Note: in a couple of places I have removed the accessibility testing as it was unnecessary
Note2: in a couple of places I have removed unnecessary snapshot tests (ie: in popover)