### PR TITLE
feat: polymorphic link and button

### DIFF
--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -76,3 +76,19 @@ Setting `isRounded` creates a rounded button
 ```tsx live
 <Button isRounded>Rounded Button</Button>
 ```
+
+## Polymorphism
+
+The `Button` component supports polymorphism, therefore depending on whether it receives an `onClick`/`href` as a prop, it will produce a `button` or `link` respectively 
+
+```tsx preview
+<Button href="http://example.com/">
+  I'm a link
+</Button>
+```
+
+```tsx preview
+<Button onClick={() => console.log('clicked')}>
+  I'm a button
+</Button>
+```

--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -187,7 +187,7 @@ describe(`Button component`, () => {
     })
 
     it('renders an anchor if provided a link', async () => {
-      render(<Button to="https://atomlearning.co.uk">ATOM</Button>)
+      render(<Button href="https://atomlearning.co.uk">ATOM</Button>)
 
       expect(await screen.findByRole('link')).toHaveAttribute(
         'href',

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { Box } from '~/components/box'
 import { Loader } from '~/components/loader'
 import { styled } from '~/stitches'
+import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
 
 const getButtonOutlineVariant = (baseColor: string, interactColor: string) => ({
@@ -195,18 +196,16 @@ type ButtonProps = Override<
     as?: React.ComponentType | React.ElementType
     children: React.ReactNode
     isLoading?: boolean
-    onClick?: () => void
-    to?: string
-  }
+  } & NavigatorActions
 >
 
-export const Button: React.FC<ButtonProps> = React.forwardRef(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       children,
       isLoading,
       onClick,
-      to,
+      href,
       appearance = 'solid',
       size = 'md',
       theme = 'primary',
@@ -215,7 +214,13 @@ export const Button: React.FC<ButtonProps> = React.forwardRef(
     },
     ref
   ) => {
-    const optionalLinkProps = to ? { as: 'a', href: to } : {}
+    const optionalLinkProps = href
+      ? {
+          as: 'a',
+          href,
+          onClick: undefined
+        }
+      : {}
 
     // Note: button is not disabled when loading for accessibility purposes.
     // Instead the click action is not fired and the button looks faded
@@ -239,6 +244,6 @@ export const Button: React.FC<ButtonProps> = React.forwardRef(
       </StyledButton>
     )
   }
-)
+) as React.FC<ButtonProps>
 
 Button.displayName = 'Button'

--- a/src/components/link/Link.mdx
+++ b/src/components/link/Link.mdx
@@ -35,3 +35,19 @@ It adds default styling and the `css` prop.
   7-12+. Prepare your child for secondary school entry and beyond.
 </Text>
 ```
+
+## Polymorphism
+
+The `Link` component supports polymorphism, therefore depending on whether it receives an `onClick`/`href` as a prop, it will produce a `button` or `link` respectively 
+
+```tsx preview
+<Link href="http://example.com/">
+  I'm a link
+</Link>
+```
+
+```tsx preview
+<Link onClick={() => console.log('clicked')}>
+  I'm a button
+</Link>
+```

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { styled } from '~/stitches'
+import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
 
 import { StyledHeading } from '../heading/Heading'
@@ -38,13 +39,22 @@ type LinkProps = Override<
   React.ComponentProps<typeof StyledLink>,
   {
     as?: React.ComponentType | React.ElementType
-  }
+  } & NavigatorActions
 >
 
-export const Link: React.FC<LinkProps> = React.forwardRef(
-  ({ size = 'md', ...remainingProps }, ref) => (
-    <StyledLink size={size} {...remainingProps} ref={ref} />
-  )
-)
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ size = 'md', onClick, href, ...remainingProps }, ref) =>
+    onClick ? (
+      <StyledLink
+        as="button"
+        size={size}
+        {...remainingProps}
+        ref={ref}
+        onClick={onClick}
+      />
+    ) : (
+      <StyledLink size={size} {...remainingProps} ref={ref} href={href} />
+    )
+) as React.FC<LinkProps>
 
 Link.displayName = 'Link'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './navigatorActions.types'

--- a/src/types/navigatorActions.types.ts
+++ b/src/types/navigatorActions.types.ts
@@ -1,0 +1,3 @@
+export type NavigatorActions =
+  | { onClick: (...args: unknown[]) => void; href?: never }
+  | { onClick?: never; href: string }


### PR DESCRIPTION
This PR is an answer on following issue:
https://github.com/Atom-Learning/components/issues/148

Changes:
Support Polymorphic feature for Link and Button.

Link can render anchor or button depends on passed properties (onClick / href)
Button can render button or anchor depends on passed properties (onClick / href)