### PR TITLE
Fix markdown content bugs

### DIFF
--- a/src/components/markdown-content/MarkdownContent.mdx
+++ b/src/components/markdown-content/MarkdownContent.mdx
@@ -6,21 +6,22 @@ category: Content
 ---
 
 Currently it suppports converts the following Markdown elements into components:
-| Type | Component | Supported |
-| --- | --- | - |
-| text | `{value}` | ✅ |
-| emphasis | `<em />` | ✅ |
-| strong | `<strong />` | ✅ |
-| heading | `<Heading />` | ✅ |
-| paragraph | `<Text />` | ✅ |
-| link | `<Link />` | ✅ |
-| blockquote | | ⛔ |
-| list | `<List />` | ✅ |
-| listItem | `<List.Item />` | ✅ |
-| inlineCode | `<Box as="code" />` | ✅ |
-| code | `<Box as="pre" />` | ✅ |
-| image | `<Image />` | ✅ |
-| thematicBreak | `<Divider />` | ✅ |
+
+| Type          | Component           | Supported |
+| :------------ | :------------------ | :-------- |
+| text          | `{value}`           | ✅        |
+| emphasis      | `<em />`            | ✅        |
+| strong        | `<strong />`        | ✅        |
+| heading       | `<Heading />`       | ✅        |
+| paragraph     | `<Text />`          | ✅        |
+| link          | `<Link />`          | ✅        |
+| blockquote    |                     | ⛔        |
+| list          | `<List />`          | ✅        |
+| listItem      | `<List.Item />`     | ✅        |
+| inlineCode    | `<Box as="code" />` | ✅        |
+| code          | `<Box as="pre" />`  | ✅        |
+| image         | `<Image />`         | ✅        |
+| thematicBreak | `<Divider />`       | ✅        |
 
 ```tsx live
 <MarkdownContent
@@ -38,7 +39,7 @@ See the following example that transform the following directive into a `Button`
 
 ```tsx live
 <MarkdownContent
