### PR TITLE
Fix: Test warnings

### DIFF
--- a/src/components/action-icon/ActionIcon.test.tsx
+++ b/src/components/action-icon/ActionIcon.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
+import { expectToThrow } from '../../../test/custom-assertions/expect-to-throw'
 import { Icon } from '../icon/Icon'
 import { ActionIcon } from '.'
 
@@ -17,17 +18,17 @@ describe('ActionIcon component', () => {
   })
 
   it('throws with missing or invalid child', async () => {
-    expect(() => render(<ActionIcon />)).toThrow()
+    expectToThrow(() => render(<ActionIcon />))
 
-    expect(() => render(<ActionIcon>An invalid child</ActionIcon>)).toThrow()
+    expectToThrow(() => render(<ActionIcon>An invalid child</ActionIcon>))
 
-    expect(() =>
+    expectToThrow(() =>
       render(
         <ActionIcon>
           <p>An invalid child</p>
         </ActionIcon>
       )
-    ).toThrow()
+    )
   })
 
   it('has no programmatically detectable a11y issues', async () => {

--- a/src/components/alert-dialog/alert-context/AlertContext.tsx
+++ b/src/components/alert-dialog/alert-context/AlertContext.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import { useIsMountedRef } from '~/utilities/use-is-mounted-ref'
+
 import { Alert } from './AlertDialog'
 import { initialState, reducer } from './reducer'
 import type { alert } from './types'
@@ -14,6 +16,7 @@ const AlertContext = React.createContext<context>({
 
 export const AlertProvider: React.FC = ({ children }) => {
   const [alerts, dispatch] = React.useReducer(reducer, initialState)
+  const isMountedRef = useIsMountedRef()
 
   return (
     <AlertContext.Provider
@@ -29,12 +32,13 @@ export const AlertProvider: React.FC = ({ children }) => {
         <Alert
           {...alerts[0]}
           key={alerts[0].id}
-          onClose={() =>
-            dispatch({
-              payload: alerts[0].id,
-              type: 'REMOVE'
-            })
-          }
+          onClose={() => {
+            if (isMountedRef.current)
+              dispatch({
+                payload: alerts[0].id,
+                type: 'REMOVE'
+              })
+          }}
         />
       )}
       {children}

--- a/src/components/markdown-content/MarkdownContent.test.tsx
+++ b/src/components/markdown-content/MarkdownContent.test.tsx
@@ -44,7 +44,7 @@ describe('MarkdownContent component', () => {
 
             if (name === 'someDirective') {
               return (
-                <Box role="main" {...attributes}>
+                <Box as="span" role="main" {...attributes}>
                   {children.map(handleNode)}
                 </Box>
               )

--- a/src/utilities/use-is-mounted-ref/index.ts
+++ b/src/utilities/use-is-mounted-ref/index.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react'
+
+export const useIsMountedRef = () => {
+  const isMountedRef = useRef<boolean>()
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  })
+
+  return isMountedRef
+}

--- a/test/custom-assertions/expect-to-throw.ts
+++ b/test/custom-assertions/expect-to-throw.ts
@@ -1,0 +1,23 @@
+type JestToErrorArg = Parameters<
+  jest.Matchers<unknown, () => unknown>['toThrow']
+>[0]
+
+/**
+ * Helps prevent error logs blowing up as a result of expecting an error to be thrown,
+ * when using a library (such as enzyme)
+ *
+ * @param func Function that you would normally pass to `expect(func).toThrow()`
+ */
+export const expectToThrow = (
+  func: () => unknown,
+  error?: JestToErrorArg
+): void => {
+  // Even though the error is caught, it still gets printed to the console
+  // so we mock that out to avoid the wall of red text.
+  const spy = jest.spyOn(console, 'error')
+  spy.mockImplementation(() => null)
+
+  expect(func).toThrow(error)
+
+  spy.mockRestore()
+}


### PR DESCRIPTION
- Remove thrown errors from stdout in tests
- Ensure AlertDialog is mounted before removing
- Update MarkdownContent test case with valid HTML