### PR TITLE
feat(persist-form): adding react-hook-form-persist package

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "invariant": "^2.2.4",
     "pure-react-carousel": "^1.27.6",
     "react-hook-form": "^6.15.4",
+    "react-hook-form-persist": "^2.0.0",
     "react-hot-toast": "^1.0.2",
     "react-player": "^2.9.0",
     "uid": "^2.0.0"

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -153,17 +153,16 @@ The `process` property accepts a function of type `(value: any) => any`. It can 
 Here's an example using the `persist` prop:
 
 ```tsx
-<Form
-  persist={{ id: 'nameAndPassword', exclude: ['password'], storage: 'local' }}
->
+<Form persist={{ id: 'nameAndSecret', exclude: ['secret'], storage: 'local' }}>
   <InputField
     name="name"
     label="Name"
     validation={{ required: 'Name is required' }}
   />
-  <PasswordField
-    name="password"
-    validation={{ required: 'Password is required' }}
+  <InputField
+    name="secret"
+    label="Secret"
+    validation={{ required: 'Secret is required' }}
   />
   <Button type="submit">Submit</Button>
 </Form>

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -154,7 +154,6 @@ Here's an example using the `persist` prop:
 
 ```tsx
 <Form
-  onSubmit={console.log('')}
   persist={{ id: 'nameAndPassword', exclude: ['password'], storage: 'local' }}
 >
   <InputField
@@ -166,9 +165,7 @@ Here's an example using the `persist` prop:
     name="password"
     validation={{ required: 'Password is required' }}
   />
-  <Button type="submit" onClick={console.log('')}>
-    Submit
-  </Button>
+  <Button type="submit">Submit</Button>
 </Form>
 ```
 

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -154,7 +154,7 @@ Here's an example using the `persist` prop:
 
 ```tsx
 <Form
-  onSubmit={jest.fn()}
+  onSubmit={console.log('')}
   persist={{ id: 'nameAndPassword', exclude: ['password'], storage: 'local' }}
 >
   <InputField
@@ -166,7 +166,7 @@ Here's an example using the `persist` prop:
     name="password"
     validation={{ required: 'Password is required' }}
   />
-  <Button type="submit" onClick={jest.fn()}>
+  <Button type="submit" onClick={console.log('')}>
     Submit
   </Button>
 </Form>

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -17,6 +17,13 @@ priority: 1
 
 Custom field components should also accept a `validation` prop of type `ValidationOptions` and apply it to the field when present.
 
+`Form` is integrated with `react-hook-form-persist`'s package to save form data into session storage:
+
+- send `shouldPersist` boolean prop to persist form data to sessionStorage per `react-hook-form-persist`’s docs
+- send `persistOptions` prop with a required `id` and optional `include` or `exclude` arrays with reference to the input's names
+- `include` will only save the listed inputs to session storage and `exclude` will exclude the listed inputs
+- persisted form data in session storage will populate form with `defaultValues` on refresh
+
 Here’s an example using a simplified version of our `InputField`:
 
 ```tsx

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -17,13 +17,6 @@ priority: 1
 
 Custom field components should also accept a `validation` prop of type `ValidationOptions` and apply it to the field when present.
 
-`Form` is integrated with `react-hook-form-persist`'s package to save form data into session storage:
-
-- send `shouldPersist` boolean prop to persist form data to sessionStorage per `react-hook-form-persist`’s docs
-- send `persistOptions` prop with a required `id` and optional `include` or `exclude` arrays with reference to the input's names
-- `include` will only save the listed inputs to session storage and `exclude` will exclude the listed inputs
-- persisted form data in session storage will populate form with `defaultValues` on refresh
-
 Here’s an example using a simplified version of our `InputField`:
 
 ```tsx
@@ -145,6 +138,39 @@ These properties only apply to text inputs. If `true`, the value will be convert
 ### Custom processing
 
 The `process` property accepts a function of type `(value: any) => any`. It can be used to process the value after validation.
