### PR TITLE
fix: updated condition to apply margin on Icon inside Button

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,6 +2,7 @@ import { StitchesVariants } from '@stitches/react'
 import * as React from 'react'
 
 import { Box } from '~/components/box'
+import { Icon } from '~/components/icon'
 import { Loader } from '~/components/loader'
 import { styled } from '~/stitches'
 import { NavigatorActions } from '~/types'
@@ -182,7 +183,7 @@ const WithLoader = ({ isLoading, children }) => (
 
 const getChildren = (children) =>
   React.Children.map(children, (child: any, i) => {
-    if (child?.type?.name === 'Icon') {
+    if (child?.type === Icon) {
       return React.cloneElement(child, {
         css: { [i === 0 ? 'mr' : 'ml']: '$2' }
       })

--- a/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -12,16 +12,6 @@ exports[`Password component renders a password field 1`] = `
   position: relative;
 }
 
-.sx2cs53 {
-  display: flex;
-}
-
-.sx2cs53-re4mk {
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--sx-space-2);
-}
-
 .sxib16r {
   display: inline-block;
   fill: none;
@@ -35,6 +25,16 @@ exports[`Password component renders a password field 1`] = `
 .sxib16rmbqqh--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+}
+
+.sx2cs53 {
+  display: flex;
+}
+
+.sx2cs53-re4mk {
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--sx-space-2);
 }
 
 .sxdiu5c {


### PR DESCRIPTION
When using the library in another project, the margin on `<Icon />` inside a `<Button />` was not applied. This was because the margin was applied on components with the name `'icon'`. This name was minified, so the condition always resulted in a `false` when using the library.

Updated the condition to check if the child is an instance of the `Icon` component instead of checking the name.

_Note: the snapshot test for `PasswordField` failed. Decided to update that and include it here as it only changed the order of CSS._