### PR TITLE
Feat: update Form to take render prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@stitches/react": "0.1.7",
     "@types/react": "^17.0.2",
     "colorsys": "^1.0.22",
+    "invariant": "^2.2.4",
     "pure-react-carousel": "^1.27.6",
     "react-hook-form": "^6.15.4",
     "react-player": "^2.9.0",

--- a/sandbox/index.tsx
+++ b/sandbox/index.tsx
@@ -4,36 +4,12 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { reset } from 'stitches-reset'
 
-import { Box, Button, Form, globalCss, Input, InputField } from '../dist'
+import { Box, globalCss } from '../dist'
 
 globalCss(reset)()
 
-const FormContent = ({ formState }) => (
-  <>
-    <InputField
-      name="name"
-      label="Name"
-      validation={{
-        required: 'Name is required!',
-        minLength: { value: 3, message: 'longer!' }
-      }}
-    />
-    <Button type="submit" disabled={!formState.isValid}>
-      Submit
-    </Button>
-  </>
-)
-
 const App = () => {
-  return (
-    <Box>
-      <Form
-        onSubmit={console.log}
-        // defaultValues={{ name: 'gary' }}
-        render={FormContent}
-      />
-    </Box>
-  )
+  return <Box />
 }
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/sandbox/index.tsx
+++ b/sandbox/index.tsx
@@ -4,12 +4,36 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { reset } from 'stitches-reset'
 
-import { Box, globalCss } from '../dist'
+import { Box, Button, Form, globalCss, Input, InputField } from '../dist'
 
 globalCss(reset)()
 
+const FormContent = ({ formState }) => (
+  <>
+    <InputField
+      name="name"
+      label="Name"
+      validation={{
+        required: 'Name is required!',
+        minLength: { value: 3, message: 'longer!' }
+      }}
+    />
+    <Button type="submit" disabled={!formState.isValid}>
+      Submit
+    </Button>
+  </>
+)
+
 const App = () => {
-  return <Box />
+  return (
+    <Box>
+      <Form
+        onSubmit={console.log}
+        // defaultValues={{ name: 'gary' }}
+        render={FormContent}
+      />
+    </Box>
+  )
 }
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -228,3 +228,48 @@ const EmailField = ({ css, name, validation, required, ...rest }) => {
   )
 }
 ```
+
+## Accessing form data outside of fields
+
+The same object that `useFormContext` returns is available in an optional render prop function, making it easy to use the current form state to determine whether a button should be disabled or read the current value of a specific field. Note that if `render` is provided, `Form` should not be given any children. If both are provided, only `render` will be used.
+
+```tsx
+const SomeForm = () => {
+  return (
+    <Form
+      onSubmit={console.log}
+      render={({ formState }) => (
+        <>
+          <InputField
+            label="Name"
+            name="name"
+            validation={{ required: 'This field is required!' }}
+          />
+          <Button type="submit" disabled={!formState.isValid}>
+            Submit
+          </Button>
+        </>
+      )}
+    />
+  )
+}
+```
+
+You can also name your `render` function:
+
+```tsx
+const SomeFormContent = ({ formState }) => (
+  <>
+    <InputField
+      label="Name"
+      name="name"
+      validation={{ required: 'This field is required!' }}
+    />
+    <Button type="submit" disabled={!formState.isValid}>
+      Submit
+    </Button>
+  </>
+)
+
+const SomeForm = () => <Form onSubmit={console.log} render={SomeFormContent} />
+```

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -234,25 +234,21 @@ const EmailField = ({ css, name, validation, required, ...rest }) => {
 The same object that `useFormContext` returns is available in an optional render prop function, making it easy to use the current form state to determine whether a button should be disabled or read the current value of a specific field. Note that if `render` is provided, `Form` should not be given any children. If both are provided, only `render` will be used.
 
 ```tsx