+
+## Persisting form data
+
+`Form` is integrated with `react-hook-form-persist`'s package to save form data into session storage:
+
+- send `persist` prop to Form component to persist form data in sessionStorage
+- `persist` object has a required `id`, an optional `storage` prop and optional `include` or `exclude` arrays with reference to the input's names
+- `include` will only save the listed inputs to session storage and `exclude` will exclude the listed inputs
+- if both `include` and `exclude` are sent it will ignore `include` and use only `exclude`
+- if no `storage` prop is sent, it will default to use sessionStorage, however you can override this by sending `local` to use localStorage
+- persisted form data in sessionStorage or localStorage will populate form with `defaultValues` on refresh
+
+Here's an example using the `persist` prop:
+
+```tsx
+<Form
+  onSubmit={jest.fn()}
+  persist={{ id: 'nameAndPassword', exclude: ['password'], storage: 'local' }}
+>
+  <InputField
+    name="name"
+    label="Name"
+    validation={{ required: 'Name is required' }}
+  />
+  <PasswordField
+    name="password"
+    validation={{ required: 'Password is required' }}
+  />
+  <Button type="submit" onClick={jest.fn()}>
+    Submit
+  </Button>
+</Form>
+```
 
 ## Composing form field components
 

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -109,6 +109,29 @@ describe(`Form component`, () => {
     )
   })
 
