### PR TITLE
Feat: table styling updates

### DIFF
--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -5,10 +5,10 @@ description: The Table component displays a collection of data grouped into rows
 category: Layout
 ---
 
-The `Table` component structure mirrors that of a regular HTML table, with the smaller `Table.Body`, `Table.Cell`, `Table.Footer`, `Table.Header`, `Table.HeaderCell` and `Table Row` components corresponding to the `<tbody>`, `<td>`, `<tfoot>`, `<thead>`, `<th>` and `<tr>` tags, respectively. 
+The `Table` component structure mirrors that of a regular HTML table, with the smaller `Table.Body`, `Table.Cell`, `Table.Footer`, `Table.Header`, `Table.HeaderCell` and `Table Row` components corresponding to the `<tbody>`, `<td>`, `<tfoot>`, `<thead>`, `<th>` and `<tr>` tags, respectively.
 
 ```jsx preview
-<Table css={{ width: '500px', mb: '100px'}}>
+<Table css={{ width: '500px', mb: '100px' }}>
   <Table.Header>
     <Table.Row>
       <Table.HeaderCell>First Name</Table.HeaderCell>
@@ -64,27 +64,91 @@ Best practice: Due to rendering issues with some browsers, adding borders to `Ta
   </Table.Header>
   <Table.Body>
     <Table.Row>
-      <Table.Cell css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}>Rakim</Table.Cell>
-      <Table.Cell css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}>Jackson</Table.Cell>
-      <Table.Cell css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}>35</Table.Cell>
+      <Table.Cell
+        css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}
+      >
+        Rakim
+      </Table.Cell>
+      <Table.Cell
+        css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}
+      >
+        Jackson
+      </Table.Cell>
+      <Table.Cell
+        css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}
+      >
+        35
+      </Table.Cell>
     </Table.Row>
     <Table.Row>
-      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>Evelyn</Table.Cell>
-      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>Smith</Table.Cell>
-      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>27</Table.Cell>
+      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>
+        Evelyn
+      </Table.Cell>
+      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>
+        Smith
+      </Table.Cell>
+      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>
+        27
+      </Table.Cell>
     </Table.Row>
     <Table.Row>
-      <Table.Cell css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish'}}>Miguel</Table.Cell>
-      <Table.Cell css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish'}}>Fernandez</Table.Cell>
-      <Table.Cell css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish'}}>52</Table.Cell>
+      <Table.Cell
+        css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish' }}
+      >
+        Miguel
+      </Table.Cell>
+      <Table.Cell
+        css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish' }}
+      >
+        Fernandez
+      </Table.Cell>
+      <Table.Cell
+        css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish' }}
+      >
+        52
+      </Table.Cell>
     </Table.Row>
   </Table.Body>
   <Table.Footer>
-      <Table.Row>
-        <Table.FooterCell css={{ fontStyle: 'italic', color:'$subjectEnglish' }}>Footer 1</Table.FooterCell>
-        <Table.FooterCell css={{ fontStyle: 'italic', color:'$subjectEnglish' }}>Footer 2</Table.FooterCell>
-        <Table.FooterCell css={{ fontStyle: 'italic', color:'$subjectEnglish' }}>Footer 3</Table.FooterCell>
-      </Table.Row>
+    <Table.Row>
+      <Table.FooterCell css={{ fontStyle: 'italic', color: '$subjectEnglish' }}>
+        Footer 1
+      </Table.FooterCell>
+      <Table.FooterCell css={{ fontStyle: 'italic', color: '$subjectEnglish' }}>
+        Footer 2
+      </Table.FooterCell>
+      <Table.FooterCell css={{ fontStyle: 'italic', color: '$subjectEnglish' }}>
+        Footer 3
+      </Table.FooterCell>
+    </Table.Row>
   </Table.Footer>
