### PR TITLE
RFC: Select API

### DIFF
--- a/src/components/select-field/SelectField.mdx
+++ b/src/components/select-field/SelectField.mdx
@@ -9,14 +9,9 @@ category: Forms
 
 ```jsx preview
 <Form>
-  <SelectField
-    name="options"
-    label="Options"
-    options={[
-      { value: 1, label: 'Option 1' },
-      { value: 2, label: 'Option 2' }
-    ]}
-    css={{ width: 320 }}
-  />
+  <SelectField name="options" label="Options" css={{ width: 320 }}>
+    <option value="apples">Apples</option>
+    <option value="bananas">Bananas</option>
+  </SelectField>
 </Form>
 ```

--- a/src/components/select-field/SelectField.test.tsx
+++ b/src/components/select-field/SelectField.test.tsx
@@ -9,14 +9,10 @@ describe('SelectField component', () => {
   it('renders', async () => {
     const { container } = render(
       <Form>
-        <SelectField
-          label="Example options"
-          name="example"
-          options={[
-            { label: 'Option 1', value: 1 },
-            { label: 'Option 2', value: 2 }
-          ]}
-        />
+        <SelectField label="Example options" name="example">
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+        </SelectField>
       </Form>
     )
 
@@ -26,14 +22,10 @@ describe('SelectField component', () => {
   it('has no programmatically detectable a11y issues', async () => {
     const { container } = render(
       <Form>
-        <SelectField
-          label="Example options"
-          name="example"
-          options={[
-            { label: 'Option 1', value: 1 },
-            { label: 'Option 2', value: 2 }
-          ]}
-        />
+        <SelectField label="Example options" name="example">
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+        </SelectField>
       </Form>
     )
 

--- a/src/components/select-field/SelectField.tsx
+++ b/src/components/select-field/SelectField.tsx
@@ -9,6 +9,7 @@ type SelectFieldProps = SelectProps &
   FieldWrapperProps & { name: string; validation: ValidationOptions }
 
 export const SelectField: React.FC<SelectFieldProps> = ({
+  children,
   name,
   label,
   validation,
@@ -18,9 +19,12 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   const ref = validation ? register(validation) : register
 
   const error = errors[name]?.message
+
   return (
     <FieldWrapper fieldId={name} label={label} error={error}>
-      <Select name={name} id={name} {...remainingProps} ref={ref} />
+      <Select name={name} id={name} {...remainingProps} ref={ref}>
+        {children}
+      </Select>
     </FieldWrapper>
   )
 }

--- a/src/components/select/Select.mdx
+++ b/src/components/select/Select.mdx
@@ -20,12 +20,12 @@ A `Select` needs to be associated with a label for accessibility purposes, so ra
 
 For accessibility purposes the component needs to have the `id` prop set, to link it to the label it is associated with. If a label is not available, please add an `aria-label` to ensure that the component remains accessible
 
-## Default option
+## Placeholder
 
-The component can display a default option without a value by passing the `defaultOption` property.
+The component can display a placeholder without a value by passing the `placeholder` property.
 
 ```jsx preview
-<Select default="Please select a fruit" css={{ width: 300 }}>
+<Select placeholder="Please select a fruit" css={{ width: 300 }}>
   <option value="apples">Apples</option>
   <option value="bananas">Bananas</option>
 </Select>
@@ -36,7 +36,7 @@ The component can display a default option without a value by passing the `defau
 The component has a `disabled` state, by setting the `disabled` property.
 
 ```jsx preview
-<Select disabled default="Please select a fruit" css={{ width: 300 }}>
+<Select disabled placeholder="Please select a fruit" css={{ width: 300 }}>
   <option value="apples">Apples</option>
   <option value="bananas">Bananas</option>
 </Select>
@@ -47,7 +47,7 @@ The component has a `disabled` state, by setting the `disabled` property.
 The component can show an option as `disabled`, by setting the `disabled` property on the option.
 
 ```jsx preview
-<Select default="Please select a fruit" css={{ width: 300 }}>
+<Select placeholder="Please select a fruit" css={{ width: 300 }}>
   <option value="apples">Apples</option>
   <option value="bananas" disabled>
     Bananas

--- a/src/components/select/Select.mdx
+++ b/src/components/select/Select.mdx
@@ -10,33 +10,25 @@ It adds default styling and the `css` prop.
 A `Select` needs to be associated with a label for accessibility purposes, so rather than using the `Select` component directly in a UI, consider using a `SelectField`, which provides a `Label` and displays validation errors. Use this `Select` to compose more complex `Field` type components.
 
 ```jsx preview
-<Select
-  options={[
-    { value: 1, label: 'Apples' },
-    { value: 2, label: 'Bananas' }
-  ]}
-  css={{ width: 300 }}
-/>
+<Select css={{ width: 300 }}>
+  <option value="apples">Apples</option>
+  <option value="bananas">Bananas</option>
+</Select>
 ```
 
 ## Accessibility
 
 For accessibility purposes the component needs to have the `id` prop set, to link it to the label it is associated with. If a label is not available, please add an `aria-label` to ensure that the component remains accessible
 
-## Default Option
+## Default option
 
 The component can display a default option without a value by passing the `defaultOption` property.
 
 ```jsx preview
-<Select
-  aria-label="select number"
-  defaultOption="Please select a number:"
-  options={[
-    { value: 1, label: 'one' },
-    { value: 2, label: 'two' }
-  ]}
-  css={{ width: 300 }}
-/>
+<Select default="Please select a fruit" css={{ width: 300 }}>
+  <option value="apples">Apples</option>
+  <option value="bananas">Bananas</option>
+</Select>
 ```
 
 ## Disabled select
@@ -44,15 +36,10 @@ The component can display a default option without a value by passing the `defau
 The component has a `disabled` state, by setting the `disabled` property.
 
 ```jsx preview
-<Select
-  aria-label="can't select fruits"
-  disabled
-  options={[
-    { value: 1, label: 'Apples' },
-    { value: 2, label: 'Bananas' }
-  ]}
-  css={{ width: 300 }}
-/>
+<Select disabled default="Please select a fruit" css={{ width: 300 }}>
+  <option value="apples">Apples</option>
+  <option value="bananas">Bananas</option>
+</Select>
 ```
 
 ## Disabled Option
@@ -60,12 +47,10 @@ The component has a `disabled` state, by setting the `disabled` property.
 The component can show an option as `disabled`, by setting the `disabled` property on the option.
 
 ```jsx preview
-<Select
-  aria-label="select fruits"
-  options={[
-    { value: 1, label: 'Apples', disabled: true },
-    { value: 2, label: 'Bananas' }
-  ]}
-  css={{ width: 300 }}
-/>
+<Select default="Please select a fruit" css={{ width: 300 }}>
+  <option value="apples">Apples</option>
+  <option value="bananas" disabled>
+    Bananas
+  </option>
+</Select>
 ```

--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -35,7 +35,11 @@ describe(`Select component`, () => {
 
   it('renders a select with 3 options', async () => {
     const { container } = render(
-      <Select aria-label="dropdown" options={mockOptions} />
+      <Select aria-label="dropdown">
+        {mockOptions.map((option) => (
+          <option key={option.value} {...option} />
+        ))}
+      </Select>
     )
 
     const options = await screen.getAllByRole('option')
@@ -50,11 +54,11 @@ describe(`Select component`, () => {
 
   it('renders select with a default option', async () => {
     const { container } = render(
-      <Select
-        aria-label="dropdown"
-        defaultOption="Please select:"
-        options={mockOptions}
-      />
+      <Select aria-label="dropdown" default="Please select:">
+        {mockOptions.map((option) => (
+          <option key={option.value} {...option} />
+        ))}
+      </Select>
     )
 
     const option = await screen.getByDisplayValue('Please select:')
@@ -80,13 +84,14 @@ describe(`Select component`, () => {
 
   it('renders select with a disabled option', async () => {
     const { container } = render(
-      <Select
-        aria-label="dropdown"
-        options={[
+      <Select aria-label="dropdown">
+        {[
           ...mockOptions,
           { label: 'Option 4', value: 'value4', disabled: true }
-        ]}
-      />
+        ].map((option) => (
+          <option key={option.value} {...option} />
+        ))}
+      </Select>
     )
     const options = await screen.getAllByRole('option')
 
@@ -98,13 +103,14 @@ describe(`Select component`, () => {
 
   it('renders select with a disabled option - has no programmatically detectable a11y issues', async () => {
     const { container } = render(
-      <Select
-        aria-label="dropdown"
-        options={[
+      <Select aria-label="dropdown">
+        {[
           ...mockOptions,
           { label: 'Option 4', value: 'value4', disabled: true }
-        ]}
-      />
+        ].map((option) => (
+          <option key={option.value} {...option} />
+        ))}
+      </Select>
     )
 
     expect(await axe(container)).toHaveNoViolations()

--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -56,7 +56,7 @@ describe(`Select component`, () => {
 
   it('renders select with a default option', async () => {
     const { container } = render(
-      <Select aria-label="dropdown" default="Please select:">
+      <Select aria-label="dropdown" placeholder="Please select:">
         {mockOptions.map(({ value, label }) => (
           <option key={value} value={value}>
             {label}

--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -36,8 +36,10 @@ describe(`Select component`, () => {
   it('renders a select with 3 options', async () => {
     const { container } = render(
       <Select aria-label="dropdown">
-        {mockOptions.map((option) => (
-          <option key={option.value} {...option} />
+        {mockOptions.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
         ))}
       </Select>
     )
@@ -55,8 +57,10 @@ describe(`Select component`, () => {
   it('renders select with a default option', async () => {
     const { container } = render(
       <Select aria-label="dropdown" default="Please select:">
-        {mockOptions.map((option) => (
-          <option key={option.value} {...option} />
+        {mockOptions.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
         ))}
       </Select>
     )
@@ -88,8 +92,10 @@ describe(`Select component`, () => {
         {[
           ...mockOptions,
           { label: 'Option 4', value: 'value4', disabled: true }
-        ].map((option) => (
-          <option key={option.value} {...option} />
+        ].map(({ value, label, ...rest }) => (
+          <option key={value} value={value} {...rest}>
+            {label}
+          </option>
         ))}
       </Select>
     )
@@ -107,8 +113,10 @@ describe(`Select component`, () => {
         {[
           ...mockOptions,
           { label: 'Option 4', value: 'value4', disabled: true }
-        ].map((option) => (
-          <option key={option.value} {...option} />
+        ].map(({ value, label, ...rest }) => (
+          <option key={value} value={value} {...rest}>
+            {label}
+          </option>
         ))}
       </Select>
     )

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -49,12 +49,7 @@ export type SelectProps = Override<
   React.ComponentProps<typeof StyledSelect>,
   {
     as?: never
-    options?: {
-      value: string
-      label: string
-      disabled?: boolean
-    }[]
-    defaultOption?: string
+    default?: string
   }
   // TODO: figure out why uncommenting this causes TS errors in
   // component declaration
@@ -65,19 +60,10 @@ export type SelectProps = Override<
 >
 
 export const Select: React.FC<SelectProps> = React.forwardRef(
-  ({ options, defaultOption, ...rest }, ref) => (
-    <StyledSelect {...rest} ref={ref}>
-      {defaultOption && <option> {defaultOption}</option>}
-      {options &&
-        options.map((option) => (
-          <option
-            key={option.value}
-            value={option.value}
-            disabled={option.disabled}
-          >
-            {option.label}
-          </option>
-        ))}
+  ({ default: defaultOption, children, ...remainingProps }, ref) => (
+    <StyledSelect {...remainingProps} ref={ref}>
+      {defaultOption && <option>{defaultOption}</option>}
+      {children}
     </StyledSelect>
   )
 )

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -49,7 +49,7 @@ export type SelectProps = Override<
   React.ComponentProps<typeof StyledSelect>,
   {
     as?: never
-    default?: string
+    placeholder?: string
   }
   // TODO: figure out why uncommenting this causes TS errors in
   // component declaration
@@ -60,9 +60,13 @@ export type SelectProps = Override<
 >
 
 export const Select: React.FC<SelectProps> = React.forwardRef(
-  ({ default: defaultOption, children, ...remainingProps }, ref) => (
+  ({ placeholder, children, ...remainingProps }, ref) => (
     <StyledSelect {...remainingProps} ref={ref}>
-      {defaultOption && <option>{defaultOption}</option>}
+      {placeholder && (
+        <option disabled selected hidden>
+          {placeholder}
+        </option>
+      )}
       {children}
     </StyledSelect>
   )

--- a/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -191,7 +191,10 @@ exports[`Select component renders select with a default option 1`] = `
     aria-label="dropdown"
     class="sx8kxz1"
   >
-    <option>
+    <option
+      disabled=""
+      hidden=""
+    >
       Please select:
     </option>
     <option

--- a/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -195,17 +195,20 @@ exports[`Select component renders select with a default option 1`] = `
       Please select:
     </option>
     <option
-      label="Option 1"
       value="value1"
-    />
+    >
+      Option 1
+    </option>
     <option
-      label="Option 2"
       value="value2"
-    />
+    >
+      Option 2
+    </option>
     <option
-      label="Option 3"
       value="value3"
-    />
+    >
+      Option 3
+    </option>
   </select>
 </div>
 `;
@@ -267,22 +270,26 @@ exports[`Select component renders select with a disabled option 1`] = `
     class="sx8kxz1"
   >
     <option
-      label="Option 1"
       value="value1"
-    />
+    >
+      Option 1
+    </option>
     <option
-      label="Option 2"
       value="value2"
-    />
+    >
+      Option 2
+    </option>
     <option
-      label="Option 3"
       value="value3"
-    />
+    >
+      Option 3
+    </option>
     <option
       disabled=""
-      label="Option 4"
       value="value4"
-    />
+    >
+      Option 4
+    </option>
   </select>
 </div>
 `;

--- a/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -192,23 +192,20 @@ exports[`Select component renders select with a default option 1`] = `
     class="sx8kxz1"
   >
     <option>
-       Please select:
+      Please select:
     </option>
     <option
+      label="Option 1"
       value="value1"
-    >
-      Option 1
-    </option>
+    />
     <option
+      label="Option 2"
       value="value2"
-    >
-      Option 2
-    </option>
+    />
     <option
+      label="Option 3"
       value="value3"
-    >
-      Option 3
-    </option>
+    />
   </select>
 </div>
 `;
@@ -270,26 +267,22 @@ exports[`Select component renders select with a disabled option 1`] = `
     class="sx8kxz1"
   >
     <option
+      label="Option 1"
       value="value1"
-    >
-      Option 1
-    </option>
+    />
     <option
+      label="Option 2"
       value="value2"
-    >
-      Option 2
-    </option>
+    />
     <option
+      label="Option 3"
       value="value3"
-    >
-      Option 3
-    </option>
+    />
     <option
       disabled=""
+      label="Option 4"
       value="value4"
-    >
-      Option 4
-    </option>
+    />
   </select>
 </div>
 `;


### PR DESCRIPTION
Interested in your thoughts on this change to the `Select` component, I've been mulling this over for a few weeks and I don't think there's any reason to abstract the options into a prop, we can use the standard `<option>` HTML syntax and pass them as `children`.

Currently each options attributes are passed one by one onto the internal `<option>` element, which prevents using other standard attributes like `selected` (an easy fix by spreading the attributes but highlights the larger issue of flexibility/customisation). We also prevent using other standard `select` children like `optgroup` by abstracting `options`.