+  it('checks user input values are being persisted in sessionStorage', async () => {
+    render(
+      <Form onSubmit={jest.fn()} persist={{ id: 'nameForm' }}>
+        <InputField
+          name="name"
+          label="Name"
+          type="text"
+          validation={{ required: 'Name is required' }}
+        />
+        <Button type="submit" onClick={jest.fn()}>
+          Submit
+        </Button>
+      </Form>
+    )
+    const input = screen.getByRole('textbox', { name: 'Name' })
+
+    userEvent.type(input, 'Kyle Lowry')
+    expect(input).toHaveValue('Kyle Lowry')
+    expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
+      'Kyle Lowry'
+    )
+  })
+
   it('saves form data to sessionStorage excluding secret field', async () => {
     render(
       <Form
@@ -135,41 +158,14 @@ describe(`Form component`, () => {
 
     const nameInput = screen.getByRole('textbox', { name: 'Name' })
     const secretInput = screen.getByRole('textbox', { name: 'Secret' })
+    const parsedStorage = JSON.parse(sessionStorage.getItem('nameAndSecret'))
 
     userEvent.type(nameInput, 'Kawhi Leonard')
     userEvent.type(secretInput, 'Very secret secret')
 
-    expect(JSON.parse(sessionStorage.getItem('nameAndSecret'))).toEqual(
-      expect.anything()
-    )
-    expect(JSON.parse(sessionStorage.getItem('nameAndSecret')).name).toEqual(
-      'Kawhi Leonard'
-    )
-    expect(
-      JSON.parse(sessionStorage.getItem('nameAndSecret')).secret
-    ).toBeFalsy()
-  })
-
-  it('checks user input values are being persisted in sessionStorage', async () => {
-    render(
-      <Form onSubmit={jest.fn()} persist={{ id: 'nameForm' }}>
-        <InputField
-          name="name"
-          label="Name"
-          type="text"
-          validation={{ required: 'Name is required' }}
-        />
-        <Button type="submit" onClick={jest.fn()}>
-          Submit
-        </Button>
-      </Form>
-    )
-
-    userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'Kyle Lowry')
-    expect(screen.getByRole('textbox')).toHaveValue('Kyle Lowry')
-    expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
-      'Kyle Lowry'
-    )
+    expect(parsedStorage).toEqual(expect.anything())
+    expect(parsedStorage.name).toEqual('Kawhi Leonard')
+    expect(parsedStorage.secret).toBeFalsy()
   })
 
   it('checks data attributes are availabe in the DOM', async () => {

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -104,7 +104,9 @@ describe(`Form component`, () => {
       </Form>
     )
 
-    expect(sessionStorage.getItem('nameAndYearGroup')).toBeTruthy()
+    expect(sessionStorage.getItem('nameAndYearGroup')).toEqual(
+      expect.anything()
+    )
   })
 
   it('saves form data to sessionStorage excluding secret field', async () => {
@@ -136,31 +138,48 @@ describe(`Form component`, () => {
     ).toBeFalsy()
   })
 
-  it('checks default values are being persisted in sessionStorage', async () => {
+  it('checks user input values are being persisted in sessionStorage', async () => {
     render(
-      <Form onSubmit={jest.fn()} persist={{ id: 'nameAndTeam' }}>
+      <Form onSubmit={jest.fn()} persist={{ id: 'nameForm' }}>
         <InputField
           name="name"
           label="Name"
-          defaultValue="Kyle Lowry"
           validation={{ required: 'Name is required' }}
-        />
-        <InputField
-          name="team"
-          label="Team"
-          defaultValue="Toronto Raptors"
-          validation={{ required: 'Team is required' }}
         />
         <Button type="submit" onClick={jest.fn()}>
           Submit
         </Button>
       </Form>
     )
-    expect(JSON.parse(sessionStorage.getItem('nameAndTeam')).name).toEqual(
+
+    userEvent.type(screen.getByRole('input'), 'Kyle Lowry')
+    expect(screen.getByRole('form')).toHaveValue('Kyle Lowry')
+    expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
       'Kyle Lowry'
     )
-    expect(JSON.parse(sessionStorage.getItem('nameAndTeam')).team).toEqual(
-      'Toronto Raptors'
+  })
+
+  it('checks data attributes are availabe in the DOM', async () => {
+    render(
+      <div>
+        <Form
+          onSubmit={jest.fn()}
+          persist={{ id: 'nameAndTeam' }}
+          data-index-number="12345"
+        >
+          <InputField
+            name="name"
+            label="Name"
+            validation={{ required: 'Name is required' }}
+          />
+          <Button type="submit" onClick={jest.fn()}>
+            Submit
+          </Button>
+        </Form>
+      </div>
+    )
+    expect(screen.getByRole('form').getAttribute('data-index-number')).toEqual(
+      '12345'
     )
   })
 })

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -133,8 +133,8 @@ describe(`Form component`, () => {
       </Form>
     )
 
-    const nameInput = screen.getByRole('textbox', { name: 'name' })
-    const secretInput = screen.getByRole('textbox', { name: 'secret' })
+    const nameInput = screen.getByRole('textbox', { name: 'Name' })
+    const secretInput = screen.getByRole('textbox', { name: 'Secret' })
 
     userEvent.type(nameInput, 'Kawhi Leonard')
     userEvent.type(secretInput, 'Very secret secret')
@@ -165,7 +165,7 @@ describe(`Form component`, () => {
       </Form>
     )
 
-    userEvent.type(screen.getByRole('textbox', { name: 'name' }), 'Kyle Lowry')
+    userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'Kyle Lowry')
     expect(screen.getByRole('textbox')).toHaveValue('Kyle Lowry')
     expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
       'Kyle Lowry'

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -118,11 +118,13 @@ describe(`Form component`, () => {
         <InputField
           name="name"
           label="Name"
+          type="text"
           validation={{ required: 'Name is required' }}
         />
         <InputField
           name="secret"
           label="Secret"
+          type="text"
           validation={{ required: 'Secret is required' }}
         />
         <Button type="submit" onClick={jest.fn()}>
@@ -130,8 +132,18 @@ describe(`Form component`, () => {
         </Button>
       </Form>
     )
-    expect(JSON.parse(sessionStorage.getItem('nameAndSecret')).name).toEqual(
+
+    const nameInput = screen.getByRole('textbox', { name: 'name' })
+    const secretInput = screen.getByRole('textbox', { name: 'secret' })
+
+    userEvent.type(nameInput, 'Kawhi Leonard')
+    userEvent.type(secretInput, 'Very secret secret')
+
+    expect(JSON.parse(sessionStorage.getItem('nameAndSecret'))).toEqual(
       expect.anything()
+    )
+    expect(JSON.parse(sessionStorage.getItem('nameAndSecret')).name).toEqual(
+      'Kawhi Leonard'
     )
     expect(
       JSON.parse(sessionStorage.getItem('nameAndSecret')).secret
@@ -153,7 +165,7 @@ describe(`Form component`, () => {
       </Form>
     )
 
-    userEvent.type(screen.getByRole('textbox'), 'Kyle Lowry')
+    userEvent.type(screen.getByRole('textbox', { name: 'name' }), 'Kyle Lowry')
     expect(screen.getByRole('textbox')).toHaveValue('Kyle Lowry')
     expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
       'Kyle Lowry'
@@ -165,13 +177,13 @@ describe(`Form component`, () => {
       <div>
         <Form
           onSubmit={jest.fn()}
-          persist={{ id: 'nameAndTeam' }}
+          persist={{ id: 'cityForm' }}
           data-index-number="12345"
         >
           <InputField
-            name="name"
-            label="Name"
-            validation={{ required: 'Name is required' }}
+            name="city"
+            label="City"
+            validation={{ required: 'City is required' }}
           />
           <Button type="submit" onClick={jest.fn()}>
             Submit

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -158,11 +158,11 @@ describe(`Form component`, () => {
 
     const nameInput = screen.getByRole('textbox', { name: 'Name' })
     const secretInput = screen.getByRole('textbox', { name: 'Secret' })
-    const parsedStorage = JSON.parse(sessionStorage.getItem('nameAndSecret'))
 
     userEvent.type(nameInput, 'Kawhi Leonard')
     userEvent.type(secretInput, 'Very secret secret')
 
+    const parsedStorage = JSON.parse(sessionStorage.getItem('nameAndSecret'))
     expect(parsedStorage).toEqual(expect.anything())
     expect(parsedStorage.name).toEqual('Kawhi Leonard')
     expect(parsedStorage.secret).toBeFalsy()

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -84,4 +84,36 @@ describe(`Form component`, () => {
 
     expect(await screen.findByText('Submit')).toHaveAttribute('disabled', '')
   })
+
+  it('saves form data to sessionStorage when shouldPersist prop is true', async () => {
+    render(
+      <Form
+        onSubmit={jest.fn()}
+        shouldPersist
+        persistOptions={{ id: 'nameAndPassword', exclude: ['password'] }}
+      >
+        <InputField
+          name="name"
+          label="Name"
+          validation={{ required: 'Name is required' }}
+        />
+        <PasswordField
+          name="password"
+          validation={{ required: 'Password is required' }}
+        />
+        <Button type="submit" onClick={jest.fn()}>
+          Submit
+        </Button>
+      </Form>
+    )
+
+    expect(
+      sessionStorage.getItem('form-nameAndPassword') !== null ||
+        sessionStorage.getItem('form-nameAndPassword') !== undefined
+    )
+    expect(
+      JSON.parse(sessionStorage.getItem('form-nameAndPassword')).password ===
+        undefined
+    )
+  })
 })

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -144,6 +144,7 @@ describe(`Form component`, () => {
         <InputField
           name="name"
           label="Name"
+          type="text"
           validation={{ required: 'Name is required' }}
         />
         <Button type="submit" onClick={jest.fn()}>
@@ -152,8 +153,8 @@ describe(`Form component`, () => {
       </Form>
     )
 
-    userEvent.type(screen.getByRole('input'), 'Kyle Lowry')
-    expect(screen.getByRole('input')).toHaveValue('Kyle Lowry')
+    userEvent.type(screen.getByRole('textbox'), 'Kyle Lowry')
+    expect(screen.getByRole('textbox')).toHaveValue('Kyle Lowry')
     expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
       'Kyle Lowry'
     )

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -85,21 +85,18 @@ describe(`Form component`, () => {
     expect(await screen.findByText('Submit')).toHaveAttribute('disabled', '')
   })
 
-  it('saves form data to sessionStorage when shouldPersist prop is true', async () => {
+  it('saves form data to sessionStorage when persist prop is sent through', async () => {
     render(
-      <Form
-        onSubmit={jest.fn()}
-        shouldPersist
-        persistOptions={{ id: 'nameAndPassword', exclude: ['password'] }}
-      >
+      <Form onSubmit={jest.fn()} persist={{ id: 'nameAndYearGroup' }}>
         <InputField
           name="name"
           label="Name"
           validation={{ required: 'Name is required' }}
         />
-        <PasswordField
-          name="password"
-          validation={{ required: 'Password is required' }}
+        <InputField
+          name="yearGroup"
+          label="Year Group"
+          validation={{ required: 'Year group is required' }}
         />
         <Button type="submit" onClick={jest.fn()}>
           Submit
@@ -107,13 +104,63 @@ describe(`Form component`, () => {
       </Form>
     )
 
-    expect(
-      sessionStorage.getItem('form-nameAndPassword') !== null ||
-        sessionStorage.getItem('form-nameAndPassword') !== undefined
+    expect(sessionStorage.getItem('nameAndYearGroup')).toBeTruthy()
+  })
+
+  it('saves form data to sessionStorage excluding secret field', async () => {
+    render(
+      <Form
+        onSubmit={jest.fn()}
+        persist={{ id: 'nameAndSecret', exclude: ['secret'] }}
+      >
+        <InputField
+          name="name"
+          label="Name"
+          validation={{ required: 'Name is required' }}
+        />
+        <InputField
+          name="secret"
+          label="Secret"
+          validation={{ required: 'Secret is required' }}
+        />
+        <Button type="submit" onClick={jest.fn()}>
+          Submit
+        </Button>
+      </Form>
+    )
+    expect(JSON.parse(sessionStorage.getItem('nameAndSecret')).name).toEqual(
+      expect.anything()
     )
     expect(
-      JSON.parse(sessionStorage.getItem('form-nameAndPassword')).password ===
-        undefined
+      JSON.parse(sessionStorage.getItem('nameAndSecret')).secret
+    ).toBeFalsy()
+  })
+
+  it('checks default values are being persisted in sessionStorage', async () => {
+    render(
+      <Form onSubmit={jest.fn()} persist={{ id: 'nameAndTeam' }}>
+        <InputField
+          name="name"
+          label="Name"
+          defaultValue="Kyle Lowry"
+          validation={{ required: 'Name is required' }}
+        />
+        <InputField
+          name="team"
+          label="Team"
+          defaultValue="Toronto Raptors"
+          validation={{ required: 'Team is required' }}
+        />
+        <Button type="submit" onClick={jest.fn()}>
+          Submit
+        </Button>
+      </Form>
+    )
+    expect(JSON.parse(sessionStorage.getItem('nameAndTeam')).name).toEqual(
+      'Kyle Lowry'
+    )
+    expect(JSON.parse(sessionStorage.getItem('nameAndTeam')).team).toEqual(
+      'Toronto Raptors'
     )
   })
 })

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -153,7 +153,7 @@ describe(`Form component`, () => {
     )
 
     userEvent.type(screen.getByRole('input'), 'Kyle Lowry')
-    expect(screen.getByRole('form')).toHaveValue('Kyle Lowry')
+    expect(screen.getByRole('input')).toHaveValue('Kyle Lowry')
     expect(JSON.parse(sessionStorage.getItem('nameForm')).name).toEqual(
       'Kyle Lowry'
     )

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -36,13 +36,15 @@ const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
   let params: FormPersistParams = {
     ...options,
     storage:
-      options.storage === StorageEnum.local
+      options.storage === StorageEnum.LOCAL
         ? window.localStorage
         : window.sessionStorage
   }
 
   if (options.exclude) {
-    // Workaround for package bug
+    // Workaround for bug in react-hook-form-persist package
+    // package will still read from and save exclude param
+    // so need to send inputs we actually want to read from in include param instead
     const { exclude, ...rest } = params
     const allValues = watch()
     const include = Object.keys(allValues).filter((key) => {

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -5,15 +5,25 @@ import useFormPersist from 'react-hook-form-persist'
 
 import { styled } from '~/stitches'
 
-import {
-  FormContentProps,
+import type {
+  FormContentValues,
   FormPersistParams,
-  FormProps,
-  PersistFormWrapperProps,
-  StorageEnum
+  FormValues,
+  PersistFormWrapperValues,
+  PersistOptions
 } from './Form.types'
+import { StorageEnum } from './Form.types'
 
 const StyledForm = styled('form', {})
+
+type FormProps = React.ComponentPropsWithoutRef<typeof StyledForm> & FormValues
+
+type FormContentProps = React.ComponentPropsWithoutRef<typeof StyledForm> &
+FormContentValues
+
+type PersistFormWrapperProps = React.ComponentPropsWithoutRef<
+  typeof StyledForm
+> & PersistFormWrapperValues
 
 const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
   persist,

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -2,11 +2,18 @@ import invariant from 'invariant'
 import * as React from 'react'
 import type { UseFormMethods } from 'react-hook-form'
 import { FormProvider, useForm } from 'react-hook-form'
+import useFormPersist from 'react-hook-form-persist'
 
 import { styled } from '~/stitches'
 import { Override } from '~/utilities'
 
 const StyledForm = styled('form', {})
+
+type ExcludeAndInclude = { exclude?: string[]; include?: string[] }
+type PersistOptions = { id: string } & ExcludeAndInclude
+type FormPersistParams = {
+  storage: Storage
+} & ExcludeAndInclude
 
 type FormProps = Override<
   React.ComponentPropsWithoutRef<typeof StyledForm>,
@@ -14,33 +21,63 @@ type FormProps = Override<
     defaultValues?: { [key: string]: string | number }
     onSubmit: (data: any) => void
     validationMode: 'onBlur' | 'onSubmit'
+    shouldPersist?: boolean
+    persistOptions?: PersistOptions
   } & (
     | { children: React.ReactNode; render?: never }
     | { children?: never; render: (methods: UseFormMethods) => React.ReactNode }
   )
 >
 
-export const Form: React.FC<FormProps> = ({
-  children,
-  defaultValues = {},
-  onSubmit,
-  validationMode = 'onBlur',
-  render,
-  ...remainingProps
+type FormContentProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledForm>,
+  {
+    formMethods
+    remainingProps
+    handleSubmit: (data: any) => void
+    onSubmit: (data: any) => void
+    formContent
+  }
+>
+
+type PersistFormWrapperProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledForm>,
+  {
+    persistOptions: PersistOptions
+    watch: (data: any) => void
+    setValue
+    children: React.ReactNode | any
+  }
+>
+
+const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
+  persistOptions,
+  watch,
+  setValue,
+  children
 }) => {
-  invariant(
-    !(children && render),
-    '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
-  )
+  let params: FormPersistParams = {
+    storage: window.sessionStorage
+  }
+  if (persistOptions?.exclude) {
+    params = { ...params, exclude: persistOptions.exclude }
+  }
+  if (!persistOptions?.exclude && persistOptions?.include) {
+    params = { ...params, include: persistOptions.include }
+  }
 
-  const formMethods = useForm({
-    defaultValues,
-    mode: validationMode
-  })
-  const { handleSubmit } = formMethods
+  useFormPersist(`form-${persistOptions.id}`, { watch, setValue }, params)
 
-  const formContent = render ? render(formMethods) : children
+  return children
+}
 
+const FormContent: React.FC<FormContentProps> = ({
+  formMethods,
+  remainingProps,
+  handleSubmit,
+  onSubmit,
+  formContent
+}) => {
   return (
     <FormProvider {...formMethods}>
       <StyledForm
@@ -52,6 +89,52 @@ export const Form: React.FC<FormProps> = ({
       </StyledForm>
     </FormProvider>
   )
+}
+
+export const Form: React.FC<FormProps> = ({
+  children,
+  defaultValues = {},
+  onSubmit,
+  validationMode = 'onBlur',
+  render,
+  shouldPersist,
+  persistOptions,
+  ...remainingProps
+}) => {
+  invariant(
+    !(children && render),
+    '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
+  )
+
+  const formMethods = useForm({
+    defaultValues,
+    mode: validationMode
+  })
+  const { handleSubmit, watch, setValue } = formMethods
+
+  const formContent = render ? render(formMethods) : children
+
+  const props = {
+    formMethods,
+    remainingProps,
+    handleSubmit,
+    onSubmit,
+    formContent
+  }
+
+  if (shouldPersist && persistOptions) {
+    return (
+      <PersistFormWrapper
+        persistOptions={persistOptions}
+        watch={watch}
+        setValue={setValue}
+      >
+        <FormContent {...props} />
+      </PersistFormWrapper>
+    )
+  }
+
+  return <FormContent {...props} />
 }
 
 Form.displayName = 'Form'

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -5,8 +5,6 @@ import useFormPersist from 'react-hook-form-persist'
 
 import { styled } from '~/stitches'
 
-const StyledForm = styled('form', {})
-
 import {
   FormContentProps,
   FormPersistParams,
@@ -14,6 +12,8 @@ import {
   PersistFormWrapperProps,
   StorageEnum
 } from './Form.types'
+
+const StyledForm = styled('form', {})
 
 const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
   persist,
@@ -36,7 +36,7 @@ const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
     const { exclude, ...rest } = params
     const allValues = watch()
     const include = Object.keys(allValues).filter((key) => {
-      if (!options.exclude.includes(key)) return key
+      if (!options.exclude?.includes(key)) return key
     })
     params = { ...rest, include }
   }
@@ -79,13 +79,6 @@ export const Form: React.FC<FormProps> = ({
     !(children && render),
     '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
   )
-
-  // if (persist) {
-  //   invariant(
-  //     !(persist.include && persist.exclude),
-  //     'If `Form` is sent `persist`, it should only be given one of `include` or `exclude`. When both are provided, `exclude` will be used and `include` will be ignored.'
-  //   )
-  // }
 
   const formMethods = useForm({
     defaultValues,

--- a/src/components/form/Form.types.ts
+++ b/src/components/form/Form.types.ts
@@ -1,8 +1,8 @@
 import type { UseFormMethods } from 'react-hook-form'
 
 export enum StorageEnum {
-  local = 'local',
-  session = 'session'
+  LOCAL = 'local',
+  SESSION = 'session'
 }
 
 type ExcludeIncludeConfig = {

--- a/src/components/form/Form.types.ts
+++ b/src/components/form/Form.types.ts
@@ -1,0 +1,79 @@
+import type { UseFormMethods } from 'react-hook-form'
+
+import { styled } from '~/stitches'
+import { Override } from '~/utilities'
+
+const StyledForm = styled('form', {})
+
+type ExcludeConfig = { exclude?: string[] }
+type IncludeConfig = { include?: string[] }
+
+enum StorageEnum {
+  local = 'local',
+  session = 'session'
+}
+
+type PersistOptionsInclude = {
+  id: string
+  storage?: StorageEnum
+} & IncludeConfig
+
+type PersistOptionsExclude = {
+  id: string
+  storage?: StorageEnum
+} & ExcludeConfig
+
+// type PersistOptions = PersistOptionsInclude | PersistOptionsExclude
+
+type PersistOptions = { id: string; storage?: StorageEnum } & (
+  | IncludeConfig
+  | ExcludeConfig
+  | any
+)
+
+type FormPersistParams = {
+  storage: Storage
+  exclude?: string[]
+  include?: string[]
+}
+
+type FormProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledForm>,
+  {
+    defaultValues?: { [key: string]: string | number }
+    onSubmit: (data: any) => void
+    validationMode: 'onBlur' | 'onSubmit'
+    persist?: PersistOptions
+  } & (
+    | { children: React.ReactNode; render?: never }
+    | { children?: never; render: (methods: UseFormMethods) => React.ReactNode }
+  )
+>
+
+type FormContentProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledForm>,
+  {
+    formMethods
+    handleSubmit: (data: any) => void
+    onSubmit: (data: any) => void
+    children: React.ReactNode | any
+  }
+>
+
+type PersistFormWrapperProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledForm>,
+  {
+    persist: PersistOptions
+    watch
+    setValue
+    children: React.ReactNode | any
+  }
+>
+
+export {
+  FormPersistParams,
+  PersistFormWrapperProps,
+  FormContentProps,
+  FormProps,
+  StorageEnum
+}

--- a/src/components/form/Form.types.ts
+++ b/src/components/form/Form.types.ts
@@ -1,65 +1,44 @@
 import type { UseFormMethods } from 'react-hook-form'
 
-import { styled } from '~/stitches'
-import { Override } from '~/utilities'
-
-const StyledForm = styled('form', {})
-
-enum StorageEnum {
+export enum StorageEnum {
   local = 'local',
   session = 'session'
 }
 
-type PersistOptions = {
+type ExcludeIncludeConfig = {
+  exclude?: string[]
+  include?: string[]
+}
+
+export type PersistOptions = {
   id: string
   storage?: StorageEnum
-  exclude?: string[]
-  include?: string[]
-}
+} & ExcludeIncludeConfig
 
-type FormPersistParams = {
+export type FormPersistParams = {
   storage: Storage
-  exclude?: string[]
-  include?: string[]
+} & ExcludeIncludeConfig
+
+export type PersistFormWrapperValues = {
+  persist: PersistOptions
+  watch
+  setValue
+  children: React.ReactNode | any
 }
 
-type FormProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledForm>,
-  {
-    defaultValues?: { [key: string]: string | number }
-    onSubmit: (data: any) => void
-    validationMode: 'onBlur' | 'onSubmit'
-    persist?: PersistOptions
-  } & (
-    | { children: React.ReactNode; render?: never }
-    | { children?: never; render: (methods: UseFormMethods) => React.ReactNode }
-  )
->
-
-type FormContentProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledForm>,
-  {
-    formMethods
-    handleSubmit: (data: any) => void
-    onSubmit: (data: any) => void
-    children: React.ReactNode | any
-  }
->
-
-type PersistFormWrapperProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledForm>,
-  {
-    persist: PersistOptions
-    watch
-    setValue
-    children: React.ReactNode | any
-  }
->
-
-export {
-  FormPersistParams,
-  PersistFormWrapperProps,
-  FormContentProps,
-  FormProps,
-  StorageEnum
+export type FormContentValues = {
+  formMethods
+  handleSubmit: (data: any) => void | any
+  onSubmit: (data: any) => void | any
+  children: React.ReactNode | any
 }
+
+export type FormValues = {
+  defaultValues?: { [key: string]: string | number }
+  onSubmit: (data: any) => void | any
+  validationMode: 'onBlur' | 'onSubmit'
+  persist?: PersistOptions
+} & (
+  | { children: React.ReactNode; render?: never }
+  | { children?: never; render: (methods: UseFormMethods) => React.ReactNode }
+)

--- a/src/components/form/Form.types.ts
+++ b/src/components/form/Form.types.ts
@@ -5,31 +5,17 @@ import { Override } from '~/utilities'
 
 const StyledForm = styled('form', {})
 
-type ExcludeConfig = { exclude?: string[] }
-type IncludeConfig = { include?: string[] }
-
 enum StorageEnum {
   local = 'local',
   session = 'session'
 }
 
-type PersistOptionsInclude = {
+type PersistOptions = {
   id: string
   storage?: StorageEnum
-} & IncludeConfig
-
-type PersistOptionsExclude = {
-  id: string
-  storage?: StorageEnum
-} & ExcludeConfig
-
-// type PersistOptions = PersistOptionsInclude | PersistOptionsExclude
-
-type PersistOptions = { id: string; storage?: StorageEnum } & (
-  | IncludeConfig
-  | ExcludeConfig
-  | any
-)
+  exclude?: string[]
+  include?: string[]
+}
 
 type FormPersistParams = {
   storage: Storage


### PR DESCRIPTION
Linked issue - https://github.com/Atom-Learning/components/issues/165

## In this PR
- [x] Integrated persist functionality for the form in sessionStorage using `react-hook-form-persist`
- [x] Allow for `shouldPersist` prop to be sent to the form to indicate whether it should be used
- [x] If `shouldPersist` is true, persisted data in sessionStorage will populate `defaultValues` in the form 