+</Table>
+```
+
+## Variants
+
+The `Table` component has 2 size variants that control the row height. The to available sizes are `md`(default) and `lg` which should be used when the table needs to show more than just text, ie: `Button(s)` and `ActionIcon(s)`. The increased height helps keep the elements clickable on smaller screensizes.
+
+```jsx preview
+<Table size="lg" css={{ width: '500px', mt: '100px', ml: '100px' }}>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>First Name</Table.HeaderCell>
+      <Table.HeaderCell>Last Name</Table.HeaderCell>
+      <Table.HeaderCell>Age</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>Rakim</Table.Cell>
+      <Table.Cell>Jackson</Table.Cell>
+      <Table.Cell>35</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>Evelyn</Table.Cell>
+      <Table.Cell>Smith</Table.Cell>
+      <Table.Cell>27</Table.Cell>
+    </Table.Row>
+  </Table.Body>
 </Table>
 ```

--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -64,49 +64,19 @@ Best practice: Due to rendering issues with some browsers, adding borders to `Ta
   </Table.Header>
   <Table.Body>
     <Table.Row>
-      <Table.Cell
-        css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}
-      >
-        Rakim
-      </Table.Cell>
-      <Table.Cell
-        css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}
-      >
-        Jackson
-      </Table.Cell>
-      <Table.Cell
-        css={{ bg: '$tonal100', borderBottom: '1px solid $subjectEnglish' }}
-      >
-        35
-      </Table.Cell>
+      <Table.Cell>Rakim</Table.Cell>
+      <Table.Cell>Jackson</Table.Cell>
+      <Table.Cell>35</Table.Cell>
     </Table.Row>
     <Table.Row>
-      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>
-        Evelyn
-      </Table.Cell>
-      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>
-        Smith
-      </Table.Cell>
-      <Table.Cell css={{ borderBottom: '1px solid $subjectEnglish' }}>
-        27
-      </Table.Cell>
+      <Table.Cell>Evelyn</Table.Cell>
+      <Table.Cell>Smith</Table.Cell>
+      <Table.Cell>27</Table.Cell>
     </Table.Row>
     <Table.Row>
-      <Table.Cell
-        css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish' }}
-      >
-        Miguel
-      </Table.Cell>
-      <Table.Cell
-        css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish' }}
-      >
-        Fernandez
-      </Table.Cell>
-      <Table.Cell
-        css={{ bg: '$tonal100', borderBottom: '3px solid $subjectEnglish' }}
-      >
-        52
-      </Table.Cell>
+      <Table.Cell>Miguel</Table.Cell>
+      <Table.Cell>Fernandez</Table.Cell>
+      <Table.Cell>52</Table.Cell>
     </Table.Row>
   </Table.Body>
   <Table.Footer>

