### PR TITLE
Fix: Optional ActionDialog cancelActionText

### DIFF
--- a/src/components/alert-dialog/AlertDialog.mdx
+++ b/src/components/alert-dialog/AlertDialog.mdx
@@ -13,23 +13,19 @@ import { AlertProvider, Button, useAlert } from '@atom-learning/components'
 const Component = () => {
   const { showAlert } = useAlert()
 
-  return (
-    <Button
-      onClick={() => {
-        showAlert({
-          title: 'Are you sure you want to delete this school?',
-          description:
-            'Removing this last selected school will remove all restrictions on the exam and make it available to all schools.',
-          confirmActionText: 'Delete school',
-          onAction: (result) => {
-            if (result) console.log('Confirmation')
-          }
-        })
-      }}
-    >
-      Delete school
-    </Button>
-  )
+  const handleClick = () => {
+    showAlert({
+      title: 'Are you sure you want to delete this school?',
+      description: 'This will remove all restrictions from your school',
+      confirmActionText: 'Delete school',
+      cancelActionText: 'Cancel',
+      onAction: (result) => {
+        if (result) console.log('Confirmation')
+      }
+    })
+  }
+
+  return <Button onClick={handleClick}>Delete school</Button>
 }
 
 const App = () => (

--- a/src/components/alert-dialog/alert-context/AlertContext.tsx
+++ b/src/components/alert-dialog/alert-context/AlertContext.tsx
@@ -42,4 +42,12 @@ export const AlertProvider: React.FC = ({ children }) => {
   )
 }
 
-export const useAlert = (): context => React.useContext(AlertContext)
+export const useAlert = (): context => {
+  const context = React.useContext(AlertContext)
+
+  if (context === undefined) {
+    throw new Error('useAlert must be used within a AlertProvider')
+  }
+
+  return context
+}

--- a/src/components/alert-dialog/alert-context/AlertDialog.tsx
+++ b/src/components/alert-dialog/alert-context/AlertDialog.tsx
@@ -39,14 +39,16 @@ export const Alert: React.FC<AlertDialogContentProps> = ({
         </Text>
       )}
       <Stack gap="2" justify="end">
-        <Button
-          appearance="outline"
-          as={AlertDialog.Cancel}
-          onClick={() => onAction(false)}
-          size="sm"
-        >
-          {cancelActionText}
-        </Button>
+        {cancelActionText && (
+          <Button
+            appearance="outline"
+            as={AlertDialog.Cancel}
+            onClick={() => onAction(false)}
+            size="sm"
+          >
+            {cancelActionText}
+          </Button>
+        )}
         <Button
           as={AlertDialog.Action}
           onClick={() => onAction(true)}

--- a/src/components/alert-dialog/alert-context/types.ts
+++ b/src/components/alert-dialog/alert-context/types.ts
@@ -6,5 +6,5 @@ export type alert = {
   description?: string
   onAction: (result: boolean) => void
   confirmActionText: string
-  cancelActionText: string
+  cancelActionText?: string
 }


### PR DESCRIPTION
- Make the `cancelActionText` optional
- Tweak the docs to make it a little easier to read
- Update the `useAlert` hook to better communicate errors