### PR TITLE
feat: Remove default List marker color

### DIFF
--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -27,19 +27,13 @@ const StyledUl = styled('ul', {
   variants: {
     theme: {
       tonal: {
-        [`& ${StyledLi}`]: {
-          '&::marker': { color: '$tonal900' }
-        }
+        color: '$tonal900'
       },
       primary: {
-        [`& ${StyledLi}`]: {
-          '&::marker': { color: '$primary500' }
-        }
+        color: '$primary500'
       },
       secondary: {
-        [`& ${StyledLi}`]: {
-          '&::marker': { color: '$secondary500' }
-        }
+        color: '$secondary500'
       }
     },
     size: textVariantSize({ applyCapsize: false })
@@ -51,7 +45,7 @@ type ListProps = React.ComponentProps<typeof StyledUl> & {
 }
 
 export const List: React.FC<ListProps> & { Item: typeof StyledLi } = ({
-  theme = 'tonal',
+  theme,
   size = 'md',
   ...remainingProps
 }) => <StyledUl theme={theme} size={size} {...remainingProps} />

--- a/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/src/components/list/__snapshots__/List.test.tsx.snap
@@ -1,42 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`List component renders a list 1`] = `
-.sxl7wr3 {
+.sxxi0hp {
   font-family: var(--sx-fonts-sans);
   margin: unset;
   padding: unset;
   padding-left: var(--sx-space-3);
 }
 
-.sxl7wr3 .sx03kze {
+.sxxi0hp .sx03kze {
   padding-left: var(--sx-space-2);
 }
 
-.sxl7wr3 .sx03kze::marker {
+.sxxi0hp .sx03kze::marker {
   content: "•";
   font-weight: bold;
 }
 
-.sxl7wr3 .sx03kze:not(:last-child) {
+.sxxi0hp .sx03kze:not(:last-child) {
   margin-bottom: var(--sx-space-2);
 }
 
-.sxl7wr3 .sx03kze:last-child {
+.sxxi0hp .sx03kze:last-child {
   margin-bottom: 0;
 }
 
-.sxl7wr3k6wac--theme-tonal .sx03kze::marker {
-  color: var(--sx-colors-tonal900);
-}
-
-.sxl7wr35dbgn--size-md {
+.sxxi0hp5dbgn--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.625;
 }
 
 <div>
   <ul
-    class="sxl7wr3 sxl7wr3k6wac--theme-tonal sxl7wr35dbgn--size-md"
+    class="sxxi0hp sxxi0hp5dbgn--size-md"
   >
     <li
       class="sx03kze"


### PR DESCRIPTION
- [x] The `List` component doesn't have the `tonal` theme variant set by default anymore.
- [x] The list markers now inherit the color of the text of the list items.

These changes should prevent issues where you'd set the text color of the List items (either on the `<List.Item />` itself or one of its ancestors and the markers would keep the `$tonal900` color because the `tonal` theme was set as default.