-const SomeForm = () => {
-  return (
-    <Form
-      onSubmit={console.log}
-      render={({ formState }) => (
-        <>
-          <InputField
-            label="Name"
-            name="name"
-            validation={{ required: 'This field is required!' }}
-          />
-          <Button type="submit" disabled={!formState.isValid}>
-            Submit
-          </Button>
-        </>
-      )}
-    />
-  )
-}
+<Form
+  onSubmit={console.log}
+  render={({ formState }) => (
+    <>
+      <InputField
+        label="Name"
+        name="name"
+        validation={{ required: 'This field is required!' }}
+      />
+      <Button type="submit" disabled={!formState.isValid}>
+        Submit
+      </Button>
+    </>
+  )}
+/>
 ```
 
 You can also name your `render` function:

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -231,7 +231,7 @@ const EmailField = ({ css, name, validation, required, ...rest }) => {
 
 ## Accessing form data outside of fields
 
-The same object that `useFormContext` returns is available in an optional render prop function, making it easy to use the current form state to determine whether a button should be disabled or read the current value of a specific field. Note that if `render` is provided, `Form` should not be given any children. If both are provided, only `render` will be used.
+The same object that `useFormContext` returns is available in an optional render prop function, making it easy to use the current form state to determine whether a button should be disabled or read the current value of a specific field. Note that if `render` is provided, `Form` should not be given any children. An error will be thrown if both are provided.
 
 ```tsx
 <Form

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -54,4 +54,34 @@ describe(`Form component`, () => {
     expect(await screen.findByText('Name is required'))
     expect(await screen.findByText('Password is required'))
   })
+
+  it('passes form methods to render prop function', async () => {
+    render(
+      <Form
+        onSubmit={jest.fn()}
+        render={({ formState }) => (
+          <>
+            <InputField
+              name="name"
+              label="Name"
+              validation={{ required: 'Name is required' }}
+            />
+            <PasswordField
+              name="password"
+              validation={{ required: 'Password is required' }}
+            />
+            <Button
+              type="submit"
+              onClick={jest.fn()}
+              disabled={!formState.isValid}
+            >
+              Submit
+            </Button>
+          </>
+        )}
+      />
+    )
+
+    expect(await screen.findByText('Submit')).toHaveAttribute('disabled', '')
+  })
 })

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,3 +1,4 @@
+import invariant from 'invariant'
 import * as React from 'react'
 import type { UseFormMethods } from 'react-hook-form'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -27,10 +28,11 @@ export const Form: React.FC<FormProps> = ({
   render,
   ...remainingProps
 }) => {
-  if (process.env.NODE_ENV === 'development' && children && render)
-    console.warn(
-      '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
-    )
+  console.log('children:', children)
+  invariant(
+    !(children && render),
+    '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
+  )
 
   const formMethods = useForm({
     defaultValues,

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import type { UseFormMethods } from 'react-hook-form'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { styled } from '~/stitches'
@@ -12,7 +13,10 @@ type FormProps = Override<
     defaultValues?: { [key: string]: string | number }
     onSubmit: (data: any) => void
     validationMode: 'onBlur' | 'onSubmit'
-  }
+  } & (
+    | { children: React.ReactNode; render?: never }
+    | { children?: never; render: (methods: UseFormMethods) => React.ReactNode }
+  )
 >
 
 export const Form: React.FC<FormProps> = ({
@@ -20,13 +24,21 @@ export const Form: React.FC<FormProps> = ({
   defaultValues = {},
   onSubmit,
   validationMode = 'onBlur',
+  render,
   ...remainingProps
 }) => {
+  if (process.env.NODE_ENV === 'development' && children && render)
+    console.warn(
+      '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
+    )
+
   const formMethods = useForm({
     defaultValues,
     mode: validationMode
   })
   const { handleSubmit } = formMethods
+
+  const formContent = render ? render(formMethods) : children
 
   return (
     <FormProvider {...formMethods}>
@@ -35,7 +47,7 @@ export const Form: React.FC<FormProps> = ({
         {...remainingProps}
         onSubmit={handleSubmit(onSubmit)}
       >
-        {children}
+        {formContent}
       </StyledForm>
     </FormProvider>
   )

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -28,7 +28,6 @@ export const Form: React.FC<FormProps> = ({
   render,
   ...remainingProps
 }) => {
-  console.log('children:', children)
   invariant(
     !(children && render),
     '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'


### PR DESCRIPTION
Adds `render` prop to `Form` component, giving access to everything returned by the internal `useForm()` call. 

I added it as a prop rather than using `children` because I found [this article](https://americanexpress.io/faccs-are-an-antipattern/) on the subject pretty compelling and because it's consistent with how `react-hook-form`'s own components (`Controller`) achieve the same thing. 
