### PR TITLE
Fix: Update Tabs colors to v1.0 versions

### DIFF
--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -4,16 +4,16 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 
 const StyledTabTrigger = styled(Trigger, {
-  color: '$primary',
+  color: '$secondary',
   cursor: 'pointer',
   flexShrink: 0,
   fontFamily: '$body',
   p: '$4',
   userSelect: 'none',
-  '&:hover': { color: '$tertiary' },
+  '&:hover': { color: '$primary' },
   '&[data-disabled],&[data-disabled]:hover': { color: '$tonal500' },
   '&[data-state="active"]': {
-    color: '$secondary',
+    color: '$primary',
     fontWeight: 'bold',
     boxShadow: 'inset 0 -3px 0 0 currentColor'
   }

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -17,7 +17,7 @@ const StyledTabContent = styled(Content, {
 const StyledTriggerList = styled(List, {
   flexShrink: 0,
   display: 'flex',
-  borderBottom: '1px solid $secondary700'
+  borderBottom: '1px solid $tertiary'
 })
 
 type TabsProps = React.ComponentProps<typeof StyledRoot>


### PR DESCRIPTION
Reversed active/inactive colors; replaced old colors with v1.0 counterparts