### PR TITLE
Fix: Inline field wrapper alignment

### DIFF
--- a/src/components/checkbox-field/CheckboxField.tsx
+++ b/src/components/checkbox-field/CheckboxField.tsx
@@ -28,14 +28,14 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   const error = errors[name]?.message
 
   return (
-    <InlineFieldWrapper label={label} css={css} error={error}>
-      <Controller
-        onChange={() => setIsChecked((current) => !current)}
-        control={control}
-        name={name}
-        defaultValue={isChecked}
-        rules={{ required: true }}
-        render={({ onChange, value, name: innerName }) => (
+    <Controller
+      onChange={() => setIsChecked((current) => !current)}
+      control={control}
+      name={name}
+      defaultValue={isChecked}
+      rules={{ required: true }}
+      render={({ onChange, value, name: innerName }) => (
+        <InlineFieldWrapper label={label} css={css} error={error}>
           <Checkbox
             name={innerName}
             onCheckedChange={() => {
@@ -47,9 +47,9 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
             value={value}
             {...remainingProps}
           />
-        )}
-      />
-    </InlineFieldWrapper>
+        </InlineFieldWrapper>
+      )}
+    />
   )
 }
 

--- a/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
@@ -74,12 +74,18 @@ exports[`CheckboxField component renders 1`] = `
   display: table;
 }
 
-.sxh0wga-yi5wz {
-  align-items: baseline;
+.sx9ru2a {
   display: flex;
-  flex-direction: row;
   font-weight: 400;
   max-width: max-content;
+}
+
+.sx9ru2a0fgel--align-baseline {
+  align-items: baseline;
+}
+
+.sx9ru2aged5d--direction-row {
+  flex-direction: row;
 }
 
 <div>
@@ -91,7 +97,7 @@ exports[`CheckboxField component renders 1`] = `
       class="sx03kze"
     >
       <label
-        class="sxh0wga sxh0wgaryo8u--size-md sxh0wga-yi5wz"
+        class="sxh0wga sxh0wgaryo8u--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
       >
         <div
           class="sx03kze sx03kze-2grog"

--- a/src/components/field-wrapper/FieldWrapper.mdx
+++ b/src/components/field-wrapper/FieldWrapper.mdx
@@ -7,16 +7,24 @@ category: Forms
 
 `FieldWrapper` renders a `Label` and (when applicable) a `ValidationError`. Use it to wrap any type of input to create a consistent set of form fields.
 
-`InlineFieldWrapper` does the same but renders the label inline with the input, for example:`Checkbox`es and `Radio`s.
-
 ```tsx preview
 <FieldWrapper label="Example Field" fieldId="example">
   <Input name="example" id="example" />
 </FieldWrapper>
 ```
 
+`InlineFieldWrapper` does the same but renders the label inline with the input, for example:`Checkbox`es and `Radio`s.
+
 ```tsx preview
 <InlineFieldWrapper label="Example Checkbox">
   <Checkbox name="example2" id="example2" />
+</InlineFieldWrapper>
+```
+
+It can also be used alongside components like `Input`, `Select` or `Switch` when you may require some condensed inline fields.
+
+```tsx preview
+<InlineFieldWrapper direction="reverse" align="center" label="Toggle a field">
+  <Switch />
 </InlineFieldWrapper>
 ```

--- a/src/components/field-wrapper/FieldWrapper.mdx
+++ b/src/components/field-wrapper/FieldWrapper.mdx
@@ -21,7 +21,7 @@ category: Forms
 </InlineFieldWrapper>
 ```
 
-It can also be used alongside components like `Input`, `Select` or `Switch` when you may require some condensed inline fields.
+It can also be used alongside components like `Input`, `Select` or `Switch` when you may require some condensed inline fields. You can use the `direction` and `align` props to handle how the label is positioned relative to the component, in this case the label is placed on the right with `direction="reverse"` and it's aligned centrally with the switch.
 
 ```tsx preview
 <InlineFieldWrapper direction="reverse" align="center" label="Toggle a field">

--- a/src/components/field-wrapper/InlineFieldWrapper.tsx
+++ b/src/components/field-wrapper/InlineFieldWrapper.tsx
@@ -3,14 +3,34 @@ import * as React from 'react'
 import { Box } from '~/components/box'
 import { Label } from '~/components/label'
 import { ValidationError } from '~/components/validation-error'
-import { CSS } from '~/stitches'
+import { CSS, styled } from '~/stitches'
+
+import { Checkbox } from '../checkbox/Checkbox'
+import { RadioButton } from '../radio/RadioButton'
+
+const InlineLabel = styled(Label, {
+  display: 'flex',
+  fontWeight: 400,
+  maxWidth: 'max-content',
+  variants: {
+    align: {
+      baseline: { alignItems: 'baseline' },
+      center: { alignItems: 'center' }
+    },
+    direction: {
+      reverse: { flexDirection: 'row-reverse' },
+      row: { flexDirection: 'row' }
+    }
+  }
+})
 
 type InlineFieldWrapperProps = {
   css?: CSS
   error?: string
   label: string
   required?: boolean
-  reverse?: boolean
+  align?: 'baseline' | 'center'
+  direction?: 'row' | 'reverse'
 }
 
 export const InlineFieldWrapper: React.FC<InlineFieldWrapperProps> = ({
@@ -19,29 +39,26 @@ export const InlineFieldWrapper: React.FC<InlineFieldWrapperProps> = ({
   css,
   label,
   required,
-  reverse
+  direction = 'row',
+  align = 'baseline'
 }) => (
   <Box css={css}>
-    <Label
-      css={{
-        alignItems: 'baseline',
-        display: 'flex',
-        flexDirection: reverse ? 'row-reverse' : 'row',
-        fontWeight: 400,
-        maxWidth: 'max-content'
-      }}
-      required={required}
-    >
-      <Box
-        css={{
-          [reverse ? 'ml' : 'mr']: '$3',
-          transform: 'translateY($space$0)'
-        }}
-      >
-        {children}
-      </Box>
+    <InlineLabel direction={direction} align={align} required={required}>
+      {React.Children.map(children, (child: any) => (
+        <Box
+          css={{
+            [direction === 'reverse' ? 'ml' : 'mr']: '$3',
+            // provide offset for specific child components
+            ...((child?.type === Checkbox || child?.type === RadioButton) && {
+              transform: 'translateY($space$0)'
+            })
+          }}
+        >
+          {child}
+        </Box>
+      ))}
       {label}
-    </Label>
+    </InlineLabel>
     {error && <ValidationError css={{ mt: '$2' }}>{error}</ValidationError>}
   </Box>
 )

--- a/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
@@ -36,14 +36,6 @@ exports[`RadioField component renders 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sxh0wga-yi5wz {
-  align-items: baseline;
-  display: flex;
-  flex-direction: row;
-  font-weight: 400;
-  max-width: max-content;
-}
-
 .sx7siaz {
   align-items: center;
   -webkit-appearance: none;
@@ -87,6 +79,20 @@ exports[`RadioField component renders 1`] = `
   position: absolute;
 }
 
+.sx9ru2a {
+  display: flex;
+  font-weight: 400;
+  max-width: max-content;
+}
+
+.sx9ru2a0fgel--align-baseline {
+  align-items: baseline;
+}
+
+.sx9ru2aged5d--direction-row {
+  flex-direction: row;
+}
+
 .sxykmo8 {
   display: flex;
   flex-wrap: wrap;
@@ -121,7 +127,7 @@ exports[`RadioField component renders 1`] = `
           class="sx03kze"
         >
           <label
-            class="sxh0wga sxh0wgaryo8u--size-md sxh0wga-yi5wz"
+            class="sxh0wga sxh0wgaryo8u--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
           >
             <div
               class="sx03kze sx03kze-2grog"
@@ -155,7 +161,7 @@ exports[`RadioField component renders 1`] = `
           class="sx03kze"
         >
           <label
-            class="sxh0wga sxh0wgaryo8u--size-md sxh0wga-yi5wz"
+            class="sxh0wga sxh0wgaryo8u--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
           >
             <div
               class="sx03kze sx03kze-2grog"

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -14,7 +14,7 @@ const StyledSwitch = styled(RadixSwitch.Root, {
   p: '$0',
   position: 'relative',
   transition: 'background-color 100ms ease',
-  width: '$5',
+  width: '$4',
   '&:hover': {
     backgroundColor: '$tonal400'
   },
@@ -28,7 +28,7 @@ const StyledSwitch = styled(RadixSwitch.Root, {
 
 const StyledThumb = styled(RadixSwitch.Thumb, {
   display: 'block',
-  size: '$2',
+  size: '$1',
   backgroundColor: 'white',
   borderRadius: '$round',
   transition: 'transform 100ms',

--- a/src/components/switch/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/switch/__snapshots__/Switch.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch component renders a Switch in "on" state 1`] = `
-.sxolizv {
+.sx1jh2a {
   -webkit-appearance: none;
   appearance: none;
   background-color: var(--sx-colors-tonal300);
@@ -13,32 +13,32 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
   padding: var(--sx-space-0);
   position: relative;
   transition: background-color 100ms ease;
-  width: var(--sx-sizes-5);
+  width: var(--sx-sizes-4);
 }
 
-.sxolizv:hover {
+.sx1jh2a:hover {
   background-color: var(--sx-colors-tonal400);
 }
 
-.sxolizv[data-state="checked"] {
+.sx1jh2a[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sxolizv[data-state="checked"]:hover {
+.sx1jh2a[data-state="checked"]:hover {
   background-color: var(--sx-colors-tertiary);
 }
 
-.sx2r6fb {
+.sxxf22o {
   display: block;
-  height: var(--sx-sizes-2);
-  width: var(--sx-sizes-2);
+  height: var(--sx-sizes-1);
+  width: var(--sx-sizes-1);
   background-color: white;
   border-radius: var(--sx-radii-round);
   transition: transform 100ms;
   will-change: transform;
 }
 
-.sx2r6fb[data-state="checked"] {
+.sxxf22o[data-state="checked"] {
   transform: translateX(calc(var(--sx-sizes-2) - var(--sx-space-1)));
 }
 
@@ -51,14 +51,14 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
   />
   <button
     aria-checked="true"
-    class="sxolizv"
+    class="sx1jh2a"
     data-state="checked"
     role="switch"
     type="button"
     value="on"
   >
     <span
-      class="sx2r6fb"
+      class="sxxf22o"
       data-state="checked"
     />
   </button>
@@ -66,7 +66,7 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
 `;
 
 exports[`Switch component renders a disabled switch 1`] = `
-.sxolizv {
+.sx1jh2a {
   -webkit-appearance: none;
   appearance: none;
   background-color: var(--sx-colors-tonal300);
@@ -78,32 +78,32 @@ exports[`Switch component renders a disabled switch 1`] = `
   padding: var(--sx-space-0);
   position: relative;
   transition: background-color 100ms ease;
-  width: var(--sx-sizes-5);
+  width: var(--sx-sizes-4);
 }
 
-.sxolizv:hover {
+.sx1jh2a:hover {
   background-color: var(--sx-colors-tonal400);
 }
 
-.sxolizv[data-state="checked"] {
+.sx1jh2a[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sxolizv[data-state="checked"]:hover {
+.sx1jh2a[data-state="checked"]:hover {
   background-color: var(--sx-colors-tertiary);
 }
 
-.sx2r6fb {
+.sxxf22o {
   display: block;
-  height: var(--sx-sizes-2);
-  width: var(--sx-sizes-2);
+  height: var(--sx-sizes-1);
+  width: var(--sx-sizes-1);
   background-color: white;
   border-radius: var(--sx-radii-round);
   transition: transform 100ms;
   will-change: transform;
 }
 
-.sx2r6fb[data-state="checked"] {
+.sxxf22o[data-state="checked"] {
   transform: translateX(calc(var(--sx-sizes-2) - var(--sx-space-1)));
 }
 
@@ -116,7 +116,7 @@ exports[`Switch component renders a disabled switch 1`] = `
   />
   <button
     aria-checked="false"
-    class="sxolizv"
+    class="sx1jh2a"
     data-disabled=""
     data-state="unchecked"
     disabled=""
@@ -125,7 +125,7 @@ exports[`Switch component renders a disabled switch 1`] = `
     value="on"
   >
     <span
-      class="sx2r6fb"
+      class="sxxf22o"
       data-disabled=""
       data-state="unchecked"
     />
@@ -134,7 +134,7 @@ exports[`Switch component renders a disabled switch 1`] = `
 `;
 
 exports[`Switch component renders a switch 1`] = `
-.sxolizv {
+.sx1jh2a {
   -webkit-appearance: none;
   appearance: none;
   background-color: var(--sx-colors-tonal300);
@@ -146,32 +146,32 @@ exports[`Switch component renders a switch 1`] = `
   padding: var(--sx-space-0);
   position: relative;
   transition: background-color 100ms ease;
-  width: var(--sx-sizes-5);
+  width: var(--sx-sizes-4);
 }
 
-.sxolizv:hover {
+.sx1jh2a:hover {
   background-color: var(--sx-colors-tonal400);
 }
 
-.sxolizv[data-state="checked"] {
+.sx1jh2a[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sxolizv[data-state="checked"]:hover {
+.sx1jh2a[data-state="checked"]:hover {
   background-color: var(--sx-colors-tertiary);
 }
 
-.sx2r6fb {
+.sxxf22o {
   display: block;
-  height: var(--sx-sizes-2);
-  width: var(--sx-sizes-2);
+  height: var(--sx-sizes-1);
+  width: var(--sx-sizes-1);
   background-color: white;
   border-radius: var(--sx-radii-round);
   transition: transform 100ms;
   will-change: transform;
 }
 
-.sx2r6fb[data-state="checked"] {
+.sxxf22o[data-state="checked"] {
   transform: translateX(calc(var(--sx-sizes-2) - var(--sx-space-1)));
 }
 
@@ -183,14 +183,14 @@ exports[`Switch component renders a switch 1`] = `
   />
   <button
     aria-checked="false"
-    class="sxolizv"
+    class="sx1jh2a"
     data-state="unchecked"
     role="switch"
     type="button"
     value="on"
   >
     <span
-      class="sx2r6fb"
+      class="sxxf22o"
       data-state="unchecked"
     />
   </button>


### PR DESCRIPTION
`Switch` and `Input`/`Select` children within `InlineFieldWrapper` were throwing off the alignment, I updated `Switch` to the new design and tweaked a few layout props to allow more flexibility with alignment.

![Screenshot 2021-07-15 at 19 13 50](https://user-images.githubusercontent.com/3226804/125837677-9bc320fa-e7a8-4ac9-8076-beac0df33a5e.png)