-  content={`:button[This is a button]{href=https://atomlearning.co.uk theme="secondary" isRounded=true appearance=outline}`}
+  content={`:button[This is a button]{href=https://atomlearning.co.uk isRounded=true}`}
   handleDirectives={(node, handleNode) =>
     node.name === 'button' ? (
       <Button {...node.attributes}>{node.children.map(handleNode)}</Button>

--- a/src/components/markdown-content/MarkdownContent.tsx
+++ b/src/components/markdown-content/MarkdownContent.tsx
@@ -3,7 +3,7 @@ import fromMarkdown from 'mdast-util-from-markdown'
 import syntax from 'micromark-extension-directive'
 import * as React from 'react'
 
-import { styled } from '~/stitches'
+import { CSS, styled } from '~/stitches'
 
 import { Box } from '../box/Box'
 import { Divider } from '../divider/Divider'
@@ -17,6 +17,7 @@ import { Text } from '../text/Text'
 type MarkdownContentProps = {
   content: string
   handleDirectives?: (node, handleNode) => React.ReactElement
+  css?: CSS
 }
 
 const getHeadingProps = (depth: number): HeadingProps => {
@@ -35,6 +36,9 @@ const getHeadingProps = (depth: number): HeadingProps => {
       return { size: 'xs', as: 'h6' }
   }
 }
+
+const StyledStrong = styled('strong', { fontWeight: 600 })
+const StyledEm = styled('em', { fontStyle: 'italic' })
 
 const Code = styled(Box, {
   bg: '$tonal200',
@@ -57,7 +61,8 @@ const InlineCode = styled(Box, {
 
 export const MarkdownContent: React.FC<MarkdownContentProps> = ({
   content,
-  handleDirectives = () => null
+  handleDirectives = () => null,
+  css
 }) => {
   const AST = fromMarkdown(content, {
     extensions: [syntax()],
@@ -70,7 +75,7 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({
     }
 
     if (node.type === 'emphasis') {
-      return <em>{node.children.map(handleNode)}</em>
+      return <StyledEm>{node.children.map(handleNode)}</StyledEm>
     }
 
     if (node.type === 'heading') {
@@ -121,7 +126,7 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({
     }
 
     if (node.type === 'strong') {
-      return <strong>{node.children.map(handleNode)}</strong>
+      return <StyledStrong>{node.children.map(handleNode)}</StyledStrong>
     }
 
     if (node.type === 'text') {
@@ -139,16 +144,7 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({
     return null
   }
 
-  return (
-    <StackContent
-      css={{
-        '& strong': { fontWeight: 600 },
-        '& em': { fontStyle: 'italic' }
-      }}
-    >
-      {AST.children.map(handleNode)}
-    </StackContent>
-  )
+  return <StackContent css={css}>{AST.children.map(handleNode)}</StackContent>
 }
 
 MarkdownContent.displayName = 'MarkdownContent'

--- a/src/components/markdown-content/MarkdownContent.tsx
+++ b/src/components/markdown-content/MarkdownContent.tsx
@@ -131,7 +131,7 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({
     }
 
     if (node.type === 'thematicBreak') {
-      return <Divider css={{ my: '$5', width: '100%' }} />
+      return <Divider css={{ width: '100%' }} />
     }
 
     return null

--- a/src/components/markdown-content/MarkdownContent.tsx
+++ b/src/components/markdown-content/MarkdownContent.tsx
@@ -77,7 +77,7 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({
       const { size, as } = getHeadingProps(node.depth)
 
       return (
-        <Heading as={as} size={size}>
+        <Heading as={as} size={size} css={{ color: 'inherit' }}>
           {node.children.map(handleNode)}
         </Heading>
       )
@@ -115,7 +115,9 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({
     }
 
     if (node.type === 'paragraph') {
-      return <Text>{node.children.map(handleNode)}</Text>
+      return (
+        <Text css={{ color: 'inherit' }}>{node.children.map(handleNode)}</Text>
+      )
     }
 
     if (node.type === 'strong') {

--- a/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -109,16 +109,16 @@ exports[`MarkdownContent component renders 1`] = `
   display: table;
 }
 
-.sxhyvnz-gfp0x {
+.sxhyvnz-8ckmw {
   max-width: 65ch;
 }
 
-.sxhyvnz-gfp0x:not(:first-child) {
-  margin-top: var(--sx-space-4);
+.sxhyvnz-8ckmw:not(:first-child) {
+  margin-top: var(--sx-space-5);
 }
 
-.sxhyvnz-gfp0x:not(:last-child) {
-  margin-bottom: var(--sx-space-4);
+.sxhyvnz-8ckmw:not(:last-child) {
+  margin-bottom: var(--sx-space-5);
 }
 
 .sxkoa5n {
@@ -164,12 +164,12 @@ exports[`MarkdownContent component renders 1`] = `
   display: table;
 }
 
-.sxgpjqn-z6xef {
+.sxgpjqn-6e2be {
   max-width: 75ch;
 }
 
-.sxgpjqn-z6xef:not(:last-child) {
-  margin-bottom: var(--sx-space-4);
+.sxgpjqn-6e2be:not(:last-child) {
+  margin-bottom: var(--sx-space-5);
 }
 
 .sxfcjnm {
@@ -218,16 +218,16 @@ exports[`MarkdownContent component renders 1`] = `
   font-weight: bold;
 }
 
-.sxfcjnm-zivs9 {
+.sxfcjnm-r8wfs {
   max-width: 75ch;
 }
 
-.sxfcjnm-zivs9:not(:last-child) {
-  margin-bottom: var(--sx-space-4);
+.sxfcjnm-r8wfs:not(:last-child) {
+  margin-bottom: var(--sx-space-5);
 }
 
-.sxfcjnm-zivs9 p:before,
-.sxfcjnm-zivs9 p:after {
+.sxfcjnm-r8wfs p:before,
+.sxfcjnm-r8wfs p:after {
   display: none;
 }
 
@@ -325,7 +325,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Headings
     </h2>
@@ -333,32 +333,32 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h1
-      class="sxhyvnz sxhyvnzidto3--size-xl sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzidto3--size-xl sxhyvnz-8ckmw"
     >
       h1 Heading
     </h1>
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       h2 Heading
     </h2>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
     >
       h3 Heading
     </h3>
     <h4
-      class="sxhyvnz sxhyvnzlijcm--size-sm sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzlijcm--size-sm sxhyvnz-8ckmw"
     >
       h4 Heading
     </h4>
     <h5
-      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-8ckmw"
     >
       h5 Heading
     </h5>
     <h6
-      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-8ckmw"
     >
       h6 Heading
     </h6>
@@ -366,7 +366,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Emphasis
     </h2>
@@ -374,28 +374,28 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <strong>
         This is bold text
       </strong>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <strong>
         This is bold text
       </strong>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <em>
         This is italic text
       </em>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <em>
         This is italic text
@@ -405,7 +405,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Blockquotes
     </h2>
@@ -416,7 +416,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Lists
     </h2>
@@ -424,12 +424,12 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
     >
       Unordered
     </h3>
     <ul
-      class="sxfcjnm sxfcjnmq7qe9--size-md sxfcjnm4kvou--as-ul sxfcjnm-zivs9"
+      class="sxfcjnm sxfcjnmq7qe9--size-md sxfcjnm4kvou--as-ul sxfcjnm-r8wfs"
     >
       <li
         class="sx03kze"
@@ -529,12 +529,12 @@ exports[`MarkdownContent component renders 1`] = `
       </li>
     </ul>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
     >
       Ordered
     </h3>
     <ol
-      class="sxfcjnm sxfcjnmq7qe9--size-md sxfcjnm0fmz6--as-ol sxfcjnm-zivs9"
+      class="sxfcjnm sxfcjnmq7qe9--size-md sxfcjnm0fmz6--as-ol sxfcjnm-r8wfs"
     >
       <li
         class="sx03kze"
@@ -591,7 +591,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Code
     </h2>
@@ -599,12 +599,12 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
     >
       Inline code
     </h3>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       This is inline 
       <code
@@ -614,7 +614,7 @@ exports[`MarkdownContent component renders 1`] = `
       </code>
     </p>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
     >
       Indented code
     </h3>
@@ -627,7 +627,7 @@ line 2 of code
 line 3 of code
     </pre>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
     >
       Block code "fences"
     </h3>
@@ -640,7 +640,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Links
     </h2>
@@ -648,7 +648,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <a
         class="sx18gt8 sx18gt8ryo8u--size-md"
@@ -658,7 +658,7 @@ line 3 of code
       </a>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <a
         class="sx18gt8 sx18gt8ryo8u--size-md"
@@ -672,7 +672,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-gfp0x"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
     >
       Images
     </h2>
@@ -680,7 +680,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-z6xef"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
     >
       <img
         alt="Minion"

--- a/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -109,16 +109,20 @@ exports[`MarkdownContent component renders 1`] = `
   display: table;
 }
 
-.sxhyvnz-8ckmw {
+.sxhyvnz-y9wmg {
   max-width: 65ch;
 }
 
-.sxhyvnz-8ckmw:not(:first-child) {
+.sxhyvnz-y9wmg:not(:first-child) {
   margin-top: var(--sx-space-5);
 }
 
-.sxhyvnz-8ckmw:not(:last-child) {
+.sxhyvnz-y9wmg:not(:last-child) {
   margin-bottom: var(--sx-space-5);
+}
+
+.sxhyvnz-y9wmg {
+  color: inherit;
 }
 
 .sxkoa5n {
@@ -164,12 +168,20 @@ exports[`MarkdownContent component renders 1`] = `
   display: table;
 }
 
-.sxgpjqn-6e2be {
+.sxgpjqn-tp9pp {
   max-width: 75ch;
 }
 
-.sxgpjqn-6e2be:not(:last-child) {
+.sxgpjqn-tp9pp:not(:last-child) {
   margin-bottom: var(--sx-space-5);
+}
+
+.sxgpjqn-tp9pp {
+  color: inherit;
+}
+
+.sxgpjqn-2obmh {
+  color: inherit;
 }
 
 .sxfcjnm {
@@ -325,7 +337,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Headings
     </h2>
@@ -333,32 +345,32 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h1
-      class="sxhyvnz sxhyvnzidto3--size-xl sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzidto3--size-xl sxhyvnz-y9wmg"
     >
       h1 Heading
     </h1>
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       h2 Heading
     </h2>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-y9wmg"
     >
       h3 Heading
     </h3>
     <h4
-      class="sxhyvnz sxhyvnzlijcm--size-sm sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzlijcm--size-sm sxhyvnz-y9wmg"
     >
       h4 Heading
     </h4>
     <h5
-      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-y9wmg"
     >
       h5 Heading
     </h5>
     <h6
-      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzjrsjl--size-xs sxhyvnz-y9wmg"
     >
       h6 Heading
     </h6>
@@ -366,7 +378,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Emphasis
     </h2>
@@ -374,28 +386,28 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <strong>
         This is bold text
       </strong>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <strong>
         This is bold text
       </strong>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <em>
         This is italic text
       </em>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <em>
         This is italic text
@@ -405,7 +417,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Blockquotes
     </h2>
@@ -416,7 +428,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Lists
     </h2>
@@ -424,7 +436,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-y9wmg"
     >
       Unordered
     </h3>
@@ -435,7 +447,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           Create a list by starting a line with 
           <code
@@ -461,7 +473,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           Sub-lists are made by indenting 2 spaces:
         </p>
@@ -472,7 +484,7 @@ exports[`MarkdownContent component renders 1`] = `
             class="sx03kze"
           >
             <p
-              class="sxgpjqn sxgpjqnryo8u--size-md"
+              class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
             >
               Marker character change forces new list start:
             </p>
@@ -483,7 +495,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxgpjqn sxgpjqnryo8u--size-md"
+                  class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
                 >
                   Ac tristique libero volutpat at
                 </p>
@@ -496,7 +508,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxgpjqn sxgpjqnryo8u--size-md"
+                  class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
                 >
                   Facilisis in pretium nisl aliquet
                 </p>
@@ -509,7 +521,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxgpjqn sxgpjqnryo8u--size-md"
+                  class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
                 >
                   Nulla volutpat aliquam velit
                 </p>
@@ -522,14 +534,14 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           Very easy!
         </p>
       </li>
     </ul>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-y9wmg"
     >
       Ordered
     </h3>
@@ -540,7 +552,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           Lorem ipsum dolor sit amet
         </p>
@@ -549,7 +561,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           Consectetur adipiscing elit
         </p>
@@ -558,7 +570,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           Integer molestie lorem at massa
         </p>
@@ -567,7 +579,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           You can use sequential numbers...
         </p>
@@ -576,7 +588,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxgpjqn sxgpjqnryo8u--size-md"
+          class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-2obmh"
         >
           ...or keep all the numbers as 
           <code
@@ -591,7 +603,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Code
     </h2>
@@ -599,12 +611,12 @@ exports[`MarkdownContent component renders 1`] = `
       class="sx95fm0 sx95fm0-528w3"
     />
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-y9wmg"
     >
       Inline code
     </h3>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       This is inline 
       <code
@@ -614,7 +626,7 @@ exports[`MarkdownContent component renders 1`] = `
       </code>
     </p>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-y9wmg"
     >
       Indented code
     </h3>
@@ -627,7 +639,7 @@ line 2 of code
 line 3 of code
     </pre>
     <h3
-      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzq3glm--size-md sxhyvnz-y9wmg"
     >
       Block code "fences"
     </h3>
@@ -640,7 +652,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Links
     </h2>
@@ -648,7 +660,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <a
         class="sx18gt8 sx18gt8ryo8u--size-md"
@@ -658,7 +670,7 @@ line 3 of code
       </a>
     </p>
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <a
         class="sx18gt8 sx18gt8ryo8u--size-md"
@@ -672,7 +684,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <h2
-      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-8ckmw"
+      class="sxhyvnz sxhyvnzzf4dg--size-lg sxhyvnz-y9wmg"
     >
       Images
     </h2>
@@ -680,7 +692,7 @@ line 3 of code
       class="sx95fm0 sx95fm0-528w3"
     />
     <p
-      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-6e2be"
+      class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
       <img
         alt="Minion"

--- a/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -301,11 +301,11 @@ exports[`MarkdownContent component renders 1`] = `
   display: table;
 }
 
-.sx03kze-pwzbu strong {
+.sx4d3ki {
   font-weight: 600;
 }
 
-.sx03kze-pwzbu em {
+.sxiwbex {
   font-style: italic;
 }
 
@@ -331,7 +331,7 @@ exports[`MarkdownContent component renders 1`] = `
 
 <div>
   <div
-    class="sx03kze sx03kze-pwzbu"
+    class="sx03kze"
   >
     <hr
       class="sx95fm0 sx95fm0-528w3"
@@ -388,28 +388,36 @@ exports[`MarkdownContent component renders 1`] = `
     <p
       class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
-      <strong>
+      <strong
+        class="sx4d3ki"
+      >
         This is bold text
       </strong>
     </p>
     <p
       class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
-      <strong>
+      <strong
+        class="sx4d3ki"
+      >
         This is bold text
       </strong>
     </p>
     <p
       class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
-      <em>
+      <em
+        class="sxiwbex"
+      >
         This is italic text
       </em>
     </p>
     <p
       class="sxgpjqn sxgpjqnryo8u--size-md sxgpjqn-tp9pp"
     >
-      <em>
+      <em
+        class="sxiwbex"
+      >
         This is italic text
       </em>
     </p>

--- a/src/components/stack-content/StackContent.tsx
+++ b/src/components/stack-content/StackContent.tsx
@@ -39,16 +39,15 @@ export const StackContent: React.FC<StackContentProps> = ({
       if (type === Heading) {
         return cloneWithStyle(child, {
           maxWidth: '65ch',
-          '&:not(:first-child)': { mt: '$4' },
-          '&:not(:last-child)': { mb: '$4' }
+          '&:not(:first-child)': { mt: '$5' },
+          '&:not(:last-child)': { mb: '$5' }
         })
       }
 
       if (type === Text || type === List) {
-        console.log({ type })
         return cloneWithStyle(child, {
           maxWidth: '75ch',
-          '&:not(:last-child)': { mb: '$4' }
+          '&:not(:last-child)': { mb: '$5' }
         })
       }
 
@@ -61,8 +60,8 @@ export const StackContent: React.FC<StackContentProps> = ({
       if (type === Image) {
         return cloneWithStyle(child, {
           display: 'block',
-          '&:not(:first-child)': { mt: '$5' },
-          '&:not(:last-child)': { mb: '$5' }
+          '&:not(:first-child)': { mt: '$6' },
+          '&:not(:last-child)': { mb: '$6' }
         })
       }
 


### PR DESCRIPTION
## Fixes
- [x] Restored the original spacing between items in `StackContent`. The `$size` variables have different values since v1, but `StackContent` wasn't updated to reflect that yet.
- [x] Fixed a table that wasn't rendering in the documentation.
- [x] Removed the `theme=secondary` attribute from the `Button` example in the documentation, as there is no secondary theme anymore since v1
- [x] Made the `paragraph` and `heading` elements in `MarkdownContent` inherit their color from their ancestors. 