--- a/src/components/table/Table.test.tsx
+++ b/src/components/table/Table.test.tsx
@@ -28,7 +28,7 @@ describe(`Table component`, () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('renders with size set to log', async () => {
+  it('renders with size set to lg', async () => {
     const { container } = await render(
       <Table
         size="lg"

--- a/src/components/table/Table.test.tsx
+++ b/src/components/table/Table.test.tsx
@@ -28,6 +28,32 @@ describe(`Table component`, () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders with size set to log', async () => {
+    const { container } = await render(
+      <Table
+        size="lg"
+        css={{ height: '100px', width: '400px', color: '$primary500' }}
+      >
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Column A</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>This is text</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer>
+          <Table.Row>
+            <Table.Cell>Footer 1</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
   it('has no programmatically detectable a11y issues', async () => {
     const { container } = render(
       <Table>

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -28,12 +28,12 @@ const StyledTable = styled('table', {
     size: {
       md: {
         td: {
-          height: '48px'
+          height: '$5'
         }
       },
       lg: {
         td: {
-          height: '60px'
+          height: 'calc($5 + $0)'
         }
       }
     }

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -28,12 +28,12 @@ const StyledTable = styled('table', {
     size: {
       md: {
         [`${TableCell}`]: {
-          minHeight: '$5'
+          height: '$4'
         }
       },
       lg: {
         [`${TableCell}`]: {
-          minHeight: 'calc($5 + $0)'
+          height: '$5'
         }
       }
     }

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -23,14 +23,29 @@ type TableSubComponents = {
 const StyledTable = styled('table', {
   width: '100%',
   fontFamily: '$sans',
-  fontSize: '$sm'
+  fontSize: '$sm',
+  variants: {
+    size: {
+      md: {
+        td: {
+          height: '48px'
+        }
+      },
+      lg: {
+        td: {
+          height: '60px'
+        }
+      }
+    }
+  }
 })
 
 type TableProps = React.ComponentProps<typeof StyledTable>
 
-export const Table: React.FC<TableProps> & TableSubComponents = (
-  props: TableProps
-) => <StyledTable {...props} />
+export const Table: React.FC<TableProps> & TableSubComponents = ({
+  size = 'md',
+  ...rest
+}: TableProps) => <StyledTable size={size} {...rest} />
 
 Table.Body = TableBody
 Table.Cell = TableCell

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -28,12 +28,12 @@ const StyledTable = styled('table', {
     size: {
       md: {
         td: {
-          height: '$5'
+          minHeight: '$5'
         }
       },
       lg: {
         td: {
-          height: 'calc($5 + $0)'
+          minHeight: 'calc($5 + $0)'
         }
       }
     }

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -27,12 +27,12 @@ const StyledTable = styled('table', {
   variants: {
     size: {
       md: {
-        td: {
+        [`${TableCell}`]: {
           minHeight: '$5'
         }
       },
       lg: {
-        td: {
+        [`${TableCell}`]: {
           minHeight: 'calc($5 + $0)'
         }
       }

--- a/src/components/table/TableCell.tsx
+++ b/src/components/table/TableCell.tsx
@@ -5,7 +5,7 @@ export const TableCell = styled('td', {
   boxSizing: 'border-box',
   color: '$tonal600',
   fontFamily: '$body',
-
+  lineHeight: 1.5,
   p: '$2 $3',
   textAlign: 'left',
   verticalAlign: 'middle',

--- a/src/components/table/TableCell.tsx
+++ b/src/components/table/TableCell.tsx
@@ -2,11 +2,16 @@ import { styled } from '~/stitches'
 
 export const TableCell = styled('td', {
   borderBottom: '1px solid $tonal200',
+  boxSizing: 'border-box',
   color: '$tonal600',
-  fontFamily: '$sans',
+  fontFamily: '$body',
+
   p: '$2 $3',
   textAlign: 'left',
-  verticalAlign: 'middle'
+  verticalAlign: 'middle',
+  'tr:nth-child(even) &': {
+    bg: '$tonal50'
+  }
 })
 
 TableCell.displayName = 'TableCell'

--- a/src/components/table/TableFooterCell.tsx
+++ b/src/components/table/TableFooterCell.tsx
@@ -1,7 +1,7 @@
 import { styled } from '~/stitches'
 
 export const TableFooterCell = styled('td', {
-  color: '$secondary',
+  color: '$tonal500',
   fontFamily: '$body',
   fontWeight: 600,
   p: '$2 $3',

--- a/src/components/table/TableHeaderCell.tsx
+++ b/src/components/table/TableHeaderCell.tsx
@@ -1,13 +1,22 @@
 import { styled } from '~/stitches'
 
 export const TableHeaderCell = styled('th', {
-  bg: '$secondary',
+  bg: '$tertiary',
   color: 'white',
   fontFamily: '$body',
   fontWeight: 600,
+  lineHeight: '$fontSizes$lg',
   p: '$2 $3',
   textAlign: 'left',
-  verticalAlign: 'middle'
+  verticalAlign: 'middle',
+  '&:first-of-type': {
+    borderTopLeftRadius: '$0',
+    borderBottomLeftRadius: '$0'
+  },
+  '&:last-of-type': {
+    borderTopRightRadius: '$0',
+    borderBottomRightRadius: '$0'
+  }
 })
 
 TableHeaderCell.displayName = 'TableHeaderCell'

--- a/src/components/table/TableHeaderCell.tsx
+++ b/src/components/table/TableHeaderCell.tsx
@@ -5,7 +5,7 @@ export const TableHeaderCell = styled('th', {
   color: 'white',
   fontFamily: '$body',
   fontWeight: 600,
-  lineHeight: '$fontSizes$lg',
+  lineHeight: 1.5,
   p: '$2 $3',
   textAlign: 'left',
   verticalAlign: 'middle',

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -36,17 +36,17 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxxg7cs {
+.sxibxfj {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxxg7csy6v1p--size-md td {
-  height: var(--sx-sizes-5);
+.sxibxfjk3rdf--size-md td {
+  min-height: var(--sx-sizes-5);
 }
 
-.sxxg7cs-a5b4a {
+.sxibxfj-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -54,7 +54,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxxg7cs sxxg7csy6v1p--size-md sxxg7cs-a5b4a"
+    class="sxibxfj sxibxfjk3rdf--size-md sxibxfj-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -135,21 +135,21 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxxg7cs {
+.sxibxfj {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxxg7csy6v1p--size-md td {
-  height: var(--sx-sizes-5);
+.sxibxfjk3rdf--size-md td {
+  min-height: var(--sx-sizes-5);
 }
 
-.sxxg7csgijdn--size-lg td {
-  height: calc(var(--sx-sizes-5) + var(--sx-sizes-0));
+.sxibxfjz9c87--size-lg td {
+  min-height: calc(var(--sx-sizes-5) + var(--sx-sizes-0));
 }
 
-.sxxg7cs-a5b4a {
+.sxibxfj-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -157,7 +157,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxxg7cs sxxg7csgijdn--size-lg sxxg7cs-a5b4a"
+    class="sxibxfj sxibxfjz9c87--size-lg sxibxfj-a5b4a"
   >
     <thead
       class="sx03kze"

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -98,3 +98,106 @@ tr:nth-child(even) .sxj317c {
   </table>
 </div>
 `;
+
+exports[`Table component renders with size set to log 1`] = `
+.sxj317c {
+  border-bottom: 1px solid var(--sx-colors-tonal200);
+  box-sizing: border-box;
+  color: var(--sx-colors-tonal600);
+  font-family: var(--sx-fonts-body);
+  padding: var(--sx-space-2) var(--sx-space-3);
+  text-align: left;
+  vertical-align: middle;
+}
+
+tr:nth-child(even) .sxj317c {
+  background: var(--sx-colors-tonal50);
+}
+
+.sxyrxor {
+  background: var(--sx-colors-tertiary);
+  color: white;
+  font-family: var(--sx-fonts-body);
+  font-weight: 600;
+  line-height: var(--sx-fontSizes-lg);
+  padding: var(--sx-space-2) var(--sx-space-3);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.sxyrxor:first-of-type {
+  border-top-left-radius: var(--sx-radii-0);
+  border-bottom-left-radius: var(--sx-radii-0);
+}
+
+.sxyrxor:last-of-type {
+  border-top-right-radius: var(--sx-radii-0);
+  border-bottom-right-radius: var(--sx-radii-0);
+}
+
+.sxh18y1 {
+  width: 100%;
+  font-family: var(--sx-fonts-sans);
+  font-size: var(--sx-fontSizes-sm);
+}
+
+.sxh18y1q6419--size-md td {
+  height: 48px;
+}
+
+.sxh18y100mth--size-lg td {
+  height: 60px;
+}
+
+.sxh18y1-a5b4a {
+  height: 100px;
+  width: 400px;
+  color: var(--sx-colors-primary500);
+}
+
+<div>
+  <table
+    class="sxh18y1 sxh18y100mth--size-lg sxh18y1-a5b4a"
+  >
+    <thead
+      class="sx03kze"
+    >
+      <tr
+        class="sx03kze"
+      >
+        <th
+          class="sxyrxor"
+        >
+          Column A
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="sx03kze"
+    >
+      <tr
+        class="sx03kze"
+      >
+        <td
+          class="sxj317c"
+        >
+          This is text
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class="sx03kze"
+    >
+      <tr
+        class="sx03kze"
+      >
+        <td
+          class="sxj317c"
+        >
+          Footer 1
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table component renders 1`] = `
-.sxj317c {
+.sx9z3tc {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;
   color: var(--sx-colors-tonal600);
@@ -11,7 +11,7 @@ exports[`Table component renders 1`] = `
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sxj317c {
+tr:nth-child(even) .sx9z3tc {
   background: var(--sx-colors-tonal50);
 }
 
@@ -36,17 +36,17 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxibxfj {
+.sx2bbo2 {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxibxfjk3rdf--size-md td {
+.sx2bbo23yzb4--size-md .sx9z3tc {
   min-height: var(--sx-sizes-5);
 }
 
-.sxibxfj-a5b4a {
+.sx2bbo2-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -54,7 +54,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxibxfj sxibxfjk3rdf--size-md sxibxfj-a5b4a"
+    class="sx2bbo2 sx2bbo23yzb4--size-md sx2bbo2-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -76,7 +76,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sx9z3tc"
         >
           This is text
         </td>
@@ -89,7 +89,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sx9z3tc"
         >
           Footer 1
         </td>
@@ -100,7 +100,7 @@ tr:nth-child(even) .sxj317c {
 `;
 
 exports[`Table component renders with size set to log 1`] = `
-.sxj317c {
+.sx9z3tc {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;
   color: var(--sx-colors-tonal600);
@@ -110,7 +110,7 @@ exports[`Table component renders with size set to log 1`] = `
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sxj317c {
+tr:nth-child(even) .sx9z3tc {
   background: var(--sx-colors-tonal50);
 }
 
@@ -135,21 +135,21 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxibxfj {
+.sx2bbo2 {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxibxfjk3rdf--size-md td {
+.sx2bbo23yzb4--size-md .sx9z3tc {
   min-height: var(--sx-sizes-5);
 }
 
-.sxibxfjz9c87--size-lg td {
+.sx2bbo2mirow--size-lg .sx9z3tc {
   min-height: calc(var(--sx-sizes-5) + var(--sx-sizes-0));
 }
 
-.sxibxfj-a5b4a {
+.sx2bbo2-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -157,7 +157,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxibxfj sxibxfjz9c87--size-lg sxibxfj-a5b4a"
+    class="sx2bbo2 sx2bbo2mirow--size-lg sx2bbo2-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -179,7 +179,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sx9z3tc"
         >
           This is text
         </td>
@@ -192,7 +192,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sx9z3tc"
         >
           Footer 1
         </td>

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table component renders 1`] = `
-.sx9z3tc {
+.sxj317c {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;
   color: var(--sx-colors-tonal600);
@@ -11,7 +11,7 @@ exports[`Table component renders 1`] = `
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sx9z3tc {
+tr:nth-child(even) .sxj317c {
   background: var(--sx-colors-tonal50);
 }
 
@@ -36,17 +36,17 @@ tr:nth-child(even) .sx9z3tc {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sx2bbo2 {
+.sxwony4 {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sx2bbo23yzb4--size-md .sx9z3tc {
-  min-height: var(--sx-sizes-5);
+.sxwony4dku3k--size-md .sxj317c {
+  height: var(--sx-sizes-4);
 }
 
-.sx2bbo2-a5b4a {
+.sxwony4-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -54,7 +54,7 @@ tr:nth-child(even) .sx9z3tc {
 
 <div>
   <table
-    class="sx2bbo2 sx2bbo23yzb4--size-md sx2bbo2-a5b4a"
+    class="sxwony4 sxwony4dku3k--size-md sxwony4-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -76,7 +76,7 @@ tr:nth-child(even) .sx9z3tc {
         class="sx03kze"
       >
         <td
-          class="sx9z3tc"
+          class="sxj317c"
         >
           This is text
         </td>
@@ -89,7 +89,7 @@ tr:nth-child(even) .sx9z3tc {
         class="sx03kze"
       >
         <td
-          class="sx9z3tc"
+          class="sxj317c"
         >
           Footer 1
         </td>
@@ -100,7 +100,7 @@ tr:nth-child(even) .sx9z3tc {
 `;
 
 exports[`Table component renders with size set to log 1`] = `
-.sx9z3tc {
+.sxj317c {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;
   color: var(--sx-colors-tonal600);
@@ -110,7 +110,7 @@ exports[`Table component renders with size set to log 1`] = `
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sx9z3tc {
+tr:nth-child(even) .sxj317c {
   background: var(--sx-colors-tonal50);
 }
 
@@ -135,21 +135,21 @@ tr:nth-child(even) .sx9z3tc {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sx2bbo2 {
+.sxwony4 {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sx2bbo23yzb4--size-md .sx9z3tc {
-  min-height: var(--sx-sizes-5);
+.sxwony4dku3k--size-md .sxj317c {
+  height: var(--sx-sizes-4);
 }
 
-.sx2bbo2mirow--size-lg .sx9z3tc {
-  min-height: calc(var(--sx-sizes-5) + var(--sx-sizes-0));
+.sxwony4jopsk--size-lg .sxj317c {
+  height: var(--sx-sizes-5);
 }
 
-.sx2bbo2-a5b4a {
+.sxwony4-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -157,7 +157,7 @@ tr:nth-child(even) .sx9z3tc {
 
 <div>
   <table
-    class="sx2bbo2 sx2bbo2mirow--size-lg sx2bbo2-a5b4a"
+    class="sxwony4 sxwony4jopsk--size-lg sxwony4-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -179,7 +179,7 @@ tr:nth-child(even) .sx9z3tc {
         class="sx03kze"
       >
         <td
-          class="sx9z3tc"
+          class="sxj317c"
         >
           This is text
         </td>
@@ -192,7 +192,7 @@ tr:nth-child(even) .sx9z3tc {
         class="sx03kze"
       >
         <td
-          class="sx9z3tc"
+          class="sxj317c"
         >
           Footer 1
         </td>

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -100,7 +100,7 @@ tr:nth-child(even) .sxyjtjl {
 </div>
 `;
 
-exports[`Table component renders with size set to log 1`] = `
+exports[`Table component renders with size set to lg 1`] = `
 .sxyjtjl {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -15,23 +15,23 @@ tr:nth-child(even) .sxj317c {
   background: var(--sx-colors-tonal50);
 }
 
-.sxyrxor {
+.sxgmopz {
   background: var(--sx-colors-tertiary);
   color: white;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
-  line-height: var(--sx-fontSizes-lg);
+  line-height: 1.5;
   padding: var(--sx-space-2) var(--sx-space-3);
   text-align: left;
   vertical-align: middle;
 }
 
-.sxyrxor:first-of-type {
+.sxgmopz:first-of-type {
   border-top-left-radius: var(--sx-radii-0);
   border-bottom-left-radius: var(--sx-radii-0);
 }
 
-.sxyrxor:last-of-type {
+.sxgmopz:last-of-type {
   border-top-right-radius: var(--sx-radii-0);
   border-bottom-right-radius: var(--sx-radii-0);
 }
@@ -63,7 +63,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <th
-          class="sxyrxor"
+          class="sxgmopz"
         >
           Column A
         </th>
@@ -114,23 +114,23 @@ tr:nth-child(even) .sxj317c {
   background: var(--sx-colors-tonal50);
 }
 
-.sxyrxor {
+.sxgmopz {
   background: var(--sx-colors-tertiary);
   color: white;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
-  line-height: var(--sx-fontSizes-lg);
+  line-height: 1.5;
   padding: var(--sx-space-2) var(--sx-space-3);
   text-align: left;
   vertical-align: middle;
 }
 
-.sxyrxor:first-of-type {
+.sxgmopz:first-of-type {
   border-top-left-radius: var(--sx-radii-0);
   border-bottom-left-radius: var(--sx-radii-0);
 }
 
-.sxyrxor:last-of-type {
+.sxgmopz:last-of-type {
   border-top-right-radius: var(--sx-radii-0);
   border-bottom-right-radius: var(--sx-radii-0);
 }
@@ -166,7 +166,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <th
-          class="sxyrxor"
+          class="sxgmopz"
         >
           Column A
         </th>

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -1,32 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table component renders 1`] = `
-.sxabai0 {
+.sxj317c {
   border-bottom: 1px solid var(--sx-colors-tonal200);
+  box-sizing: border-box;
   color: var(--sx-colors-tonal600);
-  font-family: var(--sx-fonts-sans);
+  font-family: var(--sx-fonts-body);
   padding: var(--sx-space-2) var(--sx-space-3);
   text-align: left;
   vertical-align: middle;
 }
 
-.sxz26ep {
-  background: var(--sx-colors-secondary);
+tr:nth-child(even) .sxj317c {
+  background: var(--sx-colors-tonal50);
+}
+
+.sxyrxor {
+  background: var(--sx-colors-tertiary);
   color: white;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
+  line-height: var(--sx-fontSizes-lg);
   padding: var(--sx-space-2) var(--sx-space-3);
   text-align: left;
   vertical-align: middle;
 }
 
-.sxwi5ht {
+.sxyrxor:first-of-type {
+  border-top-left-radius: var(--sx-radii-0);
+  border-bottom-left-radius: var(--sx-radii-0);
+}
+
+.sxyrxor:last-of-type {
+  border-top-right-radius: var(--sx-radii-0);
+  border-bottom-right-radius: var(--sx-radii-0);
+}
+
+.sxh18y1 {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxwi5ht-a5b4a {
+.sxh18y1q6419--size-md td {
+  height: 48px;
+}
+
+.sxh18y1-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -34,7 +54,7 @@ exports[`Table component renders 1`] = `
 
 <div>
   <table
-    class="sxwi5ht sxwi5ht-a5b4a"
+    class="sxh18y1 sxh18y1q6419--size-md sxh18y1-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -43,7 +63,7 @@ exports[`Table component renders 1`] = `
         class="sx03kze"
       >
         <th
-          class="sxz26ep"
+          class="sxyrxor"
         >
           Column A
         </th>
@@ -56,7 +76,7 @@ exports[`Table component renders 1`] = `
         class="sx03kze"
       >
         <td
-          class="sxabai0"
+          class="sxj317c"
         >
           This is text
         </td>
@@ -69,7 +89,7 @@ exports[`Table component renders 1`] = `
         class="sx03kze"
       >
         <td
-          class="sxabai0"
+          class="sxj317c"
         >
           Footer 1
         </td>

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -1,17 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table component renders 1`] = `
-.sxj317c {
+.sxyjtjl {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;
   color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
+  line-height: 1.5;
   padding: var(--sx-space-2) var(--sx-space-3);
   text-align: left;
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sxj317c {
+tr:nth-child(even) .sxyjtjl {
   background: var(--sx-colors-tonal50);
 }
 
@@ -36,17 +37,17 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxwony4 {
+.sxss7ii {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxwony4dku3k--size-md .sxj317c {
+.sxss7iia43go--size-md .sxyjtjl {
   height: var(--sx-sizes-4);
 }
 
-.sxwony4-a5b4a {
+.sxss7ii-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -54,7 +55,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxwony4 sxwony4dku3k--size-md sxwony4-a5b4a"
+    class="sxss7ii sxss7iia43go--size-md sxss7ii-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -76,7 +77,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sxyjtjl"
         >
           This is text
         </td>
@@ -89,7 +90,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sxyjtjl"
         >
           Footer 1
         </td>
@@ -100,17 +101,18 @@ tr:nth-child(even) .sxj317c {
 `;
 
 exports[`Table component renders with size set to log 1`] = `
-.sxj317c {
+.sxyjtjl {
   border-bottom: 1px solid var(--sx-colors-tonal200);
   box-sizing: border-box;
   color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
+  line-height: 1.5;
   padding: var(--sx-space-2) var(--sx-space-3);
   text-align: left;
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sxj317c {
+tr:nth-child(even) .sxyjtjl {
   background: var(--sx-colors-tonal50);
 }
 
@@ -135,21 +137,21 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxwony4 {
+.sxss7ii {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxwony4dku3k--size-md .sxj317c {
+.sxss7iia43go--size-md .sxyjtjl {
   height: var(--sx-sizes-4);
 }
 
-.sxwony4jopsk--size-lg .sxj317c {
+.sxss7iifj3j5--size-lg .sxyjtjl {
   height: var(--sx-sizes-5);
 }
 
-.sxwony4-a5b4a {
+.sxss7ii-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -157,7 +159,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxwony4 sxwony4jopsk--size-lg sxwony4-a5b4a"
+    class="sxss7ii sxss7iifj3j5--size-lg sxss7ii-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -179,7 +181,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sxyjtjl"
         >
           This is text
         </td>
@@ -192,7 +194,7 @@ tr:nth-child(even) .sxj317c {
         class="sx03kze"
       >
         <td
-          class="sxj317c"
+          class="sxyjtjl"
         >
           Footer 1
         </td>

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -36,17 +36,17 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxh18y1 {
+.sxxg7cs {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxh18y1q6419--size-md td {
-  height: 48px;
+.sxxg7csy6v1p--size-md td {
+  height: var(--sx-sizes-5);
 }
 
-.sxh18y1-a5b4a {
+.sxxg7cs-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -54,7 +54,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxh18y1 sxh18y1q6419--size-md sxh18y1-a5b4a"
+    class="sxxg7cs sxxg7csy6v1p--size-md sxxg7cs-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -135,21 +135,21 @@ tr:nth-child(even) .sxj317c {
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxh18y1 {
+.sxxg7cs {
   width: 100%;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
 }
 
-.sxh18y1q6419--size-md td {
-  height: 48px;
+.sxxg7csy6v1p--size-md td {
+  height: var(--sx-sizes-5);
 }
 
-.sxh18y100mth--size-lg td {
-  height: 60px;
+.sxxg7csgijdn--size-lg td {
+  height: calc(var(--sx-sizes-5) + var(--sx-sizes-0));
 }
 
-.sxh18y1-a5b4a {
+.sxxg7cs-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -157,7 +157,7 @@ tr:nth-child(even) .sxj317c {
 
 <div>
   <table
-    class="sxh18y1 sxh18y100mth--size-lg sxh18y1-a5b4a"
+    class="sxxg7cs sxxg7csgijdn--size-lg sxxg7cs-a5b4a"
   >
     <thead
       class="sx03kze"


### PR DESCRIPTION
Adding styling changes using the new brand colours:
- Changing the header colour and border-radius
- Colouring every other row for better readability
- Creating a larger row to keep internal controls/buttons clickable in smaller devices

<img width="602" alt="Screenshot 2021-07-30 at 12 38 29" src="https://user-images.githubusercontent.com/5703687/127655702-4b64941e-dc53-4b4c-bd1c-b9b5291376bb.png">