### PR TITLE
Fix: Toast responsive/adaptive styles

### DIFF
--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -23,6 +23,7 @@ const slideOut = keyframes({
 
 const ToastContainer = styled('div', {
   position: 'absolute',
+  width: '100%',
   variants: {
     visible: {
       true: {
@@ -39,16 +40,20 @@ const ToastContainer = styled('div', {
 const StyledToast = styled('div', {
   alignItems: 'center',
   borderRadius: '$0',
-  boxShadow: '$2',
+  boxShadow: '$1',
   boxSizing: 'border-box',
   color: 'white',
   display: 'flex',
   minHeight: '$5',
   pl: '$4',
-  pr: '$3',
-  py: '$2',
+  position: 'relative',
+  pr: '$6',
+  py: '$4',
   transition: 'background-color 50ms ease-out, transform 150ms ease-out',
-  width: TOAST_WIDTH,
+  width: '100%',
+  '@sm': {
+    width: TOAST_WIDTH
+  },
   variants: {
     status: {
       blank: { bg: '$primary' },
@@ -111,7 +116,13 @@ export const Toast: React.FC<ToastProps> = React.memo(
             <Loader css={{ flex: '0 0 auto', ml: 'auto' }} />
           ) : (
             <ActionIcon
-              css={{ color: 'white', flex: '0 0 auto', ml: 'auto' }}
+              css={{
+                position: 'absolute',
+                top: '$2',
+                right: '$2',
+                color: 'white',
+                '&:hover,&:focus': { color: 'white', opacity: 0.5 }
+              }}
               label="Close alert"
               onClick={() => toast.dismiss(id)}
             >

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -11,10 +11,16 @@ export { default as toast } from 'react-hot-toast'
 const TOAST_Z_INDEX = 2147483647
 
 const Container = styled('div', {
-  left: `calc(50% - ${TOAST_WIDTH / 2}px)`,
+  left: '$2',
   position: 'fixed',
-  top: '$3',
-  zIndex: TOAST_Z_INDEX
+  top: '$2',
+  right: '$2',
+  zIndex: TOAST_Z_INDEX,
+  '@sm': {
+    top: '$3',
+    right: 'auto',
+    left: `calc(50% - ${TOAST_WIDTH / 2}px)`
+  }
 })
 
 export const ToastProvider: React.FC = ({ children }) => {

--- a/src/components/toast/__snapshots__/ToastProvider.test.tsx.snap
+++ b/src/components/toast/__snapshots__/ToastProvider.test.tsx.snap
@@ -1,16 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toast component renders 1`] = `
-.sxxdn77 {
-  left: calc(50% - 200px);
+.sxs49hc {
+  left: var(--sx-space-2);
   position: fixed;
-  top: var(--sx-space-3);
+  top: var(--sx-space-2);
+  right: var(--sx-space-2);
   z-index: 2147483647;
+}
+
+@media (min-width: 550px) {
+  .sxs49hc {
+    top: var(--sx-space-3);
+    right: auto;
+    left: calc(50% - 200px);
+  }
 }
 
 <div>
   <div
-    class="sxxdn77"
+    class="sxs49hc"
   />
 </div>
 `;


### PR DESCRIPTION
- Minor update to ensure toasts handle smaller viewport sizes and multi-line text

![Screenshot 2021-08-11 at 17 25 21](https://user-images.githubusercontent.com/3226804/129066793-87a7aa20-3ed8-4ba3-ae26-e9db4e57c394.png)
![Screenshot 2021-08-11 at 17 27 09](https://user-images.githubusercontent.com/3226804/129067028-eb5aca90-37c9-40ad-822b-20c1484fdb7b.png)
![Screenshot 2021-08-11 at 17 26 55](https://user-images.githubusercontent.com/3226804/129067033-a1e1b5ba-9abc-4742-8375-7b3030b96aeb.png)
