### PR TITLE
Feature: Integrate theme 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@atom-learning/icons": "^0.3.0",
     "@atom-learning/jest-stitches": "1.0.10",
-    "@atom-learning/theme": "1.0.0-beta.0",
+    "@atom-learning/theme": "1.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.12.10",

--- a/src/components/action-icon/ActionIcon.tsx
+++ b/src/components/action-icon/ActionIcon.tsx
@@ -11,21 +11,48 @@ import { Icon } from '../icon/Icon'
 const getSimpleVariant = (base: string, interact: string, active: string) => ({
   bg: 'transparent',
   color: base,
-  '&:hover, &:focus': { color: interact },
-  '&:active': { color: active }
+  '&:not(:disabled):hover, &:not(:disabled):focus': {
+    color: interact
+  },
+  '&:not(:disabled):active': {
+    color: active
+  },
+  '&[disabled]': {
+    color: '$tonal400',
+    cursor: 'not-allowed'
+  }
 })
 const getSolidVariant = (base: string, interact: string, active: string) => ({
   bg: base,
   color: 'white',
-  '&:hover, &:focus': { bg: interact, color: 'white' },
-  '&:active': { bg: active }
+  '&:not(:disabled):hover, &:not(:disabled):focus': {
+    bg: interact,
+    color: 'white'
+  },
+  '&:not(:disabled):active': {
+    bg: active
+  },
+  '&[disabled]': {
+    bg: '$tonal100',
+    color: '$tonal400',
+    cursor: 'not-allowed'
+  }
 })
 const getOutlineVariant = (base: string, interact: string, active: string) => ({
   border: '1px solid',
   borderColor: 'currentColor',
   color: base,
-  '&:hover, &:focus': { color: interact },
-  '&:active': { color: active }
+  '&:not(:disabled):hover, &:not(:disabled):focus': {
+    color: interact
+  },
+  '&:not(:disabled):active': {
+    color: active
+  },
+  '&[disabled]': {
+    borderColor: '$tonal400',
+    color: '$tonal400',
+    cursor: 'not-allowed'
+  }
 })
 
 const StyledButton = styled('button', {
@@ -39,13 +66,7 @@ const StyledButton = styled('button', {
   display: 'flex',
   justifyContent: 'center',
   p: 'unset',
-  transition: 'all 125ms ease-out',
-  '&[disabled], &[disabled]:hover, &[disabled]:focus': {
-    bg: '$tonal50',
-    color: '$tonal300',
-    borderColor: '$tonal50',
-    cursor: 'not-allowed'
-  },
+  transition: 'all 100ms ease-out',
   variants: {
     theme: {
       neutral: {},

--- a/src/components/action-icon/ActionIcon.tsx
+++ b/src/components/action-icon/ActionIcon.tsx
@@ -8,28 +8,24 @@ import { Override } from '~/utilities'
 
 import { Icon } from '../icon/Icon'
 
-const getSimpleVariant = (base: string, interact: string) => ({
+const getSimpleVariant = (base: string, interact: string, active: string) => ({
   bg: 'transparent',
   color: base,
-  '&:hover, &:focus': {
-    color: interact
-  }
+  '&:hover, &:focus': { color: interact },
+  '&:active': { color: active }
 })
-const getSolidVariant = (base: string, interact: string) => ({
+const getSolidVariant = (base: string, interact: string, active: string) => ({
   bg: base,
   color: 'white',
-  '&:hover, &:focus': {
-    bg: interact,
-    color: 'white'
-  }
+  '&:hover, &:focus': { bg: interact, color: 'white' },
+  '&:active': { bg: active }
 })
-const getOutlineVariant = (base: string, interact: string) => ({
+const getOutlineVariant = (base: string, interact: string, active: string) => ({
   border: '1px solid',
   borderColor: 'currentColor',
   color: base,
-  '&:hover, &:focus': {
-    color: interact
-  }
+  '&:hover, &:focus': { color: interact },
+  '&:active': { color: active }
 })
 
 const StyledButton = styled('button', {
@@ -45,9 +41,9 @@ const StyledButton = styled('button', {
   p: 'unset',
   transition: 'all 125ms ease-out',
   '&[disabled], &[disabled]:hover, &[disabled]:focus': {
-    bg: '$tonal100',
-    color: '$tonal600',
-    borderColor: '$tonal100',
+    bg: '$tonal50',
+    color: '$tonal300',
+    borderColor: '$tonal50',
     cursor: 'not-allowed'
   },
   variants: {
@@ -78,71 +74,71 @@ const StyledButton = styled('button', {
     {
       theme: 'neutral',
       appearance: 'simple',
-      css: getSimpleVariant('$tonal600', '$primary')
+      css: getSimpleVariant('$tonal300', '$primaryMid', '$primaryDark')
     },
     {
       theme: 'primary',
       appearance: 'simple',
-      css: getSimpleVariant('$primary', '$tertiary')
+      css: getSimpleVariant('$primary', '$primaryMid', '$primaryDark')
     },
     {
       theme: 'success',
       appearance: 'simple',
-      css: getSimpleVariant('$success', '$successDark')
+      css: getSimpleVariant('$success', '$successMid', '$successDark')
     },
     {
       theme: 'warning',
       appearance: 'simple',
-      css: getSimpleVariant('$warning', '$warningDark')
+      css: getSimpleVariant('$warning', '$warningMid', '$warningDark')
     },
     {
       theme: 'danger',
       appearance: 'simple',
-      css: getSimpleVariant('$danger', '$dangerDark')
+      css: getSimpleVariant('$danger', '$dangerMid', '$dangerDark')
     },
 
     // Appearance Solid
     {
       theme: 'primary',
       appearance: 'solid',
-      css: getSolidVariant('$primary', '$tertiary')
+      css: getSolidVariant('$primary', '$primaryMid', '$primaryDark')
     },
     {
       theme: 'success',
       appearance: 'solid',
-      css: getSolidVariant('$success', '$successDark')
+      css: getSolidVariant('$success', '$successMid', '$successDark')
     },
     {
       theme: 'warning',
       appearance: 'solid',
-      css: getSolidVariant('$warning', '$warningDark')
+      css: getSolidVariant('$warning', '$warningMid', '$warningDark')
     },
     {
       theme: 'danger',
       appearance: 'solid',
-      css: getSolidVariant('$danger', '$dangerDark')
+      css: getSolidVariant('$danger', '$dangerMid', '$dangerDark')
     },
 
     // Appearance Outline
     {
       theme: 'primary',
       appearance: 'outline',
-      css: getOutlineVariant('$primary', '$tertiary')
+      css: getOutlineVariant('$primary', '$primaryMid', '$primaryDark')
     },
     {
       theme: 'success',
       appearance: 'outline',
-      css: getOutlineVariant('$success', '$successDark')
+      css: getOutlineVariant('$success', '$successMid', '$successDark')
     },
     {
       theme: 'warning',
       appearance: 'outline',
-      css: getOutlineVariant('$warning', '$warningDark')
+      css: getOutlineVariant('$warning', '$warningMid', '$warningDark')
     },
     {
       theme: 'danger',
       appearance: 'outline',
-      css: getOutlineVariant('$danger', '$dangerDark')
+      css: getOutlineVariant('$danger', '$dangerMid', '$dangerDark')
     }
   ]
 })
@@ -206,7 +202,12 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
             `Children of type ${child?.type} aren't permitted. Only an ${Icon.displayName} component is allowed in ${ActionIcon.displayName}`
           )
 
-          return child
+          return React.cloneElement(child, {
+            css: {
+              size: size === 'lg' ? 20 : 16,
+              ...(child.props.css ? child.props.css : {})
+            }
+          })
         })}
       </StyledButton>
     )

--- a/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
+++ b/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
@@ -1,22 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActionIcon component renders 1`] = `
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6mbqqh--size-md {
+.sxakl60zozsa--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxd2uai {
+.sxakl60-d7dk3 {
+  height: 16px;
+  width: 16px;
+}
+
+.sx5tsqk {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
@@ -31,34 +36,38 @@ exports[`ActionIcon component renders 1`] = `
   transition: all 125ms ease-out;
 }
 
-.sxd2uai[disabled],
-.sxd2uai[disabled]:hover,
-.sxd2uai[disabled]:focus {
-  background: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
-  border-color: var(--sx-colors-tonal100);
+.sx5tsqk[disabled],
+.sx5tsqk[disabled]:hover,
+.sx5tsqk[disabled]:focus {
+  background: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal50);
   cursor: not-allowed;
 }
 
-.sxd2uaie6fss--size-md {
+.sx5tsqke6fss--size-md {
   height: var(--sx-sizes-3);
   width: var(--sx-sizes-3);
 }
 
-.sxd2uai94b5u--c2 {
+.sx5tsqk97pz9--c2 {
   background: transparent;
   color: var(--sx-colors-primary);
 }
 
-.sxd2uai94b5u--c2:hover,
-.sxd2uai94b5u--c2:focus {
-  color: var(--sx-colors-tertiary);
+.sx5tsqk97pz9--c2:hover,
+.sx5tsqk97pz9--c2:focus {
+  color: var(--sx-colors-primaryMid);
+}
+
+.sx5tsqk97pz9--c2:active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
     aria-label="Mark as complete"
-    class="sxd2uai sxd2uai03kze--theme-primary sxd2uai03kze--appearance-simple sxd2uaie6fss--size-md sxd2uai94b5u--c2"
+    class="sx5tsqk sx5tsqk03kze--theme-primary sx5tsqk03kze--appearance-simple sx5tsqke6fss--size-md sx5tsqk97pz9--c2"
     type="button"
   >
     <svg />

--- a/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
+++ b/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ActionIcon component renders 1`] = `
   width: 16px;
 }
 
-.sx5tsqk {
+.sxua1zw {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
@@ -33,41 +33,37 @@ exports[`ActionIcon component renders 1`] = `
   display: flex;
   justify-content: center;
   padding: unset;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
 }
 
-.sx5tsqk[disabled],
-.sx5tsqk[disabled]:hover,
-.sx5tsqk[disabled]:focus {
-  background: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  border-color: var(--sx-colors-tonal50);
-  cursor: not-allowed;
-}
-
-.sx5tsqke6fss--size-md {
+.sxua1zwe6fss--size-md {
   height: var(--sx-sizes-3);
   width: var(--sx-sizes-3);
 }
 
-.sx5tsqk97pz9--c2 {
+.sxua1zw2gexy--c2 {
   background: transparent;
   color: var(--sx-colors-primary);
 }
 
-.sx5tsqk97pz9--c2:hover,
-.sx5tsqk97pz9--c2:focus {
+.sxua1zw2gexy--c2:not(:disabled):hover,
+.sxua1zw2gexy--c2:not(:disabled):focus {
   color: var(--sx-colors-primaryMid);
 }
 
-.sx5tsqk97pz9--c2:active {
+.sxua1zw2gexy--c2:not(:disabled):active {
   color: var(--sx-colors-primaryDark);
+}
+
+.sxua1zw2gexy--c2[disabled] {
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
 }
 
 <div>
   <button
     aria-label="Mark as complete"
-    class="sx5tsqk sx5tsqk03kze--theme-primary sx5tsqk03kze--appearance-simple sx5tsqke6fss--size-md sx5tsqk97pz9--c2"
+    class="sxua1zw sxua1zw03kze--theme-primary sxua1zw03kze--appearance-simple sxua1zwe6fss--size-md sxua1zw2gexy--c2"
     type="button"
   >
     <svg />

--- a/src/components/box/Box.mdx
+++ b/src/components/box/Box.mdx
@@ -19,7 +19,7 @@ To show an example of the benefits of using `Box`, the card below is composed to
 <Box
   as="article"
   css={{
-    border: '1px solid $tonal300',
+    border: '1px solid $tonal100',
     borderRadius: '$2',
     overflow: 'hidden',
     width: '320px'

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,10 +1,11 @@
 import { StitchesVariants } from '@stitches/react'
+import { darken } from 'polished'
 import * as React from 'react'
 
 import { Box } from '~/components/box'
 import { Icon } from '~/components/icon'
 import { Loader } from '~/components/loader'
-import { styled } from '~/stitches'
+import { styled, theme } from '~/stitches'
 import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
 
@@ -16,11 +17,14 @@ const getButtonOutlineVariant = (
   border: '1px solid',
   borderColor: 'currentColor',
   color: base,
-  bg: 'white',
+  '&[disabled]': {
+    borderColor: '$tonal400',
+    color: '$tonal400',
+    cursor: 'not-allowed'
+  },
   '&:not([disabled]):hover, &:not([disabled]):focus': {
     textDecoration: 'none',
-    color: interact,
-    bg: 'white'
+    color: interact
   },
   '&:not([disabled]):active': {
     color: active
@@ -35,6 +39,11 @@ const getButtonSolidVariant = (
 ) => ({
   bg: base,
   color: text,
+  '&[disabled]': {
+    bg: '$tonal100',
+    color: '$tonal400',
+    cursor: 'not-allowed'
+  },
   '&:not([disabled]):hover, &:not([disabled]):focus': {
     bg: interact,
     color: text
@@ -54,21 +63,15 @@ export const StyledButton = styled('button', {
   fontFamily: '$body',
   fontWeight: 600,
   justifyContent: 'center',
-  letterSpacing: '0.02em',
   p: 'unset',
   textDecoration: 'none',
   transition: 'all 100ms ease-out',
   whiteSpace: 'nowrap',
   width: 'max-content',
-  '&[disabled]': {
-    bg: '$tonal50',
-    borderColor: '$tonal50',
-    color: '$tonal300',
-    cursor: 'not-allowed'
-  },
   variants: {
     theme: {
       primary: {},
+      secondary: {},
       success: {},
       warning: {},
       danger: {}
@@ -89,12 +92,18 @@ export const StyledButton = styled('button', {
         lineHeight: 1.5,
         height: '$4',
         px: '$5'
+      },
+      lg: {
+        fontSize: '$lg',
+        lineHeight: 1.5,
+        height: '$5',
+        px: '$5'
       }
     },
     isLoading: {
       true: {
         cursor: 'not-allowed',
-        opacity: 0.5,
+        opacity: 0.6,
         pointerEvents: 'none'
       }
     },
@@ -115,6 +124,15 @@ export const StyledButton = styled('button', {
       theme: 'primary',
       appearance: 'solid',
       css: getButtonSolidVariant('$primary', '$primaryMid', '$primaryDark')
+    },
+    {
+      theme: 'secondary',
+      appearance: 'solid',
+      css: getButtonSolidVariant(
+        '$primaryDark',
+        darken(0.1, theme.colors.primaryDark.value),
+        darken(0.15, theme.colors.primaryDark.value)
+      )
     },
     {
       theme: 'success',
@@ -162,13 +180,25 @@ const WithLoader = ({ isLoading, children }) => (
   </>
 )
 
+const getIconSize = (size) => {
+  switch (size) {
+    case 'lg':
+      return 22
+    case 'md':
+      return 20
+    case 'sm':
+    default:
+      return 16
+  }
+}
+
 const getChildren = (children, size) =>
   React.Children.map(children, (child, i) => {
     if (child?.type === Icon) {
       return React.cloneElement(child, {
         css: {
           [i === 0 ? 'mr' : 'ml']: size === 'sm' ? '$2' : '$3',
-          size: size === 'md' ? 20 : 16,
+          size: getIconSize(size),
           ...(child.props.css ? child.props.css : {})
         }
       })

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -8,7 +8,11 @@ import { styled } from '~/stitches'
 import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
 
-const getButtonOutlineVariant = (base: string, interact: string) => ({
+const getButtonOutlineVariant = (
+  base: string,
+  interact: string,
+  active: string
+) => ({
   border: '1px solid',
   borderColor: 'currentColor',
   color: base,
@@ -19,13 +23,14 @@ const getButtonOutlineVariant = (base: string, interact: string) => ({
     bg: 'white'
   },
   '&:not([disabled]):active': {
-    color: base
+    color: active
   }
 })
 
 const getButtonSolidVariant = (
   base: string,
   interact: string,
+  active: string,
   text = 'white'
 ) => ({
   bg: base,
@@ -35,7 +40,7 @@ const getButtonSolidVariant = (
     color: text
   },
   '&:not([disabled]):active': {
-    bg: base
+    bg: active
   }
 })
 
@@ -52,13 +57,13 @@ export const StyledButton = styled('button', {
   letterSpacing: '0.02em',
   p: 'unset',
   textDecoration: 'none',
-  transition: 'all 125ms ease-out',
+  transition: 'all 100ms ease-out',
   whiteSpace: 'nowrap',
   width: 'max-content',
   '&[disabled]': {
-    bg: '$tonal100',
-    borderColor: '$tonal100',
-    color: '$tonal600',
+    bg: '$tonal50',
+    borderColor: '$tonal50',
+    color: '$tonal300',
     cursor: 'not-allowed'
   },
   variants: {
@@ -109,27 +114,32 @@ export const StyledButton = styled('button', {
     {
       theme: 'primary',
       appearance: 'solid',
-      css: getButtonSolidVariant('$primary', '$tertiary')
+      css: getButtonSolidVariant('$primary', '$primaryMid', '$primaryDark')
     },
     {
       theme: 'success',
       appearance: 'solid',
-      css: getButtonSolidVariant('$success', '$successDark')
+      css: getButtonSolidVariant('$success', '$successMid', '$successDark')
     },
     {
       theme: 'warning',
       appearance: 'solid',
-      css: getButtonSolidVariant('$warning', '$warningDark', '$tonal900')
+      css: getButtonSolidVariant(
+        '$warning',
+        '$warningMid',
+        '$warningDark',
+        '$tonal500'
+      )
     },
     {
       theme: 'danger',
       appearance: 'solid',
-      css: getButtonSolidVariant('$danger', '$dangerDark')
+      css: getButtonSolidVariant('$danger', '$dangerMid', '$dangerDark')
     },
     {
       theme: 'primary',
       appearance: 'outline',
-      css: getButtonOutlineVariant('$primary', '$tertiary')
+      css: getButtonOutlineVariant('$primary', '$primaryMid', '$primaryDark')
     }
   ]
 })
@@ -153,13 +163,14 @@ const WithLoader = ({ isLoading, children }) => (
 )
 
 const getChildren = (children, size) =>
-  React.Children.map(children, (child: any, i) => {
+  React.Children.map(children, (child, i) => {
     if (child?.type === Icon) {
       return React.cloneElement(child, {
         css: {
-          [i === 0 ? 'mr' : 'ml']: size === 'sm' ? '$2' : '$3'
-        },
-        size: size === 'lg' ? 'md' : 'sm'
+          [i === 0 ? 'mr' : 'ml']: size === 'sm' ? '$2' : '$3',
+          size: size === 'md' ? 20 : 16,
+          ...(child.props.css ? child.props.css : {})
+        }
       })
     }
     return child

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
   margin-right: 2px;
 }
 
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -99,7 +99,6 @@ exports[`Button component Loading state renders a loading button 1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -107,14 +106,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -122,52 +114,62 @@ exports[`Button component Loading state renders a loading button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftclmkcj--isRounded-true {
+.sxsi1d3lmkcj--isRounded-true {
   border-radius: var(--sx-radii-round);
 }
 
-.sxxtftch1fyd--isLoading-true {
+.sxsi1d32s6lw--isLoading-true {
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 0.6;
   pointer-events: none;
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
-.sxxtftcy29n0--c2 {
+.sxsi1d3e8irk--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):hover,
-.sxxtftcy29n0--c2:not([disabled]):focus {
+.sxsi1d3e8irk--c2[disabled] {
+  border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d3e8irk--c2:not([disabled]):hover,
+.sxsi1d3e8irk--c2:not([disabled]):focus {
   text-decoration: none;
   color: var(--sx-colors-primaryMid);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):active {
+.sxsi1d3e8irk--c2:not([disabled]):active {
   color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftch1fyd--isLoading-true sxxtftc52zgx--c2"
+    class="sxsi1d3 sxsi1d303kze--theme-primary sxsi1d303kze--appearance-solid sxsi1d3dwxsw--size-md sxsi1d32s6lw--isLoading-true sxsi1d30v6w3--c2"
     type="button"
   >
     <div
@@ -199,7 +201,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
 `;
 
 exports[`Button component renders a button 1`] = `
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -209,7 +211,6 @@ exports[`Button component renders a button 1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -217,14 +218,7 @@ exports[`Button component renders a button 1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -232,24 +226,30 @@ exports[`Button component renders a button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftc52zgx--c2"
+    class="sxsi1d3 sxsi1d303kze--theme-primary sxsi1d303kze--appearance-solid sxsi1d3dwxsw--size-md sxsi1d30v6w3--c2"
     type="button"
   >
     BUTTON
@@ -279,7 +279,7 @@ exports[`Button component renders a button with an icon 1`] = `
   width: 20px;
 }
 
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -289,7 +289,6 @@ exports[`Button component renders a button with an icon 1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -297,14 +296,7 @@ exports[`Button component renders a button with an icon 1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -312,42 +304,52 @@ exports[`Button component renders a button with an icon 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
-.sxxtftcy29n0--c2 {
+.sxsi1d3e8irk--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):hover,
-.sxxtftcy29n0--c2:not([disabled]):focus {
+.sxsi1d3e8irk--c2[disabled] {
+  border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d3e8irk--c2:not([disabled]):hover,
+.sxsi1d3e8irk--c2:not([disabled]):focus {
   text-decoration: none;
   color: var(--sx-colors-primaryMid);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):active {
+.sxsi1d3e8irk--c2:not([disabled]):active {
   color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftc52zgx--c2"
+    class="sxsi1d3 sxsi1d303kze--theme-primary sxsi1d303kze--appearance-solid sxsi1d3dwxsw--size-md sxsi1d30v6w3--c2"
     type="button"
   >
     BUTTON 
@@ -366,7 +368,7 @@ exports[`Button component renders a button with an icon 1`] = `
 `;
 
 exports[`Button component renders a disabled button 1`] = `
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -376,7 +378,6 @@ exports[`Button component renders a disabled button 1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -384,14 +385,7 @@ exports[`Button component renders a disabled button 1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -399,42 +393,52 @@ exports[`Button component renders a disabled button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
-.sxxtftcy29n0--c2 {
+.sxsi1d3e8irk--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):hover,
-.sxxtftcy29n0--c2:not([disabled]):focus {
+.sxsi1d3e8irk--c2[disabled] {
+  border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d3e8irk--c2:not([disabled]):hover,
+.sxsi1d3e8irk--c2:not([disabled]):focus {
   text-decoration: none;
   color: var(--sx-colors-primaryMid);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):active {
+.sxsi1d3e8irk--c2:not([disabled]):active {
   color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftc52zgx--c2"
+    class="sxsi1d3 sxsi1d303kze--theme-primary sxsi1d303kze--appearance-solid sxsi1d3dwxsw--size-md sxsi1d30v6w3--c2"
     disabled=""
     type="button"
   >
@@ -444,7 +448,7 @@ exports[`Button component renders a disabled button 1`] = `
 `;
 
 exports[`Button component renders a disabled warning outline button 1`] = `
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -454,7 +458,6 @@ exports[`Button component renders a disabled warning outline button 1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -462,14 +465,7 @@ exports[`Button component renders a disabled warning outline button 1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -477,42 +473,52 @@ exports[`Button component renders a disabled warning outline button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
-.sxxtftcy29n0--c2 {
+.sxsi1d3e8irk--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):hover,
-.sxxtftcy29n0--c2:not([disabled]):focus {
+.sxsi1d3e8irk--c2[disabled] {
+  border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d3e8irk--c2:not([disabled]):hover,
+.sxsi1d3e8irk--c2:not([disabled]):focus {
   text-decoration: none;
   color: var(--sx-colors-primaryMid);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):active {
+.sxsi1d3e8irk--c2:not([disabled]):active {
   color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-warning sxxtftc03kze--appearance-outline sxxtftcdwxsw--size-md"
+    class="sxsi1d3 sxsi1d303kze--theme-warning sxsi1d303kze--appearance-outline sxsi1d3dwxsw--size-md"
     disabled=""
     type="button"
   >
@@ -522,7 +528,7 @@ exports[`Button component renders a disabled warning outline button 1`] = `
 `;
 
 exports[`Button component renders a outline button 1`] = `
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -532,7 +538,6 @@ exports[`Button component renders a outline button 1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -540,14 +545,7 @@ exports[`Button component renders a outline button 1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -555,42 +553,52 @@ exports[`Button component renders a outline button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
-.sxxtftcy29n0--c2 {
+.sxsi1d3e8irk--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):hover,
-.sxxtftcy29n0--c2:not([disabled]):focus {
+.sxsi1d3e8irk--c2[disabled] {
+  border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d3e8irk--c2:not([disabled]):hover,
+.sxsi1d3e8irk--c2:not([disabled]):focus {
   text-decoration: none;
   color: var(--sx-colors-primaryMid);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):active {
+.sxsi1d3e8irk--c2:not([disabled]):active {
   color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-outline sxxtftcdwxsw--size-md sxxtftcy29n0--c2"
+    class="sxsi1d3 sxsi1d303kze--theme-primary sxsi1d303kze--appearance-outline sxsi1d3dwxsw--size-md sxsi1d3e8irk--c2"
     type="button"
   >
     BUTTON
@@ -620,7 +628,7 @@ exports[`Button component renders a rounded button  1`] = `
   width: 20px;
 }
 
-.sxxtftc {
+.sxsi1d3 {
   align-items: center;
   background: unset;
   border: unset;
@@ -630,7 +638,6 @@ exports[`Button component renders a rounded button  1`] = `
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   justify-content: center;
-  letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
   transition: all 100ms ease-out;
@@ -638,14 +645,7 @@ exports[`Button component renders a rounded button  1`] = `
   width: max-content;
 }
 
-.sxxtftc[disabled] {
-  background: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  cursor: not-allowed;
-}
-
-.sxxtftcdwxsw--size-md {
+.sxsi1d3dwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -653,46 +653,56 @@ exports[`Button component renders a rounded button  1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxxtftclmkcj--isRounded-true {
+.sxsi1d3lmkcj--isRounded-true {
   border-radius: var(--sx-radii-round);
 }
 
-.sxxtftc52zgx--c2 {
+.sxsi1d30v6w3--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):hover,
-.sxxtftc52zgx--c2:not([disabled]):focus {
+.sxsi1d30v6w3--c2[disabled] {
+  background: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d30v6w3--c2:not([disabled]):hover,
+.sxsi1d30v6w3--c2:not([disabled]):focus {
   background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxxtftc52zgx--c2:not([disabled]):active {
+.sxsi1d30v6w3--c2:not([disabled]):active {
   background: var(--sx-colors-primaryDark);
 }
 
-.sxxtftcy29n0--c2 {
+.sxsi1d3e8irk--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):hover,
-.sxxtftcy29n0--c2:not([disabled]):focus {
+.sxsi1d3e8irk--c2[disabled] {
+  border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxsi1d3e8irk--c2:not([disabled]):hover,
+.sxsi1d3e8irk--c2:not([disabled]):focus {
   text-decoration: none;
   color: var(--sx-colors-primaryMid);
-  background: white;
 }
 
-.sxxtftcy29n0--c2:not([disabled]):active {
+.sxsi1d3e8irk--c2:not([disabled]):active {
   color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftclmkcj--isRounded-true sxxtftc52zgx--c2"
+    class="sxsi1d3 sxsi1d303kze--theme-primary sxsi1d303kze--appearance-solid sxsi1d3dwxsw--size-md sxsi1d3lmkcj--isRounded-true sxsi1d30v6w3--c2"
     type="button"
   >
     BUTTON 

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -23,23 +23,25 @@ exports[`Button component Loading state renders a loading button 1`] = `
   }
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6or94y--size-sm {
-  height: var(--sx-sizes-1);
-  width: var(--sx-sizes-1);
+.sxakl60zozsa--size-md {
+  height: var(--sx-sizes-2);
+  width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxtros6-898e9 {
+.sxakl60-qa905 {
   margin-left: var(--sx-space-3);
+  height: 20px;
+  width: 20px;
 }
 
 .sx03kze-e0n2q {
@@ -87,7 +89,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
   margin-right: 2px;
 }
 
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -100,19 +102,19 @@ exports[`Button component Loading state renders a loading button 1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -120,52 +122,52 @@ exports[`Button component Loading state renders a loading button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlmkcj--isRounded-true {
+.sxxtftclmkcj--isRounded-true {
   border-radius: var(--sx-radii-round);
 }
 
-.sxk4zgnh1fyd--isLoading-true {
+.sxxtftch1fyd--isLoading-true {
   cursor: not-allowed;
   opacity: 0.5;
   pointer-events: none;
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
-.sxk4zgncklkz--c2 {
+.sxxtftcy29n0--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):hover,
-.sxk4zgncklkz--c2:not([disabled]):focus {
+.sxxtftcy29n0--c2:not([disabled]):hover,
+.sxxtftcy29n0--c2:not([disabled]):focus {
   text-decoration: none;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primaryMid);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):active {
-  color: var(--sx-colors-primary);
+.sxxtftcy29n0--c2:not([disabled]):active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-primary sxk4zgn03kze--appearance-solid sxk4zgndwxsw--size-md sxk4zgnh1fyd--isLoading-true sxk4zgnlee6n--c2"
+    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftch1fyd--isLoading-true sxxtftc52zgx--c2"
     type="button"
   >
     <div
@@ -197,7 +199,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
 `;
 
 exports[`Button component renders a button 1`] = `
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -210,19 +212,19 @@ exports[`Button component renders a button 1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -230,24 +232,24 @@ exports[`Button component renders a button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-primary sxk4zgn03kze--appearance-solid sxk4zgndwxsw--size-md sxk4zgnlee6n--c2"
+    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftc52zgx--c2"
     type="button"
   >
     BUTTON
@@ -256,26 +258,28 @@ exports[`Button component renders a button 1`] = `
 `;
 
 exports[`Button component renders a button with an icon 1`] = `
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6or94y--size-sm {
-  height: var(--sx-sizes-1);
-  width: var(--sx-sizes-1);
+.sxakl60zozsa--size-md {
+  height: var(--sx-sizes-2);
+  width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxtros6-898e9 {
+.sxakl60-qa905 {
   margin-left: var(--sx-space-3);
+  height: 20px;
+  width: 20px;
 }
 
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -288,19 +292,19 @@ exports[`Button component renders a button with an icon 1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -308,48 +312,48 @@ exports[`Button component renders a button with an icon 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
-.sxk4zgncklkz--c2 {
+.sxxtftcy29n0--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):hover,
-.sxk4zgncklkz--c2:not([disabled]):focus {
+.sxxtftcy29n0--c2:not([disabled]):hover,
+.sxxtftcy29n0--c2:not([disabled]):focus {
   text-decoration: none;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primaryMid);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):active {
-  color: var(--sx-colors-primary);
+.sxxtftcy29n0--c2:not([disabled]):active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-primary sxk4zgn03kze--appearance-solid sxk4zgndwxsw--size-md sxk4zgnlee6n--c2"
+    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftc52zgx--c2"
     type="button"
   >
     BUTTON 
     <svg
       aria-hidden="true"
-      class="sxtros6 sxtros6or94y--size-sm sxtros6-898e9"
+      class="sxakl60 sxakl60zozsa--size-md sxakl60-qa905"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -362,7 +366,7 @@ exports[`Button component renders a button with an icon 1`] = `
 `;
 
 exports[`Button component renders a disabled button 1`] = `
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -375,19 +379,19 @@ exports[`Button component renders a disabled button 1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -395,42 +399,42 @@ exports[`Button component renders a disabled button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
-.sxk4zgncklkz--c2 {
+.sxxtftcy29n0--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):hover,
-.sxk4zgncklkz--c2:not([disabled]):focus {
+.sxxtftcy29n0--c2:not([disabled]):hover,
+.sxxtftcy29n0--c2:not([disabled]):focus {
   text-decoration: none;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primaryMid);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):active {
-  color: var(--sx-colors-primary);
+.sxxtftcy29n0--c2:not([disabled]):active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-primary sxk4zgn03kze--appearance-solid sxk4zgndwxsw--size-md sxk4zgnlee6n--c2"
+    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftc52zgx--c2"
     disabled=""
     type="button"
   >
@@ -440,7 +444,7 @@ exports[`Button component renders a disabled button 1`] = `
 `;
 
 exports[`Button component renders a disabled warning outline button 1`] = `
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -453,19 +457,19 @@ exports[`Button component renders a disabled warning outline button 1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -473,42 +477,42 @@ exports[`Button component renders a disabled warning outline button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
-.sxk4zgncklkz--c2 {
+.sxxtftcy29n0--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):hover,
-.sxk4zgncklkz--c2:not([disabled]):focus {
+.sxxtftcy29n0--c2:not([disabled]):hover,
+.sxxtftcy29n0--c2:not([disabled]):focus {
   text-decoration: none;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primaryMid);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):active {
-  color: var(--sx-colors-primary);
+.sxxtftcy29n0--c2:not([disabled]):active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-warning sxk4zgn03kze--appearance-outline sxk4zgndwxsw--size-md"
+    class="sxxtftc sxxtftc03kze--theme-warning sxxtftc03kze--appearance-outline sxxtftcdwxsw--size-md"
     disabled=""
     type="button"
   >
@@ -518,7 +522,7 @@ exports[`Button component renders a disabled warning outline button 1`] = `
 `;
 
 exports[`Button component renders a outline button 1`] = `
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -531,19 +535,19 @@ exports[`Button component renders a outline button 1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -551,42 +555,42 @@ exports[`Button component renders a outline button 1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
-.sxk4zgncklkz--c2 {
+.sxxtftcy29n0--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):hover,
-.sxk4zgncklkz--c2:not([disabled]):focus {
+.sxxtftcy29n0--c2:not([disabled]):hover,
+.sxxtftcy29n0--c2:not([disabled]):focus {
   text-decoration: none;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primaryMid);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):active {
-  color: var(--sx-colors-primary);
+.sxxtftcy29n0--c2:not([disabled]):active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-primary sxk4zgn03kze--appearance-outline sxk4zgndwxsw--size-md sxk4zgncklkz--c2"
+    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-outline sxxtftcdwxsw--size-md sxxtftcy29n0--c2"
     type="button"
   >
     BUTTON
@@ -595,26 +599,28 @@ exports[`Button component renders a outline button 1`] = `
 `;
 
 exports[`Button component renders a rounded button  1`] = `
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6or94y--size-sm {
-  height: var(--sx-sizes-1);
-  width: var(--sx-sizes-1);
+.sxakl60zozsa--size-md {
+  height: var(--sx-sizes-2);
+  width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxtros6-898e9 {
+.sxakl60-qa905 {
   margin-left: var(--sx-space-3);
+  height: 20px;
+  width: 20px;
 }
 
-.sxk4zgn {
+.sxxtftc {
   align-items: center;
   background: unset;
   border: unset;
@@ -627,19 +633,19 @@ exports[`Button component renders a rounded button  1`] = `
   letter-spacing: 0.02em;
   padding: unset;
   text-decoration: none;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
   white-space: nowrap;
   width: max-content;
 }
 
-.sxk4zgn[disabled] {
-  background: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxxtftc[disabled] {
+  background: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxk4zgndwxsw--size-md {
+.sxxtftcdwxsw--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
   height: var(--sx-sizes-4);
@@ -647,52 +653,52 @@ exports[`Button component renders a rounded button  1`] = `
   padding-right: var(--sx-space-5);
 }
 
-.sxk4zgnlmkcj--isRounded-true {
+.sxxtftclmkcj--isRounded-true {
   border-radius: var(--sx-radii-round);
 }
 
-.sxk4zgnlee6n--c2 {
+.sxxtftc52zgx--c2 {
   background: var(--sx-colors-primary);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):hover,
-.sxk4zgnlee6n--c2:not([disabled]):focus {
-  background: var(--sx-colors-tertiary);
+.sxxtftc52zgx--c2:not([disabled]):hover,
+.sxxtftc52zgx--c2:not([disabled]):focus {
+  background: var(--sx-colors-primaryMid);
   color: white;
 }
 
-.sxk4zgnlee6n--c2:not([disabled]):active {
-  background: var(--sx-colors-primary);
+.sxxtftc52zgx--c2:not([disabled]):active {
+  background: var(--sx-colors-primaryDark);
 }
 
-.sxk4zgncklkz--c2 {
+.sxxtftcy29n0--c2 {
   border: 1px solid;
   border-color: currentColor;
   color: var(--sx-colors-primary);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):hover,
-.sxk4zgncklkz--c2:not([disabled]):focus {
+.sxxtftcy29n0--c2:not([disabled]):hover,
+.sxxtftcy29n0--c2:not([disabled]):focus {
   text-decoration: none;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primaryMid);
   background: white;
 }
 
-.sxk4zgncklkz--c2:not([disabled]):active {
-  color: var(--sx-colors-primary);
+.sxxtftcy29n0--c2:not([disabled]):active {
+  color: var(--sx-colors-primaryDark);
 }
 
 <div>
   <button
-    class="sxk4zgn sxk4zgn03kze--theme-primary sxk4zgn03kze--appearance-solid sxk4zgndwxsw--size-md sxk4zgnlmkcj--isRounded-true sxk4zgnlee6n--c2"
+    class="sxxtftc sxxtftc03kze--theme-primary sxxtftc03kze--appearance-solid sxxtftcdwxsw--size-md sxxtftclmkcj--isRounded-true sxxtftc52zgx--c2"
     type="button"
   >
     BUTTON 
     <svg
       aria-hidden="true"
-      class="sxtros6 sxtros6or94y--size-sm sxtros6-898e9"
+      class="sxakl60 sxakl60zozsa--size-md sxakl60-qa905"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/src/components/carousel/CarouselArrows.tsx
+++ b/src/components/carousel/CarouselArrows.tsx
@@ -12,7 +12,7 @@ const buttonStyles = {
   alignItems: 'center',
   bg: 'unset',
   border: 'unset',
-  color: '$tertiary',
+  color: '$primary',
   cursor: 'pointer',
   display: 'flex',
   justifyContent: 'center',
@@ -22,10 +22,13 @@ const buttonStyles = {
   transform: 'translateY(-50%)',
   transition: 'color 0.15s ease-in-out',
   '&:hover': {
-    color: '$primary'
+    color: '$primaryMid'
+  },
+  '&:active': {
+    color: '$primaryDark'
   },
   '&:disabled': {
-    color: '$tonal300'
+    color: '$tonal100'
   }
 }
 

--- a/src/components/carousel/CarouselPagination.tsx
+++ b/src/components/carousel/CarouselPagination.tsx
@@ -5,16 +5,19 @@ import { styled } from '~/stitches'
 export const CarouselPagination = styled(DotGroup, {
   justifyContent: 'center',
   '& button': {
-    bg: '$tonal300',
+    bg: '$tonal200',
     border: 'none',
     borderRadius: '50%',
     cursor: 'pointer',
     mx: '$1',
     p: '$1',
     size: '$space$3',
-    transition: 'all 0.25s ease-in',
+    transition: 'all 100ms ease-in',
     '&[class*="selected"]': {
-      bg: '$tertiary'
+      bg: '$primary'
+    },
+    '&:hover, &:focus': {
+      bg: '$primaryMid'
     }
   }
 })

--- a/src/components/carousel/__snapshots__/Carousel.test.tsx.snap
+++ b/src/components/carousel/__snapshots__/Carousel.test.tsx.snap
@@ -15,26 +15,26 @@ exports[`Carousel component renders 1`] = `
   padding-right: var(--sx-space-3);
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6mbqqh--size-md {
+.sxakl60zozsa--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sx9lsuj {
+.sxq7l9k {
   align-items: center;
   background: unset;
   border: unset;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primary);
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -46,36 +46,40 @@ exports[`Carousel component renders 1`] = `
   transition: color 0.15s ease-in-out;
 }
 
-.sx9lsuj:hover {
-  color: var(--sx-colors-primary);
+.sxq7l9k:hover {
+  color: var(--sx-colors-primaryMid);
 }
 
-.sx9lsuj:disabled {
-  color: var(--sx-colors-tonal300);
+.sxq7l9k:active {
+  color: var(--sx-colors-primaryDark);
 }
 
-.sx9lsuj-pqx9j {
+.sxq7l9k:disabled {
+  color: var(--sx-colors-tonal100);
+}
+
+.sxq7l9k-pqx9j {
   position: absolute;
   left: var(--sx-space-2);
 }
 
 @media (min-width: 800px) {
-  .sx9lsuj-pqx9j {
+  .sxq7l9k-pqx9j {
     left: var(--sx-space-3);
   }
 }
 
 @media (min-width: 1100px) {
-  .sx9lsuj-pqx9j {
+  .sxq7l9k-pqx9j {
     left: var(--sx-space-4);
   }
 }
 
-.sx9lsuj {
+.sxq7l9k {
   align-items: center;
   background: unset;
   border: unset;
-  color: var(--sx-colors-tertiary);
+  color: var(--sx-colors-primary);
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -87,37 +91,41 @@ exports[`Carousel component renders 1`] = `
   transition: color 0.15s ease-in-out;
 }
 
-.sx9lsuj:hover {
-  color: var(--sx-colors-primary);
+.sxq7l9k:hover {
+  color: var(--sx-colors-primaryMid);
 }
 
-.sx9lsuj:disabled {
-  color: var(--sx-colors-tonal300);
+.sxq7l9k:active {
+  color: var(--sx-colors-primaryDark);
 }
 
-.sx9lsuj-dtra5 {
+.sxq7l9k:disabled {
+  color: var(--sx-colors-tonal100);
+}
+
+.sxq7l9k-dtra5 {
   position: absolute;
   right: var(--sx-space-2);
 }
 
 @media (min-width: 800px) {
-  .sx9lsuj-dtra5 {
+  .sxq7l9k-dtra5 {
     right: var(--sx-space-3);
   }
 }
 
 @media (min-width: 1100px) {
-  .sx9lsuj-dtra5 {
+  .sxq7l9k-dtra5 {
     right: var(--sx-space-4);
   }
 }
 
-.sxin7l7 {
+.sx30b1r {
   justify-content: center;
 }
 
-.sxin7l7 button {
-  background: var(--sx-colors-tonal300);
+.sx30b1r button {
+  background: var(--sx-colors-tonal200);
   border: none;
   border-radius: 50%;
   cursor: pointer;
@@ -126,11 +134,16 @@ exports[`Carousel component renders 1`] = `
   padding: var(--sx-space-1);
   height: var(--sx-space-3);
   width: var(--sx-space-3);
-  transition: all 0.25s ease-in;
+  transition: all 100ms ease-in;
 }
 
-.sxin7l7 button[class*="selected"] {
-  background: var(--sx-colors-tertiary);
+.sx30b1r button[class*="selected"] {
+  background: var(--sx-colors-primary);
+}
+
+.sx30b1r button:hover,
+.sx30b1r button:focus {
+  background: var(--sx-colors-primaryMid);
 }
 
 .sx03kze-iy5j5 {
@@ -198,13 +211,13 @@ exports[`Carousel component renders 1`] = `
     >
       <button
         aria-label="previous"
-        class="buttonBack___1mlaL carousel__back-button sx9lsuj sx9lsuj-pqx9j"
+        class="buttonBack___1mlaL carousel__back-button sxq7l9k sxq7l9k-pqx9j"
         disabled=""
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="sxtros6 sxtros6mbqqh--size-md"
+          class="sxakl60 sxakl60zozsa--size-md"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -215,12 +228,12 @@ exports[`Carousel component renders 1`] = `
       </button>
       <button
         aria-label="next"
-        class="buttonNext___2mOCa carousel__next-button sx9lsuj sx9lsuj-dtra5"
+        class="buttonNext___2mOCa carousel__next-button sxq7l9k sxq7l9k-dtra5"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="sxtros6 sxtros6mbqqh--size-md"
+          class="sxakl60 sxakl60zozsa--size-md"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -335,7 +348,7 @@ exports[`Carousel component renders 1`] = `
         </div>
       </div>
       <div
-        class="carousel__dot-group sxin7l7"
+        class="carousel__dot-group sx30b1r"
       >
         <button
           aria-label="slide dot"

--- a/src/components/checkbox-field/CheckboxField.tsx
+++ b/src/components/checkbox-field/CheckboxField.tsx
@@ -55,6 +55,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
               onChange(event.target.value !== CheckboxValue.ON)
             }}
             value={value ? CheckboxValue.ON : CheckboxValue.OFF}
+            {...(error && { state: 'error' })}
             {...remainingProps}
           />
         </InlineFieldWrapper>

--- a/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`CheckboxField component renders 1`] = `
   transform: translateY(var(--sx-space-0));
 }
 
-.sxt3cs2 {
+.sx3rpph {
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal500);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: 3px;
   color: white;
   cursor: pointer;
@@ -23,52 +23,52 @@ exports[`CheckboxField component renders 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxt3cs2[data-state="unchecked"]:focus,
-.sxt3cs2[data-state="unchecked"]:hover {
+.sx3rpph[data-state="unchecked"]:focus,
+.sx3rpph[data-state="unchecked"]:hover {
   outline: none;
 }
 
-.sxt3cs2[data-state="checked"] {
+.sx3rpph[data-state="checked"] {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxt3cs2[data-state="checked"]:hover,
-.sxt3cs2[data-state="unchecked"]:focus {
+.sx3rpph[data-state="checked"]:hover,
+.sx3rpph[data-state="unchecked"]:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxt3cs2[disabled] {
-  background-color: var(--sx-colors-tonal200);
-  border-color: var(--sx-colors-tonal400);
+.sx3rpph[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  border-color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxt3cs2:focus-within {
+.sx3rpph:focus-within {
   outline: none;
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -97,7 +97,7 @@ exports[`CheckboxField component renders 1`] = `
       class="sx03kze"
     >
       <label
-        class="sx5eeij sx5eeij8bitc--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
+        class="sxbagj1 sxbagj18bitc--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
       >
         <div
           class="sx03kze sx03kze-2grog"
@@ -110,7 +110,7 @@ exports[`CheckboxField component renders 1`] = `
           />
           <button
             aria-checked="false"
-            class="sxt3cs2"
+            class="sx3rpph"
             data-state="unchecked"
             role="checkbox"
             type="button"

--- a/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`CheckboxField component renders 1`] = `
   transform: translateY(var(--sx-space-0));
 }
 
-.sx3rpph {
+.sx8za6f {
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal300);
+  border: 1px solid var(--sx-colors-tonal400);
   border-radius: 3px;
   color: white;
   cursor: pointer;
@@ -23,30 +23,26 @@ exports[`CheckboxField component renders 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sx3rpph[data-state="unchecked"]:focus,
-.sx3rpph[data-state="unchecked"]:hover {
-  outline: none;
-}
-
-.sx3rpph[data-state="checked"] {
+.sx8za6f[data-state="checked"] {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sx3rpph[data-state="checked"]:hover,
-.sx3rpph[data-state="unchecked"]:focus {
+.sx8za6f[data-state="indeterminate"] {
+  background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
-  outline: none;
 }
 
-.sx3rpph[disabled] {
+.sx8za6f:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
+}
+
+.sx8za6f[disabled] {
   background-color: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal400);
   cursor: not-allowed;
-}
-
-.sx3rpph:focus-within {
-  outline: none;
+  color: var(--sx-colors-tonal400);
 }
 
 .sxbagj1 {
@@ -110,7 +106,7 @@ exports[`CheckboxField component renders 1`] = `
           />
           <button
             aria-checked="false"
-            class="sx3rpph"
+            class="sx8za6f"
             data-state="unchecked"
             role="checkbox"
             type="button"

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import { Icon } from '../icon'
 const StyledCheckbox = styled(RadixCheckbox.Root, {
   appearance: 'none',
   backgroundColor: 'transparent',
-  border: '1px solid $colors$tonal500',
+  border: '1px solid $colors$tonal300',
   borderRadius: '3px',
   color: 'white',
   cursor: 'pointer',
@@ -31,8 +31,8 @@ const StyledCheckbox = styled(RadixCheckbox.Root, {
     outline: 'none'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal200',
-    borderColor: '$tonal400',
+    backgroundColor: '$tonal100',
+    borderColor: '$tonal300',
     cursor: 'not-allowed'
   },
   '&:focus-within': {
@@ -45,8 +45,12 @@ type CheckboxProps = React.ComponentProps<typeof StyledCheckbox>
 const CheckboxIcon = () => (
   <Icon
     is={Ok}
-    size="xs"
-    css={{ pointerEvents: 'none', position: 'absolute', strokeWidth: '3' }}
+    css={{
+      size: '$space$3',
+      pointerEvents: 'none',
+      position: 'absolute',
+      strokeWidth: '3'
+    }}
   />
 )
 

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { Ok } from '@atom-learning/icons'
+import { Minus, Ok } from '@atom-learning/icons'
 import * as RadixCheckbox from '@radix-ui/react-checkbox'
 import * as React from 'react'
 
@@ -9,7 +9,7 @@ import { Icon } from '../icon'
 const StyledCheckbox = styled(RadixCheckbox.Root, {
   appearance: 'none',
   backgroundColor: 'transparent',
-  border: '1px solid $colors$tonal300',
+  border: '1px solid $colors$tonal400',
   borderRadius: '3px',
   color: 'white',
   cursor: 'pointer',
@@ -19,24 +19,30 @@ const StyledCheckbox = styled(RadixCheckbox.Root, {
   alignItems: 'center',
   justifyContent: 'center',
   transition: 'all 50ms ease-out',
-  '&[data-state="unchecked"]:focus, &[data-state="unchecked"]:hover': {
-    outline: 'none'
-  },
   '&[data-state="checked"]': {
     backgroundColor: '$primary',
     borderColor: '$primary'
   },
-  '&[data-state="checked"]:hover, &[data-state="unchecked"]:focus': {
-    borderColor: '$primary',
-    outline: 'none'
+  '&[data-state="indeterminate"]': {
+    backgroundColor: '$primary',
+    borderColor: '$primary'
+  },
+  '&:focus': {
+    outline: '2px solid $primary',
+    outlineOffset: '1px'
   },
   '&[disabled]': {
     backgroundColor: '$tonal100',
-    borderColor: '$tonal300',
-    cursor: 'not-allowed'
+    borderColor: '$tonal400',
+    cursor: 'not-allowed',
+    color: '$tonal400'
   },
-  '&:focus-within': {
-    outline: 'none'
+  variants: {
+    state: {
+      error: {
+        borderColor: '$danger'
+      }
+    }
   }
 })
 
@@ -53,11 +59,24 @@ const CheckboxIcon = () => (
     }}
   />
 )
+const MinusIcon = () => (
+  <Icon
+    is={Minus}
+    css={{
+      size: '$space$3',
+      pointerEvents: 'none',
+      position: 'absolute',
+      strokeWidth: '3'
+    }}
+  />
+)
 
 export const Checkbox: React.FC<CheckboxProps> = React.forwardRef(
   (props, ref) => (
     <StyledCheckbox {...props} ref={ref}>
-      <RadixCheckbox.Indicator as={CheckboxIcon} />
+      <RadixCheckbox.Indicator
+        as={props.checked === 'indeterminate' ? MinusIcon : CheckboxIcon}
+      />
     </StyledCheckbox>
   )
 )

--- a/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkbox component renders a checkbox 1`] = `
-.sxt3cs2 {
+.sx3rpph {
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal500);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: 3px;
   color: white;
   cursor: pointer;
@@ -18,29 +18,29 @@ exports[`Checkbox component renders a checkbox 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxt3cs2[data-state="unchecked"]:focus,
-.sxt3cs2[data-state="unchecked"]:hover {
+.sx3rpph[data-state="unchecked"]:focus,
+.sx3rpph[data-state="unchecked"]:hover {
   outline: none;
 }
 
-.sxt3cs2[data-state="checked"] {
+.sx3rpph[data-state="checked"] {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxt3cs2[data-state="checked"]:hover,
-.sxt3cs2[data-state="unchecked"]:focus {
+.sx3rpph[data-state="checked"]:hover,
+.sx3rpph[data-state="unchecked"]:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxt3cs2[disabled] {
-  background-color: var(--sx-colors-tonal200);
-  border-color: var(--sx-colors-tonal400);
+.sx3rpph[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  border-color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxt3cs2:focus-within {
+.sx3rpph:focus-within {
   outline: none;
 }
 
@@ -53,7 +53,7 @@ exports[`Checkbox component renders a checkbox 1`] = `
     />
     <button
       aria-checked="false"
-      class="sxt3cs2"
+      class="sx3rpph"
       data-state="unchecked"
       role="checkbox"
       title="test"

--- a/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkbox component renders a checkbox 1`] = `
-.sx3rpph {
+.sx8za6f {
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal300);
+  border: 1px solid var(--sx-colors-tonal400);
   border-radius: 3px;
   color: white;
   cursor: pointer;
@@ -18,30 +18,26 @@ exports[`Checkbox component renders a checkbox 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sx3rpph[data-state="unchecked"]:focus,
-.sx3rpph[data-state="unchecked"]:hover {
-  outline: none;
-}
-
-.sx3rpph[data-state="checked"] {
+.sx8za6f[data-state="checked"] {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sx3rpph[data-state="checked"]:hover,
-.sx3rpph[data-state="unchecked"]:focus {
+.sx8za6f[data-state="indeterminate"] {
+  background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
-  outline: none;
 }
 
-.sx3rpph[disabled] {
+.sx8za6f:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
+}
+
+.sx8za6f[disabled] {
   background-color: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal400);
   cursor: not-allowed;
-}
-
-.sx3rpph:focus-within {
-  outline: none;
+  color: var(--sx-colors-tonal400);
 }
 
 <div>
@@ -53,7 +49,7 @@ exports[`Checkbox component renders a checkbox 1`] = `
     />
     <button
       aria-checked="false"
-      class="sx3rpph"
+      class="sx8za6f"
       data-state="unchecked"
       role="checkbox"
       title="test"

--- a/src/components/combobox/ComboboxInput.tsx
+++ b/src/components/combobox/ComboboxInput.tsx
@@ -7,14 +7,14 @@ export const ComboboxInput = styled(BaseComboboxInput, {
   boxShadow: 'none', // prevent default iOS default styling
   fontSize: '$md', // prevent iOS zooming on focus
   appearance: 'none',
-  backgroundImage: encodeBackgroundIcon(theme.colors.tonal500.value, 'chevron'),
+  backgroundImage: encodeBackgroundIcon(theme.colors.tonal300.value, 'chevron'),
   backgroundPosition: 'right $space$3 top 50%, 0 0',
   backgroundRepeat: 'no-repeat, repeat',
   backgroundSize: '20px auto, 100%',
-  border: '1px solid $tonal400',
+  border: '1px solid $tonal300',
   borderRadius: '$0',
   boxSizing: 'border-box',
-  color: '$tonal800',
+  color: '$tonal500',
   cursor: 'text',
   display: 'block',
   fontFamily: '$body',
@@ -28,8 +28,8 @@ export const ComboboxInput = styled(BaseComboboxInput, {
     outline: 'none'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal300',
-    color: '$tonal700',
+    backgroundColor: '$tonal100',
+    color: '$tonal400',
     cursor: 'not-allowed'
   },
   variants: {

--- a/src/components/combobox/ComboboxInput.tsx
+++ b/src/components/combobox/ComboboxInput.tsx
@@ -14,7 +14,7 @@ export const ComboboxInput = styled(BaseComboboxInput, {
   border: '1px solid $tonal300',
   borderRadius: '$0',
   boxSizing: 'border-box',
-  color: '$tonal500',
+  color: '$tonal600',
   cursor: 'text',
   display: 'block',
   fontFamily: '$body',
@@ -23,6 +23,10 @@ export const ComboboxInput = styled(BaseComboboxInput, {
   pr: '$6',
   transition: 'all 100ms ease-out',
   width: '100%',
+  '&::placeholder': {
+    color: '$tonal300',
+    opacity: 1
+  },
   '&:focus-within': {
     borderColor: '$primary',
     outline: 'none'

--- a/src/components/combobox/ComboboxOption.tsx
+++ b/src/components/combobox/ComboboxOption.tsx
@@ -3,12 +3,12 @@ import { ComboboxOption as BaseComboboxOption } from '@reach/combobox'
 import { styled } from '~/stitches'
 
 export const ComboboxOption = styled(BaseComboboxOption, {
-  color: '$tonal800',
+  color: '$tonal500',
   cursor: 'pointer',
   m: 0,
   p: '$2',
   '&:hover, &[aria-selected="true"]': {
-    bg: '$tonal100',
+    bg: '$tonal50',
     borderRadius: '$0'
   },
   '[data-user-value]': {

--- a/src/components/combobox/ComboboxPopover.tsx
+++ b/src/components/combobox/ComboboxPopover.tsx
@@ -4,7 +4,7 @@ import { styled } from '~/stitches'
 
 export const ComboboxPopover = styled(BaseComboboxPopover, {
   bg: 'white',
-  border: 'solid 1px $tonal200',
+  border: 'solid 1px $tonal100',
   borderRadius: '$0',
   boxShadow: '$1',
   boxSizing: 'border-box',

--- a/src/components/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Combobox component renders 1`] = `
-.sxq3xso {
+.sxpdrdd {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -13,7 +13,7 @@ exports[`Combobox component renders 1`] = `
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -24,12 +24,17 @@ exports[`Combobox component renders 1`] = `
   width: 100%;
 }
 
-.sxq3xso:focus-within {
+.sxpdrdd::placeholder {
+  color: var(--sx-colors-tonal300);
+  opacity: 1;
+}
+
+.sxpdrdd:focus-within {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq3xso[disabled] {
+.sxpdrdd[disabled] {
   background-color: var(--sx-colors-tonal100);
   color: var(--sx-colors-tonal400);
   cursor: not-allowed;
@@ -85,7 +90,7 @@ exports[`Combobox component renders 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Favourite fruit"
-      class="sxq3xso"
+      class="sxpdrdd"
       data-reach-combobox-input=""
       data-state="idle"
       id="fruit"

--- a/src/components/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Combobox component renders 1`] = `
-.sx3x2hs {
+.sxq3xso {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -10,10 +10,10 @@ exports[`Combobox component renders 1`] = `
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-repeat: no-repeat, repeat;
   background-size: 20px auto, 100%;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -24,14 +24,14 @@ exports[`Combobox component renders 1`] = `
   width: 100%;
 }
 
-.sx3x2hs:focus-within {
+.sxq3xso:focus-within {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx3x2hs[disabled] {
-  background-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal700);
+.sxq3xso[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
@@ -43,26 +43,26 @@ exports[`Combobox component renders 1`] = `
   user-select: none;
 }
 
-.sx9xqc6 {
-  color: var(--sx-colors-tonal800);
+.sxv968g {
+  color: var(--sx-colors-tonal500);
   cursor: pointer;
   margin: 0;
   padding: var(--sx-space-2);
 }
 
-.sx9xqc6:hover,
-.sx9xqc6[aria-selected="true"] {
-  background: var(--sx-colors-tonal100);
+.sxv968g:hover,
+.sxv968g[aria-selected="true"] {
+  background: var(--sx-colors-tonal50);
   border-radius: var(--sx-radii-0);
 }
 
-.sx9xqc6 [data-user-value] {
+.sxv968g [data-user-value] {
   color: var(--sx-colors-primary);
 }
 
-.sx18r6s {
+.sxg4zfd {
   background: white;
-  border: solid 1px var(--sx-colors-tonal200);
+  border: solid 1px var(--sx-colors-tonal100);
   border-radius: var(--sx-radii-0);
   box-shadow: var(--sx-shadows-1);
   box-sizing: border-box;
@@ -85,7 +85,7 @@ exports[`Combobox component renders 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Favourite fruit"
-      class="sx3x2hs"
+      class="sxq3xso"
       data-reach-combobox-input=""
       data-state="idle"
       id="fruit"

--- a/src/components/divider/Divider.tsx
+++ b/src/components/divider/Divider.tsx
@@ -2,7 +2,7 @@ import { styled } from '~/stitches'
 
 export const Divider = styled('hr', {
   border: 0,
-  borderTop: '1px solid $tonal400',
+  borderTop: '1px solid $tonal200',
   mx: 'auto',
   width: '50%'
 })

--- a/src/components/divider/__snapshots__/Divider.test.tsx.snap
+++ b/src/components/divider/__snapshots__/Divider.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Divider component renders 1`] = `
-.sx95fm0 {
+.sxlgf7o {
   border: 0;
-  border-top: 1px solid var(--sx-colors-tonal400);
+  border-top: 1px solid var(--sx-colors-tonal200);
   margin-left: auto;
   margin-right: auto;
   width: 50%;
@@ -11,7 +11,7 @@ exports[`Divider component renders 1`] = `
 
 <div>
   <hr
-    class="sx95fm0"
+    class="sxlgf7o"
   />
 </div>
 `;

--- a/src/components/field-wrapper/FieldWrapper.tsx
+++ b/src/components/field-wrapper/FieldWrapper.tsx
@@ -46,7 +46,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
       )}
     </Flex>
     {description && (
-      <Text size="sm" css={{ color: '$tonal500', mb: '$3', maxWidth: '80ch' }}>
+      <Text size="sm" css={{ color: '$tonal300', mb: '$3', maxWidth: '80ch' }}>
         {description}
       </Text>
     )}

--- a/src/components/field-wrapper/InlineFieldWrapper.tsx
+++ b/src/components/field-wrapper/InlineFieldWrapper.tsx
@@ -67,7 +67,7 @@ export const InlineFieldWrapper: React.FC<InlineFieldWrapperProps> = ({
       <Text
         size="sm"
         css={{
-          color: '$tonal500',
+          color: '$tonal300',
           mt: '$2',
           [direction === 'reverse' ? 'mr' : 'ml']: 'calc($space$3 + $sizes$1)', // calc required to get correct offset value
           maxWidth: '80ch'

--- a/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FieldWrapper component renders 1`] = `
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -18,18 +18,24 @@ exports[`FieldWrapper component renders 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
@@ -50,61 +56,61 @@ exports[`FieldWrapper component renders 1`] = `
   margin-top: var(--sx-space-2);
 }
 
-.sxj1d4e {
-  color: var(--sx-colors-tonal800);
+.sxyn8hn {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxj1d4eid6h2--size-sm {
+.sxyn8hnid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxj1d4eid6h2--size-sm::before {
+.sxyn8hnid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxj1d4eid6h2--size-sm::after {
+.sxyn8hnid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxj1d4e-n4ol9 {
+.sxyn8hn-n4ol9 {
   color: inherit;
   transform: translateY(var(--sx-space-1));
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxlc3or {
+.sxlyjic {
   background: unset;
   border: unset;
   padding: unset;
@@ -114,65 +120,65 @@ exports[`FieldWrapper component renders 1`] = `
   text-decoration: none;
 }
 
-.sxlc3or:focus,
-.sxlc3or:hover {
-  color: var(--sx-colors-tertiary);
+.sxlyjic:focus,
+.sxlyjic:hover {
+  color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlc3or:active {
-  color: var(--sx-colors-primary);
+.sxlyjic:active {
+  color: var(--sx-colors-primaryDark);
 }
 
-.sxj1d4e > .sxlc3or,
-.sxh1zwe > .sxlc3or,
-.sx03kze > .sxlc3or {
+.sxyn8hn > .sxlyjic,
+.sxlk8sk > .sxlyjic,
+.sx03kze > .sxlyjic {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxj1d4e > .sxlc3or::before,
-.sxj1d4e > .sxlc3or::after,
-.sxh1zwe > .sxlc3or::before,
-.sxh1zwe > .sxlc3or::after,
-.sx03kze > .sxlc3or::before,
-.sx03kze > .sxlc3or::after {
+.sxyn8hn > .sxlyjic::before,
+.sxyn8hn > .sxlyjic::after,
+.sxlk8sk > .sxlyjic::before,
+.sxlk8sk > .sxlyjic::after,
+.sx03kze > .sxlyjic::before,
+.sx03kze > .sxlyjic::after {
   content: none;
 }
 
-.sxlc3orid6h2--size-sm {
+.sxlyjicid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxlc3orid6h2--size-sm::before {
+.sxlyjicid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxlc3orid6h2--size-sm::after {
+.sxlyjicid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6or94y--size-sm {
+.sxakl60op5z4--size-sm {
   height: var(--sx-sizes-1);
   width: var(--sx-sizes-1);
+  stroke-width: 1.75;
 }
 
-.sxtros6-iux96 {
+.sxakl60-iux96 {
   margin-right: var(--sx-space-2);
   flex-shrink: 0;
 }
@@ -185,20 +191,20 @@ exports[`FieldWrapper component renders 1`] = `
       class="sx2cs53 sx2cs53-qom1k"
     >
       <label
-        class="sx5eeij sx5eeij8bitc--size-md"
+        class="sxbagj1 sxbagj18bitc--size-md"
         for="example"
       >
         Example Field
       </label>
       <a
-        class="sxlc3or sxlc3orid6h2--size-sm"
+        class="sxlyjic sxlyjicid6h2--size-sm"
         href="https://example.com"
       >
         Example prompt
       </a>
     </div>
     <input
-      class="sx1s1jh sx1s1jhpw03g--size-md"
+      class="sxtvycl sxtvyclpw03g--size-md"
       id="example"
       name="example"
       type="text"
@@ -208,7 +214,7 @@ exports[`FieldWrapper component renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="sxtros6 sxtros6or94y--size-sm sxtros6-iux96"
+        class="sxakl60 sxakl60op5z4--size-sm sxakl60-iux96"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -228,7 +234,7 @@ exports[`FieldWrapper component renders 1`] = `
         />
       </svg>
       <p
-        class="sxj1d4e sxj1d4eid6h2--size-sm sxj1d4e-n4ol9"
+        class="sxyn8hn sxyn8hnid6h2--size-sm sxyn8hn-n4ol9"
       >
         Example error
       </p>

--- a/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FieldWrapper component renders 1`] = `
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -18,24 +18,23 @@ exports[`FieldWrapper component renders 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
@@ -56,31 +55,31 @@ exports[`FieldWrapper component renders 1`] = `
   margin-top: var(--sx-space-2);
 }
 
-.sxyn8hn {
-  color: var(--sx-colors-tonal500);
+.sx8yt8k {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxyn8hnid6h2--size-sm {
+.sx8yt8kid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxyn8hnid6h2--size-sm::before {
+.sx8yt8kid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxyn8hnid6h2--size-sm::after {
+.sx8yt8kid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxyn8hn-n4ol9 {
+.sx8yt8k-n4ol9 {
   color: inherit;
   transform: translateY(var(--sx-space-1));
 }
@@ -110,7 +109,7 @@ exports[`FieldWrapper component renders 1`] = `
   display: table;
 }
 
-.sxlyjic {
+.sxi05ns {
   background: unset;
   border: unset;
   padding: unset;
@@ -120,44 +119,44 @@ exports[`FieldWrapper component renders 1`] = `
   text-decoration: none;
 }
 
-.sxlyjic:focus,
-.sxlyjic:hover {
+.sxi05ns:focus,
+.sxi05ns:hover {
   color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlyjic:active {
+.sxi05ns:active {
   color: var(--sx-colors-primaryDark);
 }
 
-.sxyn8hn > .sxlyjic,
-.sxlk8sk > .sxlyjic,
-.sx03kze > .sxlyjic {
+.sx8yt8k > .sxi05ns,
+.sx8wio2 > .sxi05ns,
+.sx03kze > .sxi05ns {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxyn8hn > .sxlyjic::before,
-.sxyn8hn > .sxlyjic::after,
-.sxlk8sk > .sxlyjic::before,
-.sxlk8sk > .sxlyjic::after,
-.sx03kze > .sxlyjic::before,
-.sx03kze > .sxlyjic::after {
+.sx8yt8k > .sxi05ns::before,
+.sx8yt8k > .sxi05ns::after,
+.sx8wio2 > .sxi05ns::before,
+.sx8wio2 > .sxi05ns::after,
+.sx03kze > .sxi05ns::before,
+.sx03kze > .sxi05ns::after {
   content: none;
 }
 
-.sxlyjicid6h2--size-sm {
+.sxi05nsid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxlyjicid6h2--size-sm::before {
+.sxi05nsid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxlyjicid6h2--size-sm::after {
+.sxi05nsid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
@@ -197,14 +196,14 @@ exports[`FieldWrapper component renders 1`] = `
         Example Field
       </label>
       <a
-        class="sxlyjic sxlyjicid6h2--size-sm"
+        class="sxi05ns sxi05nsid6h2--size-sm"
         href="https://example.com"
       >
         Example prompt
       </a>
     </div>
     <input
-      class="sxtvycl sxtvyclpw03g--size-md"
+      class="sx7g9w1 sx7g9w1pw03g--size-md"
       id="example"
       name="example"
       type="text"
@@ -234,7 +233,7 @@ exports[`FieldWrapper component renders 1`] = `
         />
       </svg>
       <p
-        class="sxyn8hn sxyn8hnid6h2--size-sm sxyn8hn-n4ol9"
+        class="sx8yt8k sx8yt8kid6h2--size-sm sx8yt8k-n4ol9"
       >
         Example error
       </p>

--- a/src/components/heading/Heading.tsx
+++ b/src/components/heading/Heading.tsx
@@ -4,7 +4,7 @@ import { styled } from '~/stitches'
 import { capsize, Override } from '~/utilities'
 
 export const StyledHeading = styled('h2', {
-  color: '$tonal500',
+  color: '$tonal600',
   fontFamily: '$display',
   fontWeight: 700,
   m: 0,

--- a/src/components/heading/Heading.tsx
+++ b/src/components/heading/Heading.tsx
@@ -4,7 +4,7 @@ import { styled } from '~/stitches'
 import { capsize, Override } from '~/utilities'
 
 export const StyledHeading = styled('h2', {
-  color: '$tonal800',
+  color: '$tonal500',
   fontFamily: '$display',
   fontWeight: 700,
   m: 0,

--- a/src/components/heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/heading/__snapshots__/Heading.test.tsx.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Heading component renders a heading 1`] = `
-.sxh1zwe {
-  color: var(--sx-colors-tonal800);
+.sxlk8sk {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-display);
   font-weight: 700;
   margin: 0;
 }
 
-.sxh1zwe9zj0i--size-md {
+.sxlk8sk9zj0i--size-md {
   font-size: var(--sx-fontSizes-xl);
   line-height: 1.14;
 }
 
-.sxh1zwe9zj0i--size-md::before {
+.sxlk8sk9zj0i--size-md::before {
   content: '';
   margin-bottom: -0.2174em;
   display: table;
 }
 
-.sxh1zwe9zj0i--size-md::after {
+.sxlk8sk9zj0i--size-md::after {
   content: '';
   margin-top: -0.2254em;
   display: table;
@@ -27,7 +27,7 @@ exports[`Heading component renders a heading 1`] = `
 
 <div>
   <h2
-    class="sxh1zwe sxh1zwe9zj0i--size-md"
+    class="sxlk8sk sxlk8sk9zj0i--size-md"
   >
     HEADING
   </h2>

--- a/src/components/heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/heading/__snapshots__/Heading.test.tsx.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Heading component renders a heading 1`] = `
-.sxlk8sk {
-  color: var(--sx-colors-tonal500);
+.sx8wio2 {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-display);
   font-weight: 700;
   margin: 0;
 }
 
-.sxlk8sk9zj0i--size-md {
+.sx8wio29zj0i--size-md {
   font-size: var(--sx-fontSizes-xl);
   line-height: 1.14;
 }
 
-.sxlk8sk9zj0i--size-md::before {
+.sx8wio29zj0i--size-md::before {
   content: '';
   margin-bottom: -0.2174em;
   display: table;
 }
 
-.sxlk8sk9zj0i--size-md::after {
+.sx8wio29zj0i--size-md::after {
   content: '';
   margin-top: -0.2254em;
   display: table;
@@ -27,7 +27,7 @@ exports[`Heading component renders a heading 1`] = `
 
 <div>
   <h2
-    class="sxlk8sk sxlk8sk9zj0i--size-md"
+    class="sx8wio2 sx8wio29zj0i--size-md"
   >
     HEADING
   </h2>

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -9,14 +9,12 @@ const StyledIcon = styled('svg', {
   stroke: 'currentcolor',
   strokeLinecap: 'round',
   strokeLinejoin: 'round',
-  strokeWidth: '2',
   verticalAlign: 'middle',
   variants: {
     size: {
-      xs: { size: '$space$3' },
-      sm: { size: '$1' },
-      md: { size: '$2' },
-      lg: { size: '$3' }
+      sm: { size: '$1', strokeWidth: '1.75' },
+      md: { size: '$2', strokeWidth: '2' },
+      lg: { size: '$3', strokeWidth: '2' }
     }
   }
 })

--- a/src/components/icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/Icon.test.tsx.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Icon component renders an icon 1`] = `
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6mbqqh--size-md {
+.sxakl60zozsa--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
 <div>
   <svg
     aria-hidden="true"
-    class="sxtros6 sxtros6mbqqh--size-md"
+    class="sxakl60 sxakl60zozsa--size-md"
     title="check"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -43,31 +43,31 @@ exports[`InputField component renders a field in error state 1`] = `
   margin-top: var(--sx-space-2);
 }
 
-.sxyn8hn {
-  color: var(--sx-colors-tonal500);
+.sx8yt8k {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxyn8hnid6h2--size-sm {
+.sx8yt8kid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxyn8hnid6h2--size-sm::before {
+.sx8yt8kid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxyn8hnid6h2--size-sm::after {
+.sx8yt8kid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxyn8hn-n4ol9 {
+.sx8yt8k-n4ol9 {
   color: inherit;
   transform: translateY(var(--sx-space-1));
 }
@@ -102,14 +102,14 @@ exports[`InputField component renders a field in error state 1`] = `
   margin-left: var(--sx-space-1);
 }
 
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -119,29 +119,28 @@ exports[`InputField component renders a field in error state 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sxtvyclhpnso--state-error {
+.sx7g9w1hpnso--state-error {
   border: 1px solid var(--sx-colors-danger);
 }
 
@@ -169,7 +168,7 @@ exports[`InputField component renders a field in error state 1`] = `
         </label>
       </div>
       <input
-        class="sxtvycl sxtvyclpw03g--size-md sxtvyclhpnso--state-error"
+        class="sx7g9w1 sx7g9w1pw03g--size-md sx7g9w1hpnso--state-error"
         id="INPUT FIELD"
         name="INPUT FIELD"
         type="text"
@@ -199,7 +198,7 @@ exports[`InputField component renders a field in error state 1`] = `
           />
         </svg>
         <p
-          class="sxyn8hn sxyn8hnid6h2--size-sm sxyn8hn-n4ol9"
+          class="sx8yt8k sx8yt8kid6h2--size-sm sx8yt8k-n4ol9"
         >
           This field is required
         </p>
@@ -256,14 +255,14 @@ exports[`InputField component renders a field with a number input 1`] = `
   display: table;
 }
 
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -273,24 +272,23 @@ exports[`InputField component renders a field with a number input 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
@@ -314,7 +312,7 @@ exports[`InputField component renders a field with a number input 1`] = `
         </label>
       </div>
       <input
-        class="sxtvycl sxtvyclpw03g--size-md"
+        class="sx7g9w1 sx7g9w1pw03g--size-md"
         id="INPUT FIELD"
         inputmode="numeric"
         name="INPUT FIELD"
@@ -369,14 +367,14 @@ exports[`InputField component renders a field with a text input 1`] = `
   display: table;
 }
 
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -386,24 +384,23 @@ exports[`InputField component renders a field with a text input 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
@@ -427,7 +424,7 @@ exports[`InputField component renders a field with a text input 1`] = `
         </label>
       </div>
       <input
-        class="sxtvycl sxtvyclpw03g--size-md"
+        class="sx7g9w1 sx7g9w1pw03g--size-md"
         id="INPUT FIELD"
         name="INPUT FIELD"
         placeholder="INPUT FIELD"

--- a/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -7,22 +7,22 @@ exports[`InputField component renders a field in error state 1`] = `
   width: 100px;
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6or94y--size-sm {
+.sxakl60op5z4--size-sm {
   height: var(--sx-sizes-1);
   width: var(--sx-sizes-1);
+  stroke-width: 1.75;
 }
 
-.sxtros6-iux96 {
+.sxakl60-iux96 {
   margin-right: var(--sx-space-2);
   flex-shrink: 0;
 }
@@ -43,55 +43,55 @@ exports[`InputField component renders a field in error state 1`] = `
   margin-top: var(--sx-space-2);
 }
 
-.sxj1d4e {
-  color: var(--sx-colors-tonal800);
+.sxyn8hn {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxj1d4eid6h2--size-sm {
+.sxyn8hnid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxj1d4eid6h2--size-sm::before {
+.sxyn8hnid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxj1d4eid6h2--size-sm::after {
+.sxyn8hnid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxj1d4e-n4ol9 {
+.sxyn8hn-n4ol9 {
   color: inherit;
   transform: translateY(var(--sx-space-1));
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -102,14 +102,14 @@ exports[`InputField component renders a field in error state 1`] = `
   margin-left: var(--sx-space-1);
 }
 
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -119,23 +119,29 @@ exports[`InputField component renders a field in error state 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sx1s1jhhpnso--state-error {
+.sxtvyclhpnso--state-error {
   border: 1px solid var(--sx-colors-danger);
 }
 
@@ -151,7 +157,7 @@ exports[`InputField component renders a field in error state 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="INPUT FIELD"
         >
           INPUT FIELD
@@ -163,7 +169,7 @@ exports[`InputField component renders a field in error state 1`] = `
         </label>
       </div>
       <input
-        class="sx1s1jh sx1s1jhpw03g--size-md sx1s1jhhpnso--state-error"
+        class="sxtvycl sxtvyclpw03g--size-md sxtvyclhpnso--state-error"
         id="INPUT FIELD"
         name="INPUT FIELD"
         type="text"
@@ -173,7 +179,7 @@ exports[`InputField component renders a field in error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="sxtros6 sxtros6or94y--size-sm sxtros6-iux96"
+          class="sxakl60 sxakl60op5z4--size-sm sxakl60-iux96"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -193,7 +199,7 @@ exports[`InputField component renders a field in error state 1`] = `
           />
         </svg>
         <p
-          class="sxj1d4e sxj1d4eid6h2--size-sm sxj1d4e-n4ol9"
+          class="sxyn8hn sxyn8hnid6h2--size-sm sxyn8hn-n4ol9"
         >
           This field is required
         </p>
@@ -225,39 +231,39 @@ exports[`InputField component renders a field with a number input 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -267,18 +273,24 @@ exports[`InputField component renders a field with a number input 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
@@ -295,14 +307,14 @@ exports[`InputField component renders a field with a number input 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="INPUT FIELD"
         >
           INPUT FIELD
         </label>
       </div>
       <input
-        class="sx1s1jh sx1s1jhpw03g--size-md"
+        class="sxtvycl sxtvyclpw03g--size-md"
         id="INPUT FIELD"
         inputmode="numeric"
         name="INPUT FIELD"
@@ -332,39 +344,39 @@ exports[`InputField component renders a field with a text input 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -374,18 +386,24 @@ exports[`InputField component renders a field with a text input 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
@@ -402,14 +420,14 @@ exports[`InputField component renders a field with a text input 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="INPUT FIELD"
         >
           INPUT FIELD
         </label>
       </div>
       <input
-        class="sx1s1jh sx1s1jhpw03g--size-md"
+        class="sxtvycl sxtvyclpw03g--size-md"
         id="INPUT FIELD"
         name="INPUT FIELD"
         placeholder="INPUT FIELD"

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -9,7 +9,7 @@ const StyledInput = styled('input', {
   borderRadius: '$0',
   boxShadow: 'none', // prevent default iOS default styling
   boxSizing: 'border-box',
-  color: '$tonal800',
+  color: '$tonal500',
   cursor: 'text',
   display: 'block',
   fontFamily: '$body',
@@ -21,9 +21,14 @@ const StyledInput = styled('input', {
     outline: 'none'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal100',
-    color: '$tonal600',
+    backgroundColor: '$tonal50',
+    borderColor: '$tonal300',
+    color: '$tonal300',
     cursor: 'not-allowed'
+  },
+  '&::placeholder': {
+    color: '$tonal200',
+    opacity: 1
   },
   variants: {
     size: {

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -9,7 +9,7 @@ const StyledInput = styled('input', {
   borderRadius: '$0',
   boxShadow: 'none', // prevent default iOS default styling
   boxSizing: 'border-box',
-  color: '$tonal500',
+  color: '$tonal600',
   cursor: 'text',
   display: 'block',
   fontFamily: '$body',
@@ -21,13 +21,12 @@ const StyledInput = styled('input', {
     outline: 'none'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal50',
-    borderColor: '$tonal300',
-    color: '$tonal300',
+    backgroundColor: '$tonal100',
+    color: '$tonal400',
     cursor: 'not-allowed'
   },
   '&::placeholder': {
-    color: '$tonal200',
+    color: '$tonal300',
     opacity: 1
   },
   variants: {

--- a/src/components/input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/input/__snapshots__/Input.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Input component renders a number input 1`] = `
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -18,23 +18,29 @@ exports[`Input component renders a number input 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sx1s1jh-6obnf {
+.sxtvycl-6obnf {
   margin: auto;
   height: 100px;
   width: 100px;
@@ -42,7 +48,7 @@ exports[`Input component renders a number input 1`] = `
 
 <div>
   <input
-    class="sx1s1jh sx1s1jhpw03g--size-md sx1s1jh-6obnf"
+    class="sxtvycl sxtvyclpw03g--size-md sxtvycl-6obnf"
     inputmode="numeric"
     pattern="[0-9]*"
     placeholder="001"
@@ -52,14 +58,14 @@ exports[`Input component renders a number input 1`] = `
 `;
 
 exports[`Input component renders a text input 1`] = `
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -69,23 +75,29 @@ exports[`Input component renders a text input 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sx1s1jh-6obnf {
+.sxtvycl-6obnf {
   margin: auto;
   height: 100px;
   width: 100px;
@@ -93,7 +105,7 @@ exports[`Input component renders a text input 1`] = `
 
 <div>
   <input
-    class="sx1s1jh sx1s1jhpw03g--size-md sx1s1jh-6obnf"
+    class="sxtvycl sxtvyclpw03g--size-md sxtvycl-6obnf"
     placeholder="INPUT"
     type="text"
   />

--- a/src/components/input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/input/__snapshots__/Input.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Input component renders a number input 1`] = `
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -18,29 +18,28 @@ exports[`Input component renders a number input 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sxtvycl-6obnf {
+.sx7g9w1-6obnf {
   margin: auto;
   height: 100px;
   width: 100px;
@@ -48,7 +47,7 @@ exports[`Input component renders a number input 1`] = `
 
 <div>
   <input
-    class="sxtvycl sxtvyclpw03g--size-md sxtvycl-6obnf"
+    class="sx7g9w1 sx7g9w1pw03g--size-md sx7g9w1-6obnf"
     inputmode="numeric"
     pattern="[0-9]*"
     placeholder="001"
@@ -58,14 +57,14 @@ exports[`Input component renders a number input 1`] = `
 `;
 
 exports[`Input component renders a text input 1`] = `
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -75,29 +74,28 @@ exports[`Input component renders a text input 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sxtvycl-6obnf {
+.sx7g9w1-6obnf {
   margin: auto;
   height: 100px;
   width: 100px;
@@ -105,7 +103,7 @@ exports[`Input component renders a text input 1`] = `
 
 <div>
   <input
-    class="sxtvycl sxtvyclpw03g--size-md sxtvycl-6obnf"
+    class="sx7g9w1 sx7g9w1pw03g--size-md sx7g9w1-6obnf"
     placeholder="INPUT"
     type="text"
   />

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -7,7 +7,7 @@ import { textVariantSize } from '../text'
 const { sm, md } = textVariantSize()
 
 const StyledLabel = styled('label', {
-  color: '$tonal800',
+  color: '$tonal500',
   display: 'block',
   fontFamily: '$body',
   fontWeight: 600,

--- a/src/components/label/__snapshots__/Label.test.tsx.snap
+++ b/src/components/label/__snapshots__/Label.test.tsx.snap
@@ -1,26 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Label component renders a label 1`] = `
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -28,7 +28,7 @@ exports[`Label component renders a label 1`] = `
 
 <div>
   <label
-    class="sx5eeij sx5eeij8bitc--size-md"
+    class="sxbagj1 sxbagj18bitc--size-md"
   >
     TEXT
   </label>

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -17,11 +17,11 @@ export const StyledLink = styled('a', {
   fontFamily: '$body',
   textDecoration: 'none',
   '&:focus, &:hover': {
-    color: '$tertiary',
+    color: '$primaryMid',
     textDecoration: 'underline'
   },
   '&:active': {
-    color: '$primary'
+    color: '$primaryDark'
   },
   [`${StyledParagraph} > &, ${StyledHeading} > &, ${StyledLi} > &`]: {
     fontSize: '100%',
@@ -44,7 +44,9 @@ type LinkProps = Override<
 
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   ({ size = 'md', onClick, href, ...remainingProps }, ref) =>
-    onClick ? (
+    href ? (
+      <StyledLink size={size} {...remainingProps} ref={ref} href={href} />
+    ) : (
       <StyledLink
         as="button"
         size={size}
@@ -52,8 +54,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         ref={ref}
         onClick={onClick}
       />
-    ) : (
-      <StyledLink size={size} {...remainingProps} ref={ref} href={href} />
     )
 ) as React.FC<LinkProps>
 

--- a/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Link component renders an anchor 1`] = `
-.sxlyjic {
+.sxi05ns {
   background: unset;
   border: unset;
   padding: unset;
@@ -11,44 +11,44 @@ exports[`Link component renders an anchor 1`] = `
   text-decoration: none;
 }
 
-.sxlyjic:focus,
-.sxlyjic:hover {
+.sxi05ns:focus,
+.sxi05ns:hover {
   color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlyjic:active {
+.sxi05ns:active {
   color: var(--sx-colors-primaryDark);
 }
 
-.sxyn8hn > .sxlyjic,
-.sxlk8sk > .sxlyjic,
-.sx03kze > .sxlyjic {
+.sx8yt8k > .sxi05ns,
+.sx8wio2 > .sxi05ns,
+.sx03kze > .sxi05ns {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxyn8hn > .sxlyjic::before,
-.sxyn8hn > .sxlyjic::after,
-.sxlk8sk > .sxlyjic::before,
-.sxlk8sk > .sxlyjic::after,
-.sx03kze > .sxlyjic::before,
-.sx03kze > .sxlyjic::after {
+.sx8yt8k > .sxi05ns::before,
+.sx8yt8k > .sxi05ns::after,
+.sx8wio2 > .sxi05ns::before,
+.sx8wio2 > .sxi05ns::after,
+.sx03kze > .sxi05ns::before,
+.sx03kze > .sxi05ns::after {
   content: none;
 }
 
-.sxlyjic8bitc--size-md {
+.sxi05ns8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlyjic8bitc--size-md::before {
+.sxi05ns8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlyjic8bitc--size-md::after {
+.sxi05ns8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -56,7 +56,7 @@ exports[`Link component renders an anchor 1`] = `
 
 <div>
   <a
-    class="sxlyjic sxlyjic8bitc--size-md"
+    class="sxi05ns sxi05ns8bitc--size-md"
     href="https://google.com/"
   >
     GOOGLE
@@ -65,7 +65,7 @@ exports[`Link component renders an anchor 1`] = `
 `;
 
 exports[`Link component renders an large anchor 1`] = `
-.sxlyjic {
+.sxi05ns {
   background: unset;
   border: unset;
   padding: unset;
@@ -75,61 +75,61 @@ exports[`Link component renders an large anchor 1`] = `
   text-decoration: none;
 }
 
-.sxlyjic:focus,
-.sxlyjic:hover {
+.sxi05ns:focus,
+.sxi05ns:hover {
   color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlyjic:active {
+.sxi05ns:active {
   color: var(--sx-colors-primaryDark);
 }
 
-.sxyn8hn > .sxlyjic,
-.sxlk8sk > .sxlyjic,
-.sx03kze > .sxlyjic {
+.sx8yt8k > .sxi05ns,
+.sx8wio2 > .sxi05ns,
+.sx03kze > .sxi05ns {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxyn8hn > .sxlyjic::before,
-.sxyn8hn > .sxlyjic::after,
-.sxlk8sk > .sxlyjic::before,
-.sxlk8sk > .sxlyjic::after,
-.sx03kze > .sxlyjic::before,
-.sx03kze > .sxlyjic::after {
+.sx8yt8k > .sxi05ns::before,
+.sx8yt8k > .sxi05ns::after,
+.sx8wio2 > .sxi05ns::before,
+.sx8wio2 > .sxi05ns::after,
+.sx03kze > .sxi05ns::before,
+.sx03kze > .sxi05ns::after {
   content: none;
 }
 
-.sxlyjic8bitc--size-md {
+.sxi05ns8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlyjic8bitc--size-md::before {
+.sxi05ns8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlyjic8bitc--size-md::after {
+.sxi05ns8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxlyjicpfvfy--size-lg {
+.sxi05nspfvfy--size-lg {
   font-size: var(--sx-fontSizes-lg);
   line-height: 1.52;
 }
 
-.sxlyjicpfvfy--size-lg::before {
+.sxi05nspfvfy--size-lg::before {
   content: '';
   margin-bottom: -0.3983em;
   display: table;
 }
 
-.sxlyjicpfvfy--size-lg::after {
+.sxi05nspfvfy--size-lg::after {
   content: '';
   margin-top: -0.3983em;
   display: table;
@@ -137,7 +137,7 @@ exports[`Link component renders an large anchor 1`] = `
 
 <div>
   <a
-    class="sxlyjic sxlyjicpfvfy--size-lg"
+    class="sxi05ns sxi05nspfvfy--size-lg"
     href="https://google.com/"
   >
     GOOGLE

--- a/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Link component renders an anchor 1`] = `
-.sxlc3or {
+.sxlyjic {
   background: unset;
   border: unset;
   padding: unset;
@@ -11,44 +11,44 @@ exports[`Link component renders an anchor 1`] = `
   text-decoration: none;
 }
 
-.sxlc3or:focus,
-.sxlc3or:hover {
-  color: var(--sx-colors-tertiary);
+.sxlyjic:focus,
+.sxlyjic:hover {
+  color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlc3or:active {
-  color: var(--sx-colors-primary);
+.sxlyjic:active {
+  color: var(--sx-colors-primaryDark);
 }
 
-.sxj1d4e > .sxlc3or,
-.sxh1zwe > .sxlc3or,
-.sx03kze > .sxlc3or {
+.sxyn8hn > .sxlyjic,
+.sxlk8sk > .sxlyjic,
+.sx03kze > .sxlyjic {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxj1d4e > .sxlc3or::before,
-.sxj1d4e > .sxlc3or::after,
-.sxh1zwe > .sxlc3or::before,
-.sxh1zwe > .sxlc3or::after,
-.sx03kze > .sxlc3or::before,
-.sx03kze > .sxlc3or::after {
+.sxyn8hn > .sxlyjic::before,
+.sxyn8hn > .sxlyjic::after,
+.sxlk8sk > .sxlyjic::before,
+.sxlk8sk > .sxlyjic::after,
+.sx03kze > .sxlyjic::before,
+.sx03kze > .sxlyjic::after {
   content: none;
 }
 
-.sxlc3or8bitc--size-md {
+.sxlyjic8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlc3or8bitc--size-md::before {
+.sxlyjic8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlc3or8bitc--size-md::after {
+.sxlyjic8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -56,7 +56,7 @@ exports[`Link component renders an anchor 1`] = `
 
 <div>
   <a
-    class="sxlc3or sxlc3or8bitc--size-md"
+    class="sxlyjic sxlyjic8bitc--size-md"
     href="https://google.com/"
   >
     GOOGLE
@@ -65,7 +65,7 @@ exports[`Link component renders an anchor 1`] = `
 `;
 
 exports[`Link component renders an large anchor 1`] = `
-.sxlc3or {
+.sxlyjic {
   background: unset;
   border: unset;
   padding: unset;
@@ -75,61 +75,61 @@ exports[`Link component renders an large anchor 1`] = `
   text-decoration: none;
 }
 
-.sxlc3or:focus,
-.sxlc3or:hover {
-  color: var(--sx-colors-tertiary);
+.sxlyjic:focus,
+.sxlyjic:hover {
+  color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlc3or:active {
-  color: var(--sx-colors-primary);
+.sxlyjic:active {
+  color: var(--sx-colors-primaryDark);
 }
 
-.sxj1d4e > .sxlc3or,
-.sxh1zwe > .sxlc3or,
-.sx03kze > .sxlc3or {
+.sxyn8hn > .sxlyjic,
+.sxlk8sk > .sxlyjic,
+.sx03kze > .sxlyjic {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxj1d4e > .sxlc3or::before,
-.sxj1d4e > .sxlc3or::after,
-.sxh1zwe > .sxlc3or::before,
-.sxh1zwe > .sxlc3or::after,
-.sx03kze > .sxlc3or::before,
-.sx03kze > .sxlc3or::after {
+.sxyn8hn > .sxlyjic::before,
+.sxyn8hn > .sxlyjic::after,
+.sxlk8sk > .sxlyjic::before,
+.sxlk8sk > .sxlyjic::after,
+.sx03kze > .sxlyjic::before,
+.sx03kze > .sxlyjic::after {
   content: none;
 }
 
-.sxlc3or8bitc--size-md {
+.sxlyjic8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlc3or8bitc--size-md::before {
+.sxlyjic8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlc3or8bitc--size-md::after {
+.sxlyjic8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxlc3orpfvfy--size-lg {
+.sxlyjicpfvfy--size-lg {
   font-size: var(--sx-fontSizes-lg);
   line-height: 1.52;
 }
 
-.sxlc3orpfvfy--size-lg::before {
+.sxlyjicpfvfy--size-lg::before {
   content: '';
   margin-bottom: -0.3983em;
   display: table;
 }
 
-.sxlc3orpfvfy--size-lg::after {
+.sxlyjicpfvfy--size-lg::after {
   content: '';
   margin-top: -0.3983em;
   display: table;
@@ -137,7 +137,7 @@ exports[`Link component renders an large anchor 1`] = `
 
 <div>
   <a
-    class="sxlc3or sxlc3orpfvfy--size-lg"
+    class="sxlyjic sxlyjicpfvfy--size-lg"
     href="https://google.com/"
   >
     GOOGLE

--- a/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -1,40 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MarkdownContent component renders 1`] = `
-.sxyn8hn {
-  color: var(--sx-colors-tonal500);
+.sx8yt8k {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxyn8hn8bitc--size-md {
+.sx8yt8k8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxyn8hn8bitc--size-md::before {
+.sx8yt8k8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxyn8hn8bitc--size-md::after {
+.sx8yt8k8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxyn8hn-kpzng {
+.sx8yt8k-kpzng {
   color: inherit;
   max-width: 75ch;
 }
 
-.sxyn8hn-kpzng:not(:last-child) {
+.sx8yt8k-kpzng:not(:last-child) {
   margin-bottom: var(--sx-space-5);
 }
 
-.sxyn8hn-2obmh {
+.sx8yt8k-2obmh {
   color: inherit;
 }
 
@@ -52,110 +52,110 @@ exports[`MarkdownContent component renders 1`] = `
   margin-bottom: var(--sx-space-5);
 }
 
-.sxlk8sk {
-  color: var(--sx-colors-tonal500);
+.sx8wio2 {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-display);
   font-weight: 700;
   margin: 0;
 }
 
-.sxlk8sk9egxm--size-lg {
+.sx8wio29egxm--size-lg {
   font-size: var(--sx-fontSizes-2xl);
   line-height: 1.08;
 }
 
-.sxlk8sk9egxm--size-lg::before {
+.sx8wio29egxm--size-lg::before {
   content: '';
   margin-bottom: -0.1865em;
   display: table;
 }
 
-.sxlk8sk9egxm--size-lg::after {
+.sx8wio29egxm--size-lg::after {
   content: '';
   margin-top: -0.1945em;
   display: table;
 }
 
-.sxlk8skbk74v--size-xl {
+.sx8wio2bk74v--size-xl {
   font-size: var(--sx-fontSizes-3xl);
   line-height: 1.12;
 }
 
-.sxlk8skbk74v--size-xl::before {
+.sx8wio2bk74v--size-xl::before {
   content: '';
   margin-bottom: -0.206em;
   display: table;
 }
 
-.sxlk8skbk74v--size-xl::after {
+.sx8wio2bk74v--size-xl::after {
   content: '';
   margin-top: -0.214em;
   display: table;
 }
 
-.sxlk8sk9zj0i--size-md {
+.sx8wio29zj0i--size-md {
   font-size: var(--sx-fontSizes-xl);
   line-height: 1.14;
 }
 
-.sxlk8sk9zj0i--size-md::before {
+.sx8wio29zj0i--size-md::before {
   content: '';
   margin-bottom: -0.2174em;
   display: table;
 }
 
-.sxlk8sk9zj0i--size-md::after {
+.sx8wio29zj0i--size-md::after {
   content: '';
   margin-top: -0.2254em;
   display: table;
 }
 
-.sxlk8skgcpf2--size-sm {
+.sx8wio2gcpf2--size-sm {
   font-size: var(--sx-fontSizes-lg);
   line-height: 1.14;
 }
 
-.sxlk8skgcpf2--size-sm::before {
+.sx8wio2gcpf2--size-sm::before {
   content: '';
   margin-bottom: -0.2174em;
   display: table;
 }
 
-.sxlk8skgcpf2--size-sm::after {
+.sx8wio2gcpf2--size-sm::after {
   content: '';
   margin-top: -0.2254em;
   display: table;
 }
 
-.sxlk8sklt963--size-xs {
+.sx8wio2lt963--size-xs {
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlk8sklt963--size-xs::before {
+.sx8wio2lt963--size-xs::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlk8sklt963--size-xs::after {
+.sx8wio2lt963--size-xs::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxlk8sk-yo9l7 {
+.sx8wio2-yo9l7 {
   color: inherit;
   max-width: 65ch;
 }
 
-.sxlk8sk-yo9l7:not(:first-child) {
+.sx8wio2-yo9l7:not(:first-child) {
   margin-top: var(--sx-space-5);
 }
 
-.sxlk8sk-yo9l7:not(:last-child) {
+.sx8wio2-yo9l7:not(:last-child) {
   margin-bottom: var(--sx-space-5);
 }
 
@@ -268,7 +268,7 @@ exports[`MarkdownContent component renders 1`] = `
   padding: var(--sx-space-0) var(--sx-space-1);
 }
 
-.sxlyjic {
+.sxi05ns {
   background: unset;
   border: unset;
   padding: unset;
@@ -278,44 +278,44 @@ exports[`MarkdownContent component renders 1`] = `
   text-decoration: none;
 }
 
-.sxlyjic:focus,
-.sxlyjic:hover {
+.sxi05ns:focus,
+.sxi05ns:hover {
   color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlyjic:active {
+.sxi05ns:active {
   color: var(--sx-colors-primaryDark);
 }
 
-.sxyn8hn > .sxlyjic,
-.sxlk8sk > .sxlyjic,
-.sx03kze > .sxlyjic {
+.sx8yt8k > .sxi05ns,
+.sx8wio2 > .sxi05ns,
+.sx03kze > .sxi05ns {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxyn8hn > .sxlyjic::before,
-.sxyn8hn > .sxlyjic::after,
-.sxlk8sk > .sxlyjic::before,
-.sxlk8sk > .sxlyjic::after,
-.sx03kze > .sxlyjic::before,
-.sx03kze > .sxlyjic::after {
+.sx8yt8k > .sxi05ns::before,
+.sx8yt8k > .sxi05ns::after,
+.sx8wio2 > .sxi05ns::before,
+.sx8wio2 > .sxi05ns::after,
+.sx03kze > .sxi05ns::before,
+.sx03kze > .sxi05ns::after {
   content: none;
 }
 
-.sxlyjic8bitc--size-md {
+.sxi05ns8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlyjic8bitc--size-md::before {
+.sxi05ns8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlyjic8bitc--size-md::after {
+.sxi05ns8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -333,7 +333,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Headings
     </h2>
@@ -341,32 +341,32 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h1
-      class="sxlk8sk sxlk8skbk74v--size-xl sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio2bk74v--size-xl sx8wio2-yo9l7"
     >
       h1 Heading
     </h1>
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       h2 Heading
     </h2>
     <h3
-      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29zj0i--size-md sx8wio2-yo9l7"
     >
       h3 Heading
     </h3>
     <h4
-      class="sxlk8sk sxlk8skgcpf2--size-sm sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio2gcpf2--size-sm sx8wio2-yo9l7"
     >
       h4 Heading
     </h4>
     <h5
-      class="sxlk8sk sxlk8sklt963--size-xs sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio2lt963--size-xs sx8wio2-yo9l7"
     >
       h5 Heading
     </h5>
     <h6
-      class="sxlk8sk sxlk8sklt963--size-xs sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio2lt963--size-xs sx8wio2-yo9l7"
     >
       h6 Heading
     </h6>
@@ -374,7 +374,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Emphasis
     </h2>
@@ -382,7 +382,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <strong
         class="sx4d3ki"
@@ -391,7 +391,7 @@ exports[`MarkdownContent component renders 1`] = `
       </strong>
     </p>
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <strong
         class="sx4d3ki"
@@ -400,7 +400,7 @@ exports[`MarkdownContent component renders 1`] = `
       </strong>
     </p>
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <em
         class="sxiwbex"
@@ -409,7 +409,7 @@ exports[`MarkdownContent component renders 1`] = `
       </em>
     </p>
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <em
         class="sxiwbex"
@@ -421,7 +421,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Blockquotes
     </h2>
@@ -432,7 +432,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Lists
     </h2>
@@ -440,7 +440,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h3
-      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29zj0i--size-md sx8wio2-yo9l7"
     >
       Unordered
     </h3>
@@ -451,7 +451,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           Create a list by starting a line with 
           <code
@@ -477,7 +477,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           Sub-lists are made by indenting 2 spaces:
         </p>
@@ -488,7 +488,7 @@ exports[`MarkdownContent component renders 1`] = `
             class="sx03kze"
           >
             <p
-              class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+              class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
             >
               Marker character change forces new list start:
             </p>
@@ -499,7 +499,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+                  class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
                 >
                   Ac tristique libero volutpat at
                 </p>
@@ -512,7 +512,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+                  class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
                 >
                   Facilisis in pretium nisl aliquet
                 </p>
@@ -525,7 +525,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+                  class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
                 >
                   Nulla volutpat aliquam velit
                 </p>
@@ -538,14 +538,14 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           Very easy!
         </p>
       </li>
     </ul>
     <h3
-      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29zj0i--size-md sx8wio2-yo9l7"
     >
       Ordered
     </h3>
@@ -556,7 +556,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           Lorem ipsum dolor sit amet
         </p>
@@ -565,7 +565,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           Consectetur adipiscing elit
         </p>
@@ -574,7 +574,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           Integer molestie lorem at massa
         </p>
@@ -583,7 +583,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           You can use sequential numbers...
         </p>
@@ -592,7 +592,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
+          class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-2obmh"
         >
           ...or keep all the numbers as 
           <code
@@ -607,7 +607,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Code
     </h2>
@@ -615,12 +615,12 @@ exports[`MarkdownContent component renders 1`] = `
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h3
-      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29zj0i--size-md sx8wio2-yo9l7"
     >
       Inline code
     </h3>
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       This is inline 
       <code
@@ -630,7 +630,7 @@ exports[`MarkdownContent component renders 1`] = `
       </code>
     </p>
     <h3
-      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29zj0i--size-md sx8wio2-yo9l7"
     >
       Indented code
     </h3>
@@ -643,7 +643,7 @@ line 2 of code
 line 3 of code
     </pre>
     <h3
-      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29zj0i--size-md sx8wio2-yo9l7"
     >
       Block code "fences"
     </h3>
@@ -656,7 +656,7 @@ line 3 of code
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Links
     </h2>
@@ -664,20 +664,20 @@ line 3 of code
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <a
-        class="sxlyjic sxlyjic8bitc--size-md"
+        class="sxi05ns sxi05ns8bitc--size-md"
         href="http://dev.nodeca.com"
       >
         link text
       </a>
     </p>
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <a
-        class="sxlyjic sxlyjic8bitc--size-md"
+        class="sxi05ns sxi05ns8bitc--size-md"
         href="http://nodeca.github.io/pica/demo/"
         title="title text!"
       >
@@ -688,7 +688,7 @@ line 3 of code
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
+      class="sx8wio2 sx8wio29egxm--size-lg sx8wio2-yo9l7"
     >
       Images
     </h2>
@@ -696,7 +696,7 @@ line 3 of code
       class="sxlgf7o sxlgf7o-76pw2"
     />
     <p
-      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
+      class="sx8yt8k sx8yt8k8bitc--size-md sx8yt8k-kpzng"
     >
       <img
         alt="Minion"

--- a/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -1,161 +1,161 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MarkdownContent component renders 1`] = `
-.sxj1d4e {
-  color: var(--sx-colors-tonal800);
+.sxyn8hn {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxj1d4e8bitc--size-md {
+.sxyn8hn8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxj1d4e8bitc--size-md::before {
+.sxyn8hn8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxj1d4e8bitc--size-md::after {
+.sxyn8hn8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxj1d4e-kpzng {
+.sxyn8hn-kpzng {
   color: inherit;
   max-width: 75ch;
 }
 
-.sxj1d4e-kpzng:not(:last-child) {
+.sxyn8hn-kpzng:not(:last-child) {
   margin-bottom: var(--sx-space-5);
 }
 
-.sxj1d4e-2obmh {
+.sxyn8hn-2obmh {
   color: inherit;
 }
 
-.sx95fm0 {
+.sxlgf7o {
   border: 0;
-  border-top: 1px solid var(--sx-colors-tonal400);
+  border-top: 1px solid var(--sx-colors-tonal200);
   margin-left: auto;
   margin-right: auto;
   width: 50%;
 }
 
-.sx95fm0-76pw2 {
+.sxlgf7o-76pw2 {
   width: 100%;
   margin-top: var(--sx-space-5);
   margin-bottom: var(--sx-space-5);
 }
 
-.sxh1zwe {
-  color: var(--sx-colors-tonal800);
+.sxlk8sk {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-display);
   font-weight: 700;
   margin: 0;
 }
 
-.sxh1zwe9egxm--size-lg {
+.sxlk8sk9egxm--size-lg {
   font-size: var(--sx-fontSizes-2xl);
   line-height: 1.08;
 }
 
-.sxh1zwe9egxm--size-lg::before {
+.sxlk8sk9egxm--size-lg::before {
   content: '';
   margin-bottom: -0.1865em;
   display: table;
 }
 
-.sxh1zwe9egxm--size-lg::after {
+.sxlk8sk9egxm--size-lg::after {
   content: '';
   margin-top: -0.1945em;
   display: table;
 }
 
-.sxh1zwebk74v--size-xl {
+.sxlk8skbk74v--size-xl {
   font-size: var(--sx-fontSizes-3xl);
   line-height: 1.12;
 }
 
-.sxh1zwebk74v--size-xl::before {
+.sxlk8skbk74v--size-xl::before {
   content: '';
   margin-bottom: -0.206em;
   display: table;
 }
 
-.sxh1zwebk74v--size-xl::after {
+.sxlk8skbk74v--size-xl::after {
   content: '';
   margin-top: -0.214em;
   display: table;
 }
 
-.sxh1zwe9zj0i--size-md {
+.sxlk8sk9zj0i--size-md {
   font-size: var(--sx-fontSizes-xl);
   line-height: 1.14;
 }
 
-.sxh1zwe9zj0i--size-md::before {
+.sxlk8sk9zj0i--size-md::before {
   content: '';
   margin-bottom: -0.2174em;
   display: table;
 }
 
-.sxh1zwe9zj0i--size-md::after {
+.sxlk8sk9zj0i--size-md::after {
   content: '';
   margin-top: -0.2254em;
   display: table;
 }
 
-.sxh1zwegcpf2--size-sm {
+.sxlk8skgcpf2--size-sm {
   font-size: var(--sx-fontSizes-lg);
   line-height: 1.14;
 }
 
-.sxh1zwegcpf2--size-sm::before {
+.sxlk8skgcpf2--size-sm::before {
   content: '';
   margin-bottom: -0.2174em;
   display: table;
 }
 
-.sxh1zwegcpf2--size-sm::after {
+.sxlk8skgcpf2--size-sm::after {
   content: '';
   margin-top: -0.2254em;
   display: table;
 }
 
-.sxh1zwelt963--size-xs {
+.sxlk8sklt963--size-xs {
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxh1zwelt963--size-xs::before {
+.sxlk8sklt963--size-xs::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxh1zwelt963--size-xs::after {
+.sxlk8sklt963--size-xs::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxh1zwe-yo9l7 {
+.sxlk8sk-yo9l7 {
   color: inherit;
   max-width: 65ch;
 }
 
-.sxh1zwe-yo9l7:not(:first-child) {
+.sxlk8sk-yo9l7:not(:first-child) {
   margin-top: var(--sx-space-5);
 }
 
-.sxh1zwe-yo9l7:not(:last-child) {
+.sxlk8sk-yo9l7:not(:last-child) {
   margin-bottom: var(--sx-space-5);
 }
 
@@ -242,31 +242,33 @@ exports[`MarkdownContent component renders 1`] = `
   display: none;
 }
 
-.sxoyulj {
-  background: var(--sx-colors-tonal200);
-  padding: var(--sx-space-3);
-  margin-top: var(--sx-space-4);
-  margin-bottom: var(--sx-space-4);
+.sxt4nq2 {
+  background: var(--sx-colors-tonal100);
   border-radius: var(--sx-radii-1);
-  line-height: 1.4;
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-mono);
   font-size: var(--sx-fontSizes-sm);
+  line-height: 1.4;
+  margin-top: var(--sx-space-4);
+  margin-bottom: var(--sx-space-4);
+  padding: var(--sx-space-3);
 }
 
 .sxiwbex {
   font-style: italic;
 }
 
-.sxbc4si {
+.sx4omy6 {
   background: var(--sx-colors-tonal100);
   border-radius: var(--sx-radii-0);
+  color: var(--sx-colors-tonal600);
   display: inline-block;
   font-family: var(--sx-fonts-mono);
   font-size: 85%;
   padding: var(--sx-space-0) var(--sx-space-1);
 }
 
-.sxlc3or {
+.sxlyjic {
   background: unset;
   border: unset;
   padding: unset;
@@ -276,44 +278,44 @@ exports[`MarkdownContent component renders 1`] = `
   text-decoration: none;
 }
 
-.sxlc3or:focus,
-.sxlc3or:hover {
-  color: var(--sx-colors-tertiary);
+.sxlyjic:focus,
+.sxlyjic:hover {
+  color: var(--sx-colors-primaryMid);
   text-decoration: underline;
 }
 
-.sxlc3or:active {
-  color: var(--sx-colors-primary);
+.sxlyjic:active {
+  color: var(--sx-colors-primaryDark);
 }
 
-.sxj1d4e > .sxlc3or,
-.sxh1zwe > .sxlc3or,
-.sx03kze > .sxlc3or {
+.sxyn8hn > .sxlyjic,
+.sxlk8sk > .sxlyjic,
+.sx03kze > .sxlyjic {
   font-size: 100%;
   line-height: 1;
 }
 
-.sxj1d4e > .sxlc3or::before,
-.sxj1d4e > .sxlc3or::after,
-.sxh1zwe > .sxlc3or::before,
-.sxh1zwe > .sxlc3or::after,
-.sx03kze > .sxlc3or::before,
-.sx03kze > .sxlc3or::after {
+.sxyn8hn > .sxlyjic::before,
+.sxyn8hn > .sxlyjic::after,
+.sxlk8sk > .sxlyjic::before,
+.sxlk8sk > .sxlyjic::after,
+.sx03kze > .sxlyjic::before,
+.sx03kze > .sxlyjic::after {
   content: none;
 }
 
-.sxlc3or8bitc--size-md {
+.sxlyjic8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxlc3or8bitc--size-md::before {
+.sxlyjic8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxlc3or8bitc--size-md::after {
+.sxlyjic8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -328,59 +330,59 @@ exports[`MarkdownContent component renders 1`] = `
     class="sx03kze"
   >
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Headings
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h1
-      class="sxh1zwe sxh1zwebk74v--size-xl sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8skbk74v--size-xl sxlk8sk-yo9l7"
     >
       h1 Heading
     </h1>
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       h2 Heading
     </h2>
     <h3
-      class="sxh1zwe sxh1zwe9zj0i--size-md sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
     >
       h3 Heading
     </h3>
     <h4
-      class="sxh1zwe sxh1zwegcpf2--size-sm sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8skgcpf2--size-sm sxlk8sk-yo9l7"
     >
       h4 Heading
     </h4>
     <h5
-      class="sxh1zwe sxh1zwelt963--size-xs sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sklt963--size-xs sxlk8sk-yo9l7"
     >
       h5 Heading
     </h5>
     <h6
-      class="sxh1zwe sxh1zwelt963--size-xs sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sklt963--size-xs sxlk8sk-yo9l7"
     >
       h6 Heading
     </h6>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Emphasis
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <strong
         class="sx4d3ki"
@@ -389,7 +391,7 @@ exports[`MarkdownContent component renders 1`] = `
       </strong>
     </p>
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <strong
         class="sx4d3ki"
@@ -398,7 +400,7 @@ exports[`MarkdownContent component renders 1`] = `
       </strong>
     </p>
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <em
         class="sxiwbex"
@@ -407,7 +409,7 @@ exports[`MarkdownContent component renders 1`] = `
       </em>
     </p>
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <em
         class="sxiwbex"
@@ -416,29 +418,29 @@ exports[`MarkdownContent component renders 1`] = `
       </em>
     </p>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Blockquotes
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Lists
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h3
-      class="sxh1zwe sxh1zwe9zj0i--size-md sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
     >
       Unordered
     </h3>
@@ -449,23 +451,23 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           Create a list by starting a line with 
           <code
-            class="sx03kze sxbc4si"
+            class="sx03kze sx4omy6"
           >
             +
           </code>
           , 
           <code
-            class="sx03kze sxbc4si"
+            class="sx03kze sx4omy6"
           >
             -
           </code>
           , or 
           <code
-            class="sx03kze sxbc4si"
+            class="sx03kze sx4omy6"
           >
             *
           </code>
@@ -475,7 +477,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           Sub-lists are made by indenting 2 spaces:
         </p>
@@ -486,7 +488,7 @@ exports[`MarkdownContent component renders 1`] = `
             class="sx03kze"
           >
             <p
-              class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+              class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
             >
               Marker character change forces new list start:
             </p>
@@ -497,7 +499,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+                  class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
                 >
                   Ac tristique libero volutpat at
                 </p>
@@ -510,7 +512,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+                  class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
                 >
                   Facilisis in pretium nisl aliquet
                 </p>
@@ -523,7 +525,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="sx03kze"
               >
                 <p
-                  class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+                  class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
                 >
                   Nulla volutpat aliquam velit
                 </p>
@@ -536,14 +538,14 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           Very easy!
         </p>
       </li>
     </ul>
     <h3
-      class="sxh1zwe sxh1zwe9zj0i--size-md sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
     >
       Ordered
     </h3>
@@ -554,7 +556,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           Lorem ipsum dolor sit amet
         </p>
@@ -563,7 +565,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           Consectetur adipiscing elit
         </p>
@@ -572,7 +574,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           Integer molestie lorem at massa
         </p>
@@ -581,7 +583,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           You can use sequential numbers...
         </p>
@@ -590,11 +592,11 @@ exports[`MarkdownContent component renders 1`] = `
         class="sx03kze"
       >
         <p
-          class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-2obmh"
+          class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-2obmh"
         >
           ...or keep all the numbers as 
           <code
-            class="sx03kze sxbc4si"
+            class="sx03kze sx4omy6"
           >
             1.
           </code>
@@ -602,38 +604,38 @@ exports[`MarkdownContent component renders 1`] = `
       </li>
     </ol>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Code
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h3
-      class="sxh1zwe sxh1zwe9zj0i--size-md sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
     >
       Inline code
     </h3>
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       This is inline 
       <code
-        class="sx03kze sxbc4si"
+        class="sx03kze sx4omy6"
       >
         code
       </code>
     </p>
     <h3
-      class="sxh1zwe sxh1zwe9zj0i--size-md sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
     >
       Indented code
     </h3>
     <pre
-      class="sx03kze sxoyulj"
+      class="sx03kze sxt4nq2"
     >
       // Some comments
 line 1 of code
@@ -641,41 +643,41 @@ line 2 of code
 line 3 of code
     </pre>
     <h3
-      class="sxh1zwe sxh1zwe9zj0i--size-md sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9zj0i--size-md sxlk8sk-yo9l7"
     >
       Block code "fences"
     </h3>
     <pre
-      class="sx03kze sxoyulj"
+      class="sx03kze sxt4nq2"
     >
       Sample text here...
     </pre>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Links
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <a
-        class="sxlc3or sxlc3or8bitc--size-md"
+        class="sxlyjic sxlyjic8bitc--size-md"
         href="http://dev.nodeca.com"
       >
         link text
       </a>
     </p>
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <a
-        class="sxlc3or sxlc3or8bitc--size-md"
+        class="sxlyjic sxlyjic8bitc--size-md"
         href="http://nodeca.github.io/pica/demo/"
         title="title text!"
       >
@@ -683,18 +685,18 @@ line 3 of code
       </a>
     </p>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <h2
-      class="sxh1zwe sxh1zwe9egxm--size-lg sxh1zwe-yo9l7"
+      class="sxlk8sk sxlk8sk9egxm--size-lg sxlk8sk-yo9l7"
     >
       Images
     </h2>
     <hr
-      class="sx95fm0 sx95fm0-76pw2"
+      class="sxlgf7o sxlgf7o-76pw2"
     />
     <p
-      class="sxj1d4e sxj1d4e8bitc--size-md sxj1d4e-kpzng"
+      class="sxyn8hn sxyn8hn8bitc--size-md sxyn8hn-kpzng"
     >
       <img
         alt="Minion"

--- a/src/components/markdown-content/components/MarkdownCode.tsx
+++ b/src/components/markdown-content/components/MarkdownCode.tsx
@@ -10,13 +10,14 @@ type MarkdownCodeProps = {
 }
 
 const StyledCode = styled(Box, {
-  bg: '$tonal200',
-  p: '$3',
-  my: '$4',
+  bg: '$tonal100',
   borderRadius: '$1',
-  lineHeight: 1.4,
+  color: '$tonal600',
   fontFamily: '$mono',
-  fontSize: '$sm'
+  fontSize: '$sm',
+  lineHeight: 1.4,
+  my: '$4',
+  p: '$3'
 })
 
 export const MarkdownCode: React.FC<MarkdownCodeProps> = ({ node }) => (

--- a/src/components/markdown-content/components/MarkdownInlineCode.tsx
+++ b/src/components/markdown-content/components/MarkdownInlineCode.tsx
@@ -12,6 +12,7 @@ type MarkdownInlineCodeProps = {
 const StyledInlineCode = styled(Box, {
   bg: '$tonal100',
   borderRadius: '$0',
+  color: '$tonal600',
   display: 'inline-block',
   fontFamily: '$mono',
   fontSize: '85%',

--- a/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -12,22 +12,22 @@ exports[`Password component renders a password field 1`] = `
   position: relative;
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6mbqqh--size-md {
+.sxakl60zozsa--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxtros6-7bxbw {
+.sxakl60-7bxbw {
   height: 20px;
   width: 20px;
 }
@@ -42,32 +42,32 @@ exports[`Password component renders a password field 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxd2uai {
+.sx5tsqk {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
@@ -82,44 +82,48 @@ exports[`Password component renders a password field 1`] = `
   transition: all 125ms ease-out;
 }
 
-.sxd2uai[disabled],
-.sxd2uai[disabled]:hover,
-.sxd2uai[disabled]:focus {
-  background: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
-  border-color: var(--sx-colors-tonal100);
+.sx5tsqk[disabled],
+.sx5tsqk[disabled]:hover,
+.sx5tsqk[disabled]:focus {
+  background: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal50);
   cursor: not-allowed;
 }
 
-.sxd2uai2gdaw--size-lg {
+.sx5tsqk2gdaw--size-lg {
   height: var(--sx-sizes-4);
   width: var(--sx-sizes-4);
 }
 
-.sxd2uaio0ahp--c2 {
+.sx5tsqkf4d9s--c2 {
   background: transparent;
-  color: var(--sx-colors-tonal600);
+  color: var(--sx-colors-tonal300);
 }
 
-.sxd2uaio0ahp--c2:hover,
-.sxd2uaio0ahp--c2:focus {
-  color: var(--sx-colors-primary);
+.sx5tsqkf4d9s--c2:hover,
+.sx5tsqkf4d9s--c2:focus {
+  color: var(--sx-colors-primaryMid);
 }
 
-.sxd2uai-014be {
+.sx5tsqkf4d9s--c2:active {
+  color: var(--sx-colors-primaryDark);
+}
+
+.sx5tsqk-014be {
   bottom: 0;
   position: absolute;
   right: 0;
 }
 
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -129,23 +133,29 @@ exports[`Password component renders a password field 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sx1s1jh-m8e5u {
+.sxtvycl-m8e5u {
   padding-right: var(--sx-sizes-2);
 }
 
@@ -161,7 +171,7 @@ exports[`Password component renders a password field 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="password"
         >
           Password
@@ -172,19 +182,19 @@ exports[`Password component renders a password field 1`] = `
       >
         <input
           autocomplete="current-password"
-          class="sx1s1jh sx1s1jhpw03g--size-md sx1s1jh-m8e5u"
+          class="sxtvycl sxtvyclpw03g--size-md sxtvycl-m8e5u"
           id="password"
           name="password"
           type="password"
         />
         <button
           aria-label="Show password"
-          class="sxd2uai sxd2uai03kze--theme-neutral sxd2uai03kze--appearance-simple sxd2uai2gdaw--size-lg sxd2uaio0ahp--c2 sxd2uai-014be"
+          class="sx5tsqk sx5tsqk03kze--theme-neutral sx5tsqk03kze--appearance-simple sx5tsqk2gdaw--size-lg sx5tsqkf4d9s--c2 sx5tsqk-014be"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="sxtros6 sxtros6mbqqh--size-md sxtros6-7bxbw"
+            class="sxakl60 sxakl60zozsa--size-md sxakl60-7bxbw"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Password component renders a password field 1`] = `
   display: table;
 }
 
-.sx5tsqk {
+.sxua1zw {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
@@ -79,51 +79,47 @@ exports[`Password component renders a password field 1`] = `
   display: flex;
   justify-content: center;
   padding: unset;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
 }
 
-.sx5tsqk[disabled],
-.sx5tsqk[disabled]:hover,
-.sx5tsqk[disabled]:focus {
-  background: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  border-color: var(--sx-colors-tonal50);
-  cursor: not-allowed;
-}
-
-.sx5tsqk2gdaw--size-lg {
+.sxua1zw2gdaw--size-lg {
   height: var(--sx-sizes-4);
   width: var(--sx-sizes-4);
 }
 
-.sx5tsqkf4d9s--c2 {
+.sxua1zwnuwbn--c2 {
   background: transparent;
   color: var(--sx-colors-tonal300);
 }
 
-.sx5tsqkf4d9s--c2:hover,
-.sx5tsqkf4d9s--c2:focus {
+.sxua1zwnuwbn--c2:not(:disabled):hover,
+.sxua1zwnuwbn--c2:not(:disabled):focus {
   color: var(--sx-colors-primaryMid);
 }
 
-.sx5tsqkf4d9s--c2:active {
+.sxua1zwnuwbn--c2:not(:disabled):active {
   color: var(--sx-colors-primaryDark);
 }
 
-.sx5tsqk-014be {
+.sxua1zwnuwbn--c2[disabled] {
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxua1zw-014be {
   bottom: 0;
   position: absolute;
   right: 0;
 }
 
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -133,29 +129,28 @@ exports[`Password component renders a password field 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sxtvycl-m8e5u {
+.sx7g9w1-m8e5u {
   padding-right: var(--sx-sizes-2);
 }
 
@@ -182,14 +177,14 @@ exports[`Password component renders a password field 1`] = `
       >
         <input
           autocomplete="current-password"
-          class="sxtvycl sxtvyclpw03g--size-md sxtvycl-m8e5u"
+          class="sx7g9w1 sx7g9w1pw03g--size-md sx7g9w1-m8e5u"
           id="password"
           name="password"
           type="password"
         />
         <button
           aria-label="Show password"
-          class="sx5tsqk sx5tsqk03kze--theme-neutral sx5tsqk03kze--appearance-simple sx5tsqk2gdaw--size-lg sx5tsqkf4d9s--c2 sx5tsqk-014be"
+          class="sxua1zw sxua1zw03kze--theme-neutral sxua1zw03kze--appearance-simple sxua1zw2gdaw--size-lg sxua1zwnuwbn--c2 sxua1zw-014be"
           type="button"
         >
           <svg

--- a/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`PasswordInput component renders 1`] = `
   width: 20px;
 }
 
-.sx5tsqk {
+.sxua1zw {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
@@ -33,38 +33,34 @@ exports[`PasswordInput component renders 1`] = `
   display: flex;
   justify-content: center;
   padding: unset;
-  transition: all 125ms ease-out;
+  transition: all 100ms ease-out;
 }
 
-.sx5tsqk[disabled],
-.sx5tsqk[disabled]:hover,
-.sx5tsqk[disabled]:focus {
-  background: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
-  border-color: var(--sx-colors-tonal50);
-  cursor: not-allowed;
-}
-
-.sx5tsqk2gdaw--size-lg {
+.sxua1zw2gdaw--size-lg {
   height: var(--sx-sizes-4);
   width: var(--sx-sizes-4);
 }
 
-.sx5tsqkf4d9s--c2 {
+.sxua1zwnuwbn--c2 {
   background: transparent;
   color: var(--sx-colors-tonal300);
 }
 
-.sx5tsqkf4d9s--c2:hover,
-.sx5tsqkf4d9s--c2:focus {
+.sxua1zwnuwbn--c2:not(:disabled):hover,
+.sxua1zwnuwbn--c2:not(:disabled):focus {
   color: var(--sx-colors-primaryMid);
 }
 
-.sx5tsqkf4d9s--c2:active {
+.sxua1zwnuwbn--c2:not(:disabled):active {
   color: var(--sx-colors-primaryDark);
 }
 
-.sx5tsqk-014be {
+.sxua1zwnuwbn--c2[disabled] {
+  color: var(--sx-colors-tonal400);
+  cursor: not-allowed;
+}
+
+.sxua1zw-014be {
   bottom: 0;
   position: absolute;
   right: 0;
@@ -74,14 +70,14 @@ exports[`PasswordInput component renders 1`] = `
   position: relative;
 }
 
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -91,29 +87,28 @@ exports[`PasswordInput component renders 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sxtvycl-m8e5u {
+.sx7g9w1-m8e5u {
   padding-right: var(--sx-sizes-2);
 }
 
@@ -122,12 +117,12 @@ exports[`PasswordInput component renders 1`] = `
     class="sx03kze sx03kze-2v396"
   >
     <input
-      class="sxtvycl sxtvyclpw03g--size-md sxtvycl-m8e5u"
+      class="sx7g9w1 sx7g9w1pw03g--size-md sx7g9w1-m8e5u"
       type="password"
     />
     <button
       aria-label="Show password"
-      class="sx5tsqk sx5tsqk03kze--theme-neutral sx5tsqk03kze--appearance-simple sx5tsqk2gdaw--size-lg sx5tsqkf4d9s--c2 sx5tsqk-014be"
+      class="sxua1zw sxua1zw03kze--theme-neutral sxua1zw03kze--appearance-simple sxua1zw2gdaw--size-lg sxua1zwnuwbn--c2 sxua1zw-014be"
       type="button"
     >
       <svg

--- a/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PasswordInput component renders 1`] = `
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6mbqqh--size-md {
+.sxakl60zozsa--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxtros6-7bxbw {
+.sxakl60-7bxbw {
   height: 20px;
   width: 20px;
 }
 
-.sxd2uai {
+.sx5tsqk {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
@@ -36,31 +36,35 @@ exports[`PasswordInput component renders 1`] = `
   transition: all 125ms ease-out;
 }
 
-.sxd2uai[disabled],
-.sxd2uai[disabled]:hover,
-.sxd2uai[disabled]:focus {
-  background: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
-  border-color: var(--sx-colors-tonal100);
+.sx5tsqk[disabled],
+.sx5tsqk[disabled]:hover,
+.sx5tsqk[disabled]:focus {
+  background: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal50);
   cursor: not-allowed;
 }
 
-.sxd2uai2gdaw--size-lg {
+.sx5tsqk2gdaw--size-lg {
   height: var(--sx-sizes-4);
   width: var(--sx-sizes-4);
 }
 
-.sxd2uaio0ahp--c2 {
+.sx5tsqkf4d9s--c2 {
   background: transparent;
-  color: var(--sx-colors-tonal600);
+  color: var(--sx-colors-tonal300);
 }
 
-.sxd2uaio0ahp--c2:hover,
-.sxd2uaio0ahp--c2:focus {
-  color: var(--sx-colors-primary);
+.sx5tsqkf4d9s--c2:hover,
+.sx5tsqkf4d9s--c2:focus {
+  color: var(--sx-colors-primaryMid);
 }
 
-.sxd2uai-014be {
+.sx5tsqkf4d9s--c2:active {
+  color: var(--sx-colors-primaryDark);
+}
+
+.sx5tsqk-014be {
   bottom: 0;
   position: absolute;
   right: 0;
@@ -70,14 +74,14 @@ exports[`PasswordInput component renders 1`] = `
   position: relative;
 }
 
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -87,23 +91,29 @@ exports[`PasswordInput component renders 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sx1s1jh-m8e5u {
+.sxtvycl-m8e5u {
   padding-right: var(--sx-sizes-2);
 }
 
@@ -112,17 +122,17 @@ exports[`PasswordInput component renders 1`] = `
     class="sx03kze sx03kze-2v396"
   >
     <input
-      class="sx1s1jh sx1s1jhpw03g--size-md sx1s1jh-m8e5u"
+      class="sxtvycl sxtvyclpw03g--size-md sxtvycl-m8e5u"
       type="password"
     />
     <button
       aria-label="Show password"
-      class="sxd2uai sxd2uai03kze--theme-neutral sxd2uai03kze--appearance-simple sxd2uai2gdaw--size-lg sxd2uaio0ahp--c2 sxd2uai-014be"
+      class="sx5tsqk sx5tsqk03kze--theme-neutral sx5tsqk03kze--appearance-simple sx5tsqk2gdaw--size-lg sx5tsqkf4d9s--c2 sx5tsqk-014be"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="sxtros6 sxtros6mbqqh--size-md sxtros6-7bxbw"
+        class="sxakl60 sxakl60zozsa--size-md sxakl60-7bxbw"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/src/components/progress-bar/ProgressBar.mdx
+++ b/src/components/progress-bar/ProgressBar.mdx
@@ -16,13 +16,11 @@ For more examples, please read [aria-progressbar-name](https://dequeuniversity.c
 
 ## Themes
 
-These are the available `themes` for this component: `Primary` (default), `Secondary`, `Tertiary`, `Success`, `Warning`, `Danger`
+These are the available `themes` for this component: `Primary` (default), `Success`, `Warning`, `Danger`
 
 ```tsx preview
 <>
   <ProgressBar value={20} />
-  <ProgressBar theme="secondary" value={20} aria-label="Completion rate" />
-  <ProgressBar theme="tertiary" value={20} aria-label="Completion rate" />
   <ProgressBar theme="success" value={20} aria-label="Completion rate" />
   <ProgressBar theme="warning" value={20} aria-label="Completion rate" />
   <ProgressBar theme="danger" value={20} aria-label="Completion rate" />
@@ -36,18 +34,6 @@ There two options for the `appearance` property: `solid` and `outline(default)`.
 ```tsx preview
 <>
   <ProgressBar appearance="solid" value={20} aria-label="Completion rate" />
-  <ProgressBar
-    appearance="solid"
-    theme="secondary"
-    value={20}
-    aria-label="Completion rate"
-  />
-  <ProgressBar
-    appearance="solid"
-    theme="tertiary"
-    value={20}
-    aria-label="Completion rate"
-  />
   <ProgressBar
     appearance="solid"
     theme="success"

--- a/src/components/radio-field/RadioGroupField.tsx
+++ b/src/components/radio-field/RadioGroupField.tsx
@@ -51,7 +51,7 @@ export const RadioGroupField: React.FC<RadioGroupFieldProps> & {
       {description && (
         <Text
           size="sm"
-          css={{ color: '$tonal500', mb: '$3', maxWidth: '80ch' }}
+          css={{ color: '$tonal300', mb: '$3', maxWidth: '80ch' }}
         >
           {description}
         </Text>

--- a/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
@@ -6,42 +6,42 @@ exports[`RadioField component renders 1`] = `
   transform: translateY(var(--sx-space-0));
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sx5eeij-0fxuj {
+.sxbagj1-0fxuj {
   padding: 0;
   margin-bottom: var(--sx-space-3);
 }
 
-.sx7siaz {
+.sxv00ei {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal500);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-round);
   cursor: pointer;
   display: flex;
@@ -52,22 +52,22 @@ exports[`RadioField component renders 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sx7siaz:hover {
+.sxv00ei:hover {
   outline: none;
 }
 
-.sx7siaz:focus {
+.sxv00ei:focus {
   outline: none;
 }
 
-:checked + .sx7siaz {
+:checked + .sxv00ei {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sx7siaz[disabled] {
-  background-color: var(--sx-colors-tonal200);
-  border-color: var(--sx-colors-tonal400);
+.sxv00ei[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  border-color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
@@ -115,7 +115,7 @@ exports[`RadioField component renders 1`] = `
       class="sxqqba1"
     >
       <legend
-        class="sx5eeij sx5eeij8bitc--size-md sx5eeij-0fxuj"
+        class="sxbagj1 sxbagj18bitc--size-md sxbagj1-0fxuj"
       >
         Example options
       </legend>
@@ -127,7 +127,7 @@ exports[`RadioField component renders 1`] = `
           class="sx03kze"
         >
           <label
-            class="sx5eeij sx5eeij8bitc--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
+            class="sxbagj1 sxbagj18bitc--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
           >
             <div
               class="sx03kze sx03kze-2grog"
@@ -140,7 +140,7 @@ exports[`RadioField component renders 1`] = `
               />
               <button
                 aria-checked="true"
-                class="sx7siaz"
+                class="sxv00ei"
                 data-radix-roving-focus-group-id="radix-id-0-1"
                 data-state="checked"
                 role="radio"
@@ -161,7 +161,7 @@ exports[`RadioField component renders 1`] = `
           class="sx03kze"
         >
           <label
-            class="sx5eeij sx5eeij8bitc--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
+            class="sxbagj1 sxbagj18bitc--size-md sx9ru2a sx9ru2a0fgel--align-baseline sx9ru2aged5d--direction-row"
           >
             <div
               class="sx03kze sx03kze-2grog"
@@ -173,7 +173,7 @@ exports[`RadioField component renders 1`] = `
               />
               <button
                 aria-checked="false"
-                class="sx7siaz"
+                class="sxv00ei"
                 data-radix-roving-focus-group-id="radix-id-0-1"
                 data-state="unchecked"
                 role="radio"

--- a/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
@@ -36,13 +36,14 @@ exports[`RadioField component renders 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sxiuu0y {
+.sxkgwoi {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-round);
+  color: white;
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -52,27 +53,28 @@ exports[`RadioField component renders 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxiuu0y:focus {
+.sxkgwoi:focus {
   outline: 2px solid var(--sx-colors-primary);
   outline-offset: 1px;
 }
 
-:checked + .sxiuu0y {
+:checked + .sxkgwoi {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxiuu0y[disabled] {
+.sxkgwoi[disabled] {
   background-color: var(--sx-colors-tonal100);
   border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxndfzf {
+.sxddr1z {
   height: 6px;
   width: 6px;
   border-radius: var(--sx-radii-round);
-  background-color: white;
+  background-color: currentcolor;
   position: absolute;
 }
 
@@ -137,7 +139,7 @@ exports[`RadioField component renders 1`] = `
               />
               <button
                 aria-checked="true"
-                class="sxiuu0y"
+                class="sxkgwoi"
                 data-radix-roving-focus-group-id="radix-id-0-1"
                 data-state="checked"
                 role="radio"
@@ -146,7 +148,7 @@ exports[`RadioField component renders 1`] = `
                 value="1"
               >
                 <span
-                  class="sxndfzf"
+                  class="sxddr1z"
                   data-state="checked"
                 />
               </button>
@@ -170,7 +172,7 @@ exports[`RadioField component renders 1`] = `
               />
               <button
                 aria-checked="false"
-                class="sxiuu0y"
+                class="sxkgwoi"
                 data-radix-roving-focus-group-id="radix-id-0-1"
                 data-state="unchecked"
                 role="radio"

--- a/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/radio-field/__snapshots__/RadioField.test.tsx.snap
@@ -36,12 +36,12 @@ exports[`RadioField component renders 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sxv00ei {
+.sxiuu0y {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal300);
+  border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-round);
   cursor: pointer;
   display: flex;
@@ -52,22 +52,19 @@ exports[`RadioField component renders 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxv00ei:hover {
-  outline: none;
+.sxiuu0y:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
 }
 
-.sxv00ei:focus {
-  outline: none;
-}
-
-:checked + .sxv00ei {
+:checked + .sxiuu0y {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxv00ei[disabled] {
+.sxiuu0y[disabled] {
   background-color: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
@@ -140,7 +137,7 @@ exports[`RadioField component renders 1`] = `
               />
               <button
                 aria-checked="true"
-                class="sxv00ei"
+                class="sxiuu0y"
                 data-radix-roving-focus-group-id="radix-id-0-1"
                 data-state="checked"
                 role="radio"
@@ -173,7 +170,7 @@ exports[`RadioField component renders 1`] = `
               />
               <button
                 aria-checked="false"
-                class="sxv00ei"
+                class="sxiuu0y"
                 data-radix-roving-focus-group-id="radix-id-0-1"
                 data-state="unchecked"
                 role="radio"

--- a/src/components/radio/RadioButton.tsx
+++ b/src/components/radio/RadioButton.tsx
@@ -8,7 +8,7 @@ const StyledRadioButton = styled(RadioGroup.Item, {
   alignItems: 'center',
   appearance: 'none',
   backgroundColor: 'transparent',
-  border: '1px solid $tonal500',
+  border: '1px solid $tonal300',
   borderRadius: '$round',
   cursor: 'pointer',
   display: 'flex',
@@ -27,8 +27,8 @@ const StyledRadioButton = styled(RadioGroup.Item, {
     borderColor: '$primary'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal200',
-    borderColor: '$tonal400',
+    backgroundColor: '$tonal100',
+    borderColor: '$tonal300',
     cursor: 'not-allowed'
   }
 })

--- a/src/components/radio/RadioButton.tsx
+++ b/src/components/radio/RadioButton.tsx
@@ -10,13 +10,13 @@ const StyledRadioButton = styled(RadioGroup.Item, {
   backgroundColor: 'transparent',
   border: '1px solid $tonal400',
   borderRadius: '$round',
+  color: 'white',
   cursor: 'pointer',
   display: 'flex',
   justifyContent: 'center',
   p: 0,
   size: '$1',
   transition: 'all 50ms ease-out',
-
   '&:focus': {
     outline: '2px solid $primary',
     outlineOffset: '1px'
@@ -28,6 +28,7 @@ const StyledRadioButton = styled(RadioGroup.Item, {
   '&[disabled]': {
     backgroundColor: '$tonal100',
     borderColor: '$tonal400',
+    color: '$tonal400',
     cursor: 'not-allowed'
   }
 })
@@ -35,7 +36,7 @@ const StyledRadioButton = styled(RadioGroup.Item, {
 const StyledIndicator = styled(RadioGroup.Indicator, {
   size: '6px',
   borderRadius: '$round',
-  backgroundColor: 'white',
+  backgroundColor: 'currentcolor',
   position: 'absolute'
 })
 

--- a/src/components/radio/RadioButton.tsx
+++ b/src/components/radio/RadioButton.tsx
@@ -8,7 +8,7 @@ const StyledRadioButton = styled(RadioGroup.Item, {
   alignItems: 'center',
   appearance: 'none',
   backgroundColor: 'transparent',
-  border: '1px solid $tonal300',
+  border: '1px solid $tonal400',
   borderRadius: '$round',
   cursor: 'pointer',
   display: 'flex',
@@ -16,11 +16,10 @@ const StyledRadioButton = styled(RadioGroup.Item, {
   p: 0,
   size: '$1',
   transition: 'all 50ms ease-out',
-  '&:hover': {
-    outline: 'none'
-  },
+
   '&:focus': {
-    outline: 'none'
+    outline: '2px solid $primary',
+    outlineOffset: '1px'
   },
   ':checked + &': {
     backgroundColor: '$primary',
@@ -28,7 +27,7 @@ const StyledRadioButton = styled(RadioGroup.Item, {
   },
   '&[disabled]': {
     backgroundColor: '$tonal100',
-    borderColor: '$tonal300',
+    borderColor: '$tonal400',
     cursor: 'not-allowed'
   }
 })

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -1,13 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio component renders a disabled radio button 1`] = `
-.sxiuu0y {
+.sxkgwoi {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-round);
+  color: white;
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -17,27 +18,28 @@ exports[`Radio component renders a disabled radio button 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxiuu0y:focus {
+.sxkgwoi:focus {
   outline: 2px solid var(--sx-colors-primary);
   outline-offset: 1px;
 }
 
-:checked + .sxiuu0y {
+:checked + .sxkgwoi {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxiuu0y[disabled] {
+.sxkgwoi[disabled] {
   background-color: var(--sx-colors-tonal100);
   border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxndfzf {
+.sxddr1z {
   height: 6px;
   width: 6px;
   border-radius: var(--sx-radii-round);
-  background-color: white;
+  background-color: currentcolor;
   position: absolute;
 }
 
@@ -60,7 +62,7 @@ exports[`Radio component renders a disabled radio button 1`] = `
     <button
       aria-checked="false"
       aria-label="disabled indicator"
-      class="sxiuu0y"
+      class="sxkgwoi"
       data-disabled=""
       data-state="unchecked"
       disabled=""
@@ -74,13 +76,14 @@ exports[`Radio component renders a disabled radio button 1`] = `
 `;
 
 exports[`Radio component renders a radio button 1`] = `
-.sxiuu0y {
+.sxkgwoi {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-round);
+  color: white;
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -90,27 +93,28 @@ exports[`Radio component renders a radio button 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxiuu0y:focus {
+.sxkgwoi:focus {
   outline: 2px solid var(--sx-colors-primary);
   outline-offset: 1px;
 }
 
-:checked + .sxiuu0y {
+:checked + .sxkgwoi {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxiuu0y[disabled] {
+.sxkgwoi[disabled] {
   background-color: var(--sx-colors-tonal100);
   border-color: var(--sx-colors-tonal400);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxndfzf {
+.sxddr1z {
   height: 6px;
   width: 6px;
   border-radius: var(--sx-radii-round);
-  background-color: white;
+  background-color: currentcolor;
   position: absolute;
 }
 
@@ -132,7 +136,7 @@ exports[`Radio component renders a radio button 1`] = `
     <button
       aria-checked="false"
       aria-label="indicator"
-      class="sxiuu0y"
+      class="sxkgwoi"
       data-radix-roving-focus-group-id="radix-id-0-1"
       data-state="unchecked"
       role="radio"

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio component renders a disabled radio button 1`] = `
-.sx7siaz {
+.sxv00ei {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal500);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-round);
   cursor: pointer;
   display: flex;
@@ -17,22 +17,22 @@ exports[`Radio component renders a disabled radio button 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sx7siaz:hover {
+.sxv00ei:hover {
   outline: none;
 }
 
-.sx7siaz:focus {
+.sxv00ei:focus {
   outline: none;
 }
 
-:checked + .sx7siaz {
+:checked + .sxv00ei {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sx7siaz[disabled] {
-  background-color: var(--sx-colors-tonal200);
-  border-color: var(--sx-colors-tonal400);
+.sxv00ei[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  border-color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
@@ -63,7 +63,7 @@ exports[`Radio component renders a disabled radio button 1`] = `
     <button
       aria-checked="false"
       aria-label="disabled indicator"
-      class="sx7siaz"
+      class="sxv00ei"
       data-disabled=""
       data-state="unchecked"
       disabled=""
@@ -77,12 +77,12 @@ exports[`Radio component renders a disabled radio button 1`] = `
 `;
 
 exports[`Radio component renders a radio button 1`] = `
-.sx7siaz {
+.sxv00ei {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal500);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-round);
   cursor: pointer;
   display: flex;
@@ -93,22 +93,22 @@ exports[`Radio component renders a radio button 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sx7siaz:hover {
+.sxv00ei:hover {
   outline: none;
 }
 
-.sx7siaz:focus {
+.sxv00ei:focus {
   outline: none;
 }
 
-:checked + .sx7siaz {
+:checked + .sxv00ei {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sx7siaz[disabled] {
-  background-color: var(--sx-colors-tonal200);
-  border-color: var(--sx-colors-tonal400);
+.sxv00ei[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  border-color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
@@ -138,7 +138,7 @@ exports[`Radio component renders a radio button 1`] = `
     <button
       aria-checked="false"
       aria-label="indicator"
-      class="sx7siaz"
+      class="sxv00ei"
       data-radix-roving-focus-group-id="radix-id-0-1"
       data-state="unchecked"
       role="radio"

--- a/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/radio/__snapshots__/RadioButton.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio component renders a disabled radio button 1`] = `
-.sxv00ei {
+.sxiuu0y {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal300);
+  border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-round);
   cursor: pointer;
   display: flex;
@@ -17,22 +17,19 @@ exports[`Radio component renders a disabled radio button 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxv00ei:hover {
-  outline: none;
+.sxiuu0y:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
 }
 
-.sxv00ei:focus {
-  outline: none;
-}
-
-:checked + .sxv00ei {
+:checked + .sxiuu0y {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxv00ei[disabled] {
+.sxiuu0y[disabled] {
   background-color: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
@@ -63,7 +60,7 @@ exports[`Radio component renders a disabled radio button 1`] = `
     <button
       aria-checked="false"
       aria-label="disabled indicator"
-      class="sxv00ei"
+      class="sxiuu0y"
       data-disabled=""
       data-state="unchecked"
       disabled=""
@@ -77,12 +74,12 @@ exports[`Radio component renders a disabled radio button 1`] = `
 `;
 
 exports[`Radio component renders a radio button 1`] = `
-.sxv00ei {
+.sxiuu0y {
   align-items: center;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 1px solid var(--sx-colors-tonal300);
+  border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-round);
   cursor: pointer;
   display: flex;
@@ -93,22 +90,19 @@ exports[`Radio component renders a radio button 1`] = `
   transition: all 50ms ease-out;
 }
 
-.sxv00ei:hover {
-  outline: none;
+.sxiuu0y:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
 }
 
-.sxv00ei:focus {
-  outline: none;
-}
-
-:checked + .sxv00ei {
+:checked + .sxiuu0y {
   background-color: var(--sx-colors-primary);
   border-color: var(--sx-colors-primary);
 }
 
-.sxv00ei[disabled] {
+.sxiuu0y[disabled] {
   background-color: var(--sx-colors-tonal100);
-  border-color: var(--sx-colors-tonal300);
+  border-color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
@@ -138,7 +132,7 @@ exports[`Radio component renders a radio button 1`] = `
     <button
       aria-checked="false"
       aria-label="indicator"
-      class="sxv00ei"
+      class="sxiuu0y"
       data-radix-roving-focus-group-id="radix-id-0-1"
       data-state="unchecked"
       role="radio"

--- a/src/components/search-input/SearchInput.tsx
+++ b/src/components/search-input/SearchInput.tsx
@@ -22,7 +22,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
       <Icon
         is={Search}
         css={{
-          color: '$tonal500',
+          color: '$tonal300',
           pointerEvents: 'none',
           position: 'absolute',
           size: size === 'sm' ? '$1' : 20,

--- a/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -5,23 +5,23 @@ exports[`SearchInput component renders 1`] = `
   position: relative;
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6mbqqh--size-md {
+.sxakl60zozsa--size-md {
   height: var(--sx-sizes-2);
   width: var(--sx-sizes-2);
+  stroke-width: 2;
 }
 
-.sxtros6-rsz6x {
-  color: var(--sx-colors-tonal500);
+.sxakl60-31xqk {
+  color: var(--sx-colors-tonal300);
   pointer-events: none;
   position: absolute;
   height: 20px;
@@ -30,14 +30,14 @@ exports[`SearchInput component renders 1`] = `
   left: 10px;
 }
 
-.sx1s1jh {
+.sxtvycl {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -47,23 +47,29 @@ exports[`SearchInput component renders 1`] = `
   width: 100%;
 }
 
-.sx1s1jh:focus {
+.sxtvycl:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx1s1jh[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxtvycl[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  border-color: var(--sx-colors-tonal300);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx1s1jhpw03g--size-md {
+.sxtvycl::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxtvyclpw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sx1s1jh-qayb7 {
+.sxtvycl-qayb7 {
   padding-left: var(--sx-space-6);
 }
 
@@ -73,7 +79,7 @@ exports[`SearchInput component renders 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="sxtros6 sxtros6mbqqh--size-md sxtros6-rsz6x"
+      class="sxakl60 sxakl60zozsa--size-md sxakl60-31xqk"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -87,7 +93,7 @@ exports[`SearchInput component renders 1`] = `
       />
     </svg>
     <input
-      class="sx1s1jh sx1s1jhpw03g--size-md sx1s1jh-qayb7"
+      class="sxtvycl sxtvyclpw03g--size-md sxtvycl-qayb7"
       type="search"
     />
   </div>

--- a/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -30,14 +30,14 @@ exports[`SearchInput component renders 1`] = `
   left: 10px;
 }
 
-.sxtvycl {
+.sx7g9w1 {
   -webkit-appearance: none;
   appearance: none;
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-shadow: none;
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   cursor: text;
   display: block;
   font-family: var(--sx-fonts-body);
@@ -47,29 +47,28 @@ exports[`SearchInput component renders 1`] = `
   width: 100%;
 }
 
-.sxtvycl:focus {
+.sx7g9w1:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxtvycl[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  border-color: var(--sx-colors-tonal300);
-  color: var(--sx-colors-tonal300);
+.sx7g9w1[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxtvycl::placeholder {
-  color: var(--sx-colors-tonal200);
+.sx7g9w1::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxtvyclpw03g--size-md {
+.sx7g9w1pw03g--size-md {
   height: var(--sx-sizes-4);
   font-size: var(--sx-fontSizes-md);
 }
 
-.sxtvycl-qayb7 {
+.sx7g9w1-qayb7 {
   padding-left: var(--sx-space-6);
 }
 
@@ -93,7 +92,7 @@ exports[`SearchInput component renders 1`] = `
       />
     </svg>
     <input
-      class="sxtvycl sxtvyclpw03g--size-md sxtvycl-qayb7"
+      class="sx7g9w1 sx7g9w1pw03g--size-md sx7g9w1-qayb7"
       type="search"
     />
   </div>

--- a/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
+++ b/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`SelectField component renders 1`] = `
   display: table;
 }
 
-.sxe93ip {
+.sxevq90 {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
@@ -44,7 +44,7 @@ exports[`SelectField component renders 1`] = `
   background-repeat: no-repeat, repeat;
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -53,27 +53,27 @@ exports[`SelectField component renders 1`] = `
   width: 100%;
 }
 
-.sxe93ip:hover {
+.sxevq90:hover {
   cursor: pointer;
 }
 
-.sxe93ip:focus {
+.sxevq90:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxe93ip::-ms-expand {
+.sxevq90::-ms-expand {
   display: none;
 }
 
-.sxe93ip[disabled],
-.sxe93ip > option[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxevq90[disabled],
+.sxevq90 > option[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxe93ipw1wwt--size-md {
+.sxevq90w1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -101,7 +101,7 @@ exports[`SelectField component renders 1`] = `
         </label>
       </div>
       <select
-        class="sxe93ip sxe93ipw1wwt--size-md"
+        class="sxevq90 sxevq90w1wwt--size-md"
         id="example"
         name="example"
       >

--- a/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
+++ b/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
@@ -11,40 +11,40 @@ exports[`SelectField component renders 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sxq32pr {
+.sxe93ip {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
   background-repeat: no-repeat, repeat;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -53,27 +53,27 @@ exports[`SelectField component renders 1`] = `
   width: 100%;
 }
 
-.sxq32pr:hover {
+.sxe93ip:hover {
   cursor: pointer;
 }
 
-.sxq32pr:focus {
+.sxe93ip:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq32pr::-ms-expand {
+.sxe93ip::-ms-expand {
   display: none;
 }
 
-.sxq32pr[disabled],
-.sxq32pr > option[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxe93ip[disabled],
+.sxe93ip > option[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxq32prw1wwt--size-md {
+.sxe93ipw1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -94,14 +94,14 @@ exports[`SelectField component renders 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="example"
         >
           Example options
         </label>
       </div>
       <select
-        class="sxq32pr sxq32prw1wwt--size-md"
+        class="sxe93ip sxe93ipw1wwt--size-md"
         id="example"
         name="example"
       >

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -7,11 +7,11 @@ import { Override } from '~/utilities/types'
 const StyledSelect = styled('select', {
   appearance: 'none',
   backgroundColor: 'white',
-  backgroundImage: encodeBackgroundIcon(theme.colors.tonal500.value, 'chevron'),
+  backgroundImage: encodeBackgroundIcon(theme.colors.tonal300.value, 'chevron'),
   backgroundRepeat: 'no-repeat, repeat',
-  border: '1px solid $tonal400',
+  border: '1px solid $tonal300',
   borderRadius: '$0',
-  color: '$tonal800',
+  color: '$tonal500',
   display: 'block',
   fontFamily: '$body',
   fontWeight: 400,
@@ -29,8 +29,8 @@ const StyledSelect = styled('select', {
     display: 'none'
   },
   '&[disabled], > option[disabled]': {
-    backgroundColor: '$tonal100',
-    color: '$tonal600',
+    backgroundColor: '$tonal50',
+    color: '$tonal300',
     cursor: 'not-allowed'
   },
   variants: {

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -11,7 +11,7 @@ const StyledSelect = styled('select', {
   backgroundRepeat: 'no-repeat, repeat',
   border: '1px solid $tonal300',
   borderRadius: '$0',
-  color: '$tonal500',
+  color: '$tonal600',
   display: 'block',
   fontFamily: '$body',
   fontWeight: 400,
@@ -29,8 +29,8 @@ const StyledSelect = styled('select', {
     display: 'none'
   },
   '&[disabled], > option[disabled]': {
-    backgroundColor: '$tonal50',
-    color: '$tonal300',
+    backgroundColor: '$tonal100',
+    color: '$tonal400',
     cursor: 'not-allowed'
   },
   variants: {

--- a/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component renders a select with 3 options 1`] = `
-.sxq32pr {
+.sxe93ip {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
   background-repeat: no-repeat, repeat;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -18,27 +18,27 @@ exports[`Select component renders a select with 3 options 1`] = `
   width: 100%;
 }
 
-.sxq32pr:hover {
+.sxe93ip:hover {
   cursor: pointer;
 }
 
-.sxq32pr:focus {
+.sxe93ip:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq32pr::-ms-expand {
+.sxe93ip::-ms-expand {
   display: none;
 }
 
-.sxq32pr[disabled],
-.sxq32pr > option[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxe93ip[disabled],
+.sxe93ip > option[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxq32prw1wwt--size-md {
+.sxe93ipw1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -50,7 +50,7 @@ exports[`Select component renders a select with 3 options 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxq32pr sxq32prw1wwt--size-md"
+    class="sxe93ip sxe93ipw1wwt--size-md"
   >
     <option
       value="value1"
@@ -72,15 +72,15 @@ exports[`Select component renders a select with 3 options 1`] = `
 `;
 
 exports[`Select component renders an disabled select 1`] = `
-.sxq32pr {
+.sxe93ip {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
   background-repeat: no-repeat, repeat;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -89,27 +89,27 @@ exports[`Select component renders an disabled select 1`] = `
   width: 100%;
 }
 
-.sxq32pr:hover {
+.sxe93ip:hover {
   cursor: pointer;
 }
 
-.sxq32pr:focus {
+.sxe93ip:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq32pr::-ms-expand {
+.sxe93ip::-ms-expand {
   display: none;
 }
 
-.sxq32pr[disabled],
-.sxq32pr > option[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxe93ip[disabled],
+.sxe93ip > option[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxq32prw1wwt--size-md {
+.sxe93ipw1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -121,22 +121,22 @@ exports[`Select component renders an disabled select 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxq32pr sxq32prw1wwt--size-md"
+    class="sxe93ip sxe93ipw1wwt--size-md"
     disabled=""
   />
 </div>
 `;
 
 exports[`Select component renders select with a default option 1`] = `
-.sxq32pr {
+.sxe93ip {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
   background-repeat: no-repeat, repeat;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -145,27 +145,27 @@ exports[`Select component renders select with a default option 1`] = `
   width: 100%;
 }
 
-.sxq32pr:hover {
+.sxe93ip:hover {
   cursor: pointer;
 }
 
-.sxq32pr:focus {
+.sxe93ip:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq32pr::-ms-expand {
+.sxe93ip::-ms-expand {
   display: none;
 }
 
-.sxq32pr[disabled],
-.sxq32pr > option[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxe93ip[disabled],
+.sxe93ip > option[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxq32prw1wwt--size-md {
+.sxe93ipw1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -177,7 +177,7 @@ exports[`Select component renders select with a default option 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxq32pr sxq32prw1wwt--size-md"
+    class="sxe93ip sxe93ipw1wwt--size-md"
   >
     <option
       disabled=""
@@ -207,15 +207,15 @@ exports[`Select component renders select with a default option 1`] = `
 `;
 
 exports[`Select component renders select with a disabled option 1`] = `
-.sxq32pr {
+.sxe93ip {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
   background-repeat: no-repeat, repeat;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -224,27 +224,27 @@ exports[`Select component renders select with a disabled option 1`] = `
   width: 100%;
 }
 
-.sxq32pr:hover {
+.sxe93ip:hover {
   cursor: pointer;
 }
 
-.sxq32pr:focus {
+.sxe93ip:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq32pr::-ms-expand {
+.sxe93ip::-ms-expand {
   display: none;
 }
 
-.sxq32pr[disabled],
-.sxq32pr > option[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxe93ip[disabled],
+.sxe93ip > option[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxq32prw1wwt--size-md {
+.sxe93ipw1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -256,7 +256,7 @@ exports[`Select component renders select with a disabled option 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxq32pr sxq32prw1wwt--size-md"
+    class="sxe93ip sxe93ipw1wwt--size-md"
   >
     <option
       value="value1"
@@ -284,15 +284,15 @@ exports[`Select component renders select with a disabled option 1`] = `
 `;
 
 exports[`Select component renders select with no options 1`] = `
-.sxq32pr {
+.sxe93ip {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
   background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
   background-repeat: no-repeat, repeat;
-  border: 1px solid var(--sx-colors-tonal400);
+  border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -301,27 +301,27 @@ exports[`Select component renders select with no options 1`] = `
   width: 100%;
 }
 
-.sxq32pr:hover {
+.sxe93ip:hover {
   cursor: pointer;
 }
 
-.sxq32pr:focus {
+.sxe93ip:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxq32pr::-ms-expand {
+.sxe93ip::-ms-expand {
   display: none;
 }
 
-.sxq32pr[disabled],
-.sxq32pr > option[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxe93ip[disabled],
+.sxe93ip > option[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sxq32prw1wwt--size-md {
+.sxe93ipw1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -333,7 +333,7 @@ exports[`Select component renders select with no options 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxq32pr sxq32prw1wwt--size-md"
+    class="sxe93ip sxe93ipw1wwt--size-md"
   />
 </div>
 `;

--- a/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component renders a select with 3 options 1`] = `
-.sxe93ip {
+.sxevq90 {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
@@ -9,7 +9,7 @@ exports[`Select component renders a select with 3 options 1`] = `
   background-repeat: no-repeat, repeat;
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -18,27 +18,27 @@ exports[`Select component renders a select with 3 options 1`] = `
   width: 100%;
 }
 
-.sxe93ip:hover {
+.sxevq90:hover {
   cursor: pointer;
 }
 
-.sxe93ip:focus {
+.sxevq90:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxe93ip::-ms-expand {
+.sxevq90::-ms-expand {
   display: none;
 }
 
-.sxe93ip[disabled],
-.sxe93ip > option[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxevq90[disabled],
+.sxevq90 > option[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxe93ipw1wwt--size-md {
+.sxevq90w1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -50,7 +50,7 @@ exports[`Select component renders a select with 3 options 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxe93ip sxe93ipw1wwt--size-md"
+    class="sxevq90 sxevq90w1wwt--size-md"
   >
     <option
       value="value1"
@@ -72,7 +72,7 @@ exports[`Select component renders a select with 3 options 1`] = `
 `;
 
 exports[`Select component renders an disabled select 1`] = `
-.sxe93ip {
+.sxevq90 {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
@@ -80,7 +80,7 @@ exports[`Select component renders an disabled select 1`] = `
   background-repeat: no-repeat, repeat;
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -89,27 +89,27 @@ exports[`Select component renders an disabled select 1`] = `
   width: 100%;
 }
 
-.sxe93ip:hover {
+.sxevq90:hover {
   cursor: pointer;
 }
 
-.sxe93ip:focus {
+.sxevq90:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxe93ip::-ms-expand {
+.sxevq90::-ms-expand {
   display: none;
 }
 
-.sxe93ip[disabled],
-.sxe93ip > option[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxevq90[disabled],
+.sxevq90 > option[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxe93ipw1wwt--size-md {
+.sxevq90w1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -121,14 +121,14 @@ exports[`Select component renders an disabled select 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxe93ip sxe93ipw1wwt--size-md"
+    class="sxevq90 sxevq90w1wwt--size-md"
     disabled=""
   />
 </div>
 `;
 
 exports[`Select component renders select with a default option 1`] = `
-.sxe93ip {
+.sxevq90 {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
@@ -136,7 +136,7 @@ exports[`Select component renders select with a default option 1`] = `
   background-repeat: no-repeat, repeat;
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -145,27 +145,27 @@ exports[`Select component renders select with a default option 1`] = `
   width: 100%;
 }
 
-.sxe93ip:hover {
+.sxevq90:hover {
   cursor: pointer;
 }
 
-.sxe93ip:focus {
+.sxevq90:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxe93ip::-ms-expand {
+.sxevq90::-ms-expand {
   display: none;
 }
 
-.sxe93ip[disabled],
-.sxe93ip > option[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxevq90[disabled],
+.sxevq90 > option[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxe93ipw1wwt--size-md {
+.sxevq90w1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -177,7 +177,7 @@ exports[`Select component renders select with a default option 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxe93ip sxe93ipw1wwt--size-md"
+    class="sxevq90 sxevq90w1wwt--size-md"
   >
     <option
       disabled=""
@@ -207,7 +207,7 @@ exports[`Select component renders select with a default option 1`] = `
 `;
 
 exports[`Select component renders select with a disabled option 1`] = `
-.sxe93ip {
+.sxevq90 {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
@@ -215,7 +215,7 @@ exports[`Select component renders select with a disabled option 1`] = `
   background-repeat: no-repeat, repeat;
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -224,27 +224,27 @@ exports[`Select component renders select with a disabled option 1`] = `
   width: 100%;
 }
 
-.sxe93ip:hover {
+.sxevq90:hover {
   cursor: pointer;
 }
 
-.sxe93ip:focus {
+.sxevq90:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxe93ip::-ms-expand {
+.sxevq90::-ms-expand {
   display: none;
 }
 
-.sxe93ip[disabled],
-.sxe93ip > option[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxevq90[disabled],
+.sxevq90 > option[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxe93ipw1wwt--size-md {
+.sxevq90w1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -256,7 +256,7 @@ exports[`Select component renders select with a disabled option 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxe93ip sxe93ipw1wwt--size-md"
+    class="sxevq90 sxevq90w1wwt--size-md"
   >
     <option
       value="value1"
@@ -284,7 +284,7 @@ exports[`Select component renders select with a disabled option 1`] = `
 `;
 
 exports[`Select component renders select with no options 1`] = `
-.sxe93ip {
+.sxevq90 {
   -webkit-appearance: none;
   appearance: none;
   background-color: white;
@@ -292,7 +292,7 @@ exports[`Select component renders select with no options 1`] = `
   background-repeat: no-repeat, repeat;
   border: 1px solid var(--sx-colors-tonal300);
   border-radius: var(--sx-radii-0);
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 400;
@@ -301,27 +301,27 @@ exports[`Select component renders select with no options 1`] = `
   width: 100%;
 }
 
-.sxe93ip:hover {
+.sxevq90:hover {
   cursor: pointer;
 }
 
-.sxe93ip:focus {
+.sxevq90:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxe93ip::-ms-expand {
+.sxevq90::-ms-expand {
   display: none;
 }
 
-.sxe93ip[disabled],
-.sxe93ip > option[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxevq90[disabled],
+.sxevq90 > option[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxe93ipw1wwt--size-md {
+.sxevq90w1wwt--size-md {
   background-position: right var(--sx-space-3) top 50%, 0 0;
   background-size: 20px auto, 100%;
   font-size: var(--sx-fontSizes-md);
@@ -333,7 +333,7 @@ exports[`Select component renders select with no options 1`] = `
 <div>
   <select
     aria-label="dropdown"
-    class="sxe93ip sxe93ipw1wwt--size-md"
+    class="sxevq90 sxevq90w1wwt--size-md"
   />
 </div>
 `;

--- a/src/components/stack-content/StackContent.tsx
+++ b/src/components/stack-content/StackContent.tsx
@@ -23,11 +23,11 @@ type StackContentProps = React.ComponentProps<typeof StyledStackContent> & {
   css?: CSS
 }
 
-const cloneWithStyle = (child: React.ReactElement, style: CSS) =>
+const cloneWithCss = (child: React.ReactElement, css: CSS) =>
   React.cloneElement(child, {
     css: {
-      ...style,
-      ...child.props.css
+      ...css,
+      ...(child.props.css ? child.props.css : {})
     }
   })
 
@@ -44,7 +44,7 @@ export const StackContent: React.FC<StackContentProps> = ({
       const type = child?.type
 
       if (type === Heading || type === MarkdownHeading) {
-        return cloneWithStyle(child, {
+        return cloneWithCss(child, {
           maxWidth: '65ch',
           '&:not(:first-child)': { mt: '$5' },
           '&:not(:last-child)': { mb: '$5' }
@@ -57,20 +57,20 @@ export const StackContent: React.FC<StackContentProps> = ({
         type === List ||
         type === MarkdownList
       ) {
-        return cloneWithStyle(child, {
+        return cloneWithCss(child, {
           maxWidth: '75ch',
           '&:not(:last-child)': { mb: '$5' }
         })
       }
 
       if (type === Divider || type === MarkdownThematicBreak) {
-        return cloneWithStyle(child, {
+        return cloneWithCss(child, {
           my: '$5'
         })
       }
 
       if (type === Image || type === MarkdownImage) {
-        return cloneWithStyle(child, {
+        return cloneWithCss(child, {
           display: 'block',
           '&:not(:first-child)': { mt: '$6' },
           '&:not(:last-child)': { mb: '$6' }

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -13,10 +13,14 @@ const StyledSwitch = styled(RadixSwitch.Root, {
   overflow: 'hidden',
   p: '$0',
   position: 'relative',
-  transition: 'background-color 100ms ease',
+  transition: 'all 50ms ease-out',
   width: '$4',
   '&:hover': {
     backgroundColor: '$tonal300'
+  },
+  '&:focus': {
+    outline: '2px solid $primary',
+    outlineOffset: '1px'
   },
   '&[data-state="checked"]': {
     backgroundColor: '$primary'
@@ -27,11 +31,11 @@ const StyledSwitch = styled(RadixSwitch.Root, {
 })
 
 const StyledThumb = styled(RadixSwitch.Thumb, {
-  display: 'block',
-  size: '$1',
   backgroundColor: 'white',
   borderRadius: '$round',
-  transition: 'transform 100ms',
+  display: 'block',
+  size: '$1',
+  transition: 'transform 75ms',
   willChange: 'transform',
   '&[data-state="checked"]': {
     transform: 'translateX(calc($sizes$2 - $space$1))'

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -5,7 +5,7 @@ import { styled } from '~/stitches'
 
 const StyledSwitch = styled(RadixSwitch.Root, {
   appearance: 'none',
-  backgroundColor: '$tonal300',
+  backgroundColor: '$tonal200',
   border: 'none',
   borderRadius: '$round',
   cursor: 'pointer',
@@ -16,13 +16,13 @@ const StyledSwitch = styled(RadixSwitch.Root, {
   transition: 'background-color 100ms ease',
   width: '$4',
   '&:hover': {
-    backgroundColor: '$tonal400'
+    backgroundColor: '$tonal300'
   },
   '&[data-state="checked"]': {
     backgroundColor: '$primary'
   },
   '&[data-state="checked"]:hover': {
-    backgroundColor: '$tertiary'
+    backgroundColor: '$primaryMid'
   }
 })
 

--- a/src/components/switch/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/switch/__snapshots__/Switch.test.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch component renders a Switch in "on" state 1`] = `
-.sx1jh2a {
+.sxtzpi0 {
   -webkit-appearance: none;
   appearance: none;
-  background-color: var(--sx-colors-tonal300);
+  background-color: var(--sx-colors-tonal200);
   border: none;
   border-radius: var(--sx-radii-round);
   cursor: pointer;
@@ -16,16 +16,16 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
   width: var(--sx-sizes-4);
 }
 
-.sx1jh2a:hover {
-  background-color: var(--sx-colors-tonal400);
+.sxtzpi0:hover {
+  background-color: var(--sx-colors-tonal300);
 }
 
-.sx1jh2a[data-state="checked"] {
+.sxtzpi0[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sx1jh2a[data-state="checked"]:hover {
-  background-color: var(--sx-colors-tertiary);
+.sxtzpi0[data-state="checked"]:hover {
+  background-color: var(--sx-colors-primaryMid);
 }
 
 .sxxf22o {
@@ -51,7 +51,7 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
   />
   <button
     aria-checked="true"
-    class="sx1jh2a"
+    class="sxtzpi0"
     data-state="checked"
     role="switch"
     type="button"
@@ -66,10 +66,10 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
 `;
 
 exports[`Switch component renders a disabled switch 1`] = `
-.sx1jh2a {
+.sxtzpi0 {
   -webkit-appearance: none;
   appearance: none;
-  background-color: var(--sx-colors-tonal300);
+  background-color: var(--sx-colors-tonal200);
   border: none;
   border-radius: var(--sx-radii-round);
   cursor: pointer;
@@ -81,16 +81,16 @@ exports[`Switch component renders a disabled switch 1`] = `
   width: var(--sx-sizes-4);
 }
 
-.sx1jh2a:hover {
-  background-color: var(--sx-colors-tonal400);
+.sxtzpi0:hover {
+  background-color: var(--sx-colors-tonal300);
 }
 
-.sx1jh2a[data-state="checked"] {
+.sxtzpi0[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sx1jh2a[data-state="checked"]:hover {
-  background-color: var(--sx-colors-tertiary);
+.sxtzpi0[data-state="checked"]:hover {
+  background-color: var(--sx-colors-primaryMid);
 }
 
 .sxxf22o {
@@ -116,7 +116,7 @@ exports[`Switch component renders a disabled switch 1`] = `
   />
   <button
     aria-checked="false"
-    class="sx1jh2a"
+    class="sxtzpi0"
     data-disabled=""
     data-state="unchecked"
     disabled=""
@@ -134,10 +134,10 @@ exports[`Switch component renders a disabled switch 1`] = `
 `;
 
 exports[`Switch component renders a switch 1`] = `
-.sx1jh2a {
+.sxtzpi0 {
   -webkit-appearance: none;
   appearance: none;
-  background-color: var(--sx-colors-tonal300);
+  background-color: var(--sx-colors-tonal200);
   border: none;
   border-radius: var(--sx-radii-round);
   cursor: pointer;
@@ -149,16 +149,16 @@ exports[`Switch component renders a switch 1`] = `
   width: var(--sx-sizes-4);
 }
 
-.sx1jh2a:hover {
-  background-color: var(--sx-colors-tonal400);
+.sxtzpi0:hover {
+  background-color: var(--sx-colors-tonal300);
 }
 
-.sx1jh2a[data-state="checked"] {
+.sxtzpi0[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sx1jh2a[data-state="checked"]:hover {
-  background-color: var(--sx-colors-tertiary);
+.sxtzpi0[data-state="checked"]:hover {
+  background-color: var(--sx-colors-primaryMid);
 }
 
 .sxxf22o {
@@ -183,7 +183,7 @@ exports[`Switch component renders a switch 1`] = `
   />
   <button
     aria-checked="false"
-    class="sx1jh2a"
+    class="sxtzpi0"
     data-state="unchecked"
     role="switch"
     type="button"

--- a/src/components/switch/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/switch/__snapshots__/Switch.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch component renders a Switch in "on" state 1`] = `
-.sxtzpi0 {
+.sxnodlz {
   -webkit-appearance: none;
   appearance: none;
   background-color: var(--sx-colors-tonal200);
@@ -12,33 +12,38 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
   overflow: hidden;
   padding: var(--sx-space-0);
   position: relative;
-  transition: background-color 100ms ease;
+  transition: all 50ms ease-out;
   width: var(--sx-sizes-4);
 }
 
-.sxtzpi0:hover {
+.sxnodlz:hover {
   background-color: var(--sx-colors-tonal300);
 }
 
-.sxtzpi0[data-state="checked"] {
+.sxnodlz:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
+}
+
+.sxnodlz[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sxtzpi0[data-state="checked"]:hover {
+.sxnodlz[data-state="checked"]:hover {
   background-color: var(--sx-colors-primaryMid);
 }
 
-.sxxf22o {
+.sx6yqld {
+  background-color: white;
+  border-radius: var(--sx-radii-round);
   display: block;
   height: var(--sx-sizes-1);
   width: var(--sx-sizes-1);
-  background-color: white;
-  border-radius: var(--sx-radii-round);
-  transition: transform 100ms;
+  transition: transform 75ms;
   will-change: transform;
 }
 
-.sxxf22o[data-state="checked"] {
+.sx6yqld[data-state="checked"] {
   transform: translateX(calc(var(--sx-sizes-2) - var(--sx-space-1)));
 }
 
@@ -51,14 +56,14 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
   />
   <button
     aria-checked="true"
-    class="sxtzpi0"
+    class="sxnodlz"
     data-state="checked"
     role="switch"
     type="button"
     value="on"
   >
     <span
-      class="sxxf22o"
+      class="sx6yqld"
       data-state="checked"
     />
   </button>
@@ -66,7 +71,7 @@ exports[`Switch component renders a Switch in "on" state 1`] = `
 `;
 
 exports[`Switch component renders a disabled switch 1`] = `
-.sxtzpi0 {
+.sxnodlz {
   -webkit-appearance: none;
   appearance: none;
   background-color: var(--sx-colors-tonal200);
@@ -77,33 +82,38 @@ exports[`Switch component renders a disabled switch 1`] = `
   overflow: hidden;
   padding: var(--sx-space-0);
   position: relative;
-  transition: background-color 100ms ease;
+  transition: all 50ms ease-out;
   width: var(--sx-sizes-4);
 }
 
-.sxtzpi0:hover {
+.sxnodlz:hover {
   background-color: var(--sx-colors-tonal300);
 }
 
-.sxtzpi0[data-state="checked"] {
+.sxnodlz:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
+}
+
+.sxnodlz[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sxtzpi0[data-state="checked"]:hover {
+.sxnodlz[data-state="checked"]:hover {
   background-color: var(--sx-colors-primaryMid);
 }
 
-.sxxf22o {
+.sx6yqld {
+  background-color: white;
+  border-radius: var(--sx-radii-round);
   display: block;
   height: var(--sx-sizes-1);
   width: var(--sx-sizes-1);
-  background-color: white;
-  border-radius: var(--sx-radii-round);
-  transition: transform 100ms;
+  transition: transform 75ms;
   will-change: transform;
 }
 
-.sxxf22o[data-state="checked"] {
+.sx6yqld[data-state="checked"] {
   transform: translateX(calc(var(--sx-sizes-2) - var(--sx-space-1)));
 }
 
@@ -116,7 +126,7 @@ exports[`Switch component renders a disabled switch 1`] = `
   />
   <button
     aria-checked="false"
-    class="sxtzpi0"
+    class="sxnodlz"
     data-disabled=""
     data-state="unchecked"
     disabled=""
@@ -125,7 +135,7 @@ exports[`Switch component renders a disabled switch 1`] = `
     value="on"
   >
     <span
-      class="sxxf22o"
+      class="sx6yqld"
       data-disabled=""
       data-state="unchecked"
     />
@@ -134,7 +144,7 @@ exports[`Switch component renders a disabled switch 1`] = `
 `;
 
 exports[`Switch component renders a switch 1`] = `
-.sxtzpi0 {
+.sxnodlz {
   -webkit-appearance: none;
   appearance: none;
   background-color: var(--sx-colors-tonal200);
@@ -145,33 +155,38 @@ exports[`Switch component renders a switch 1`] = `
   overflow: hidden;
   padding: var(--sx-space-0);
   position: relative;
-  transition: background-color 100ms ease;
+  transition: all 50ms ease-out;
   width: var(--sx-sizes-4);
 }
 
-.sxtzpi0:hover {
+.sxnodlz:hover {
   background-color: var(--sx-colors-tonal300);
 }
 
-.sxtzpi0[data-state="checked"] {
+.sxnodlz:focus {
+  outline: 2px solid var(--sx-colors-primary);
+  outline-offset: 1px;
+}
+
+.sxnodlz[data-state="checked"] {
   background-color: var(--sx-colors-primary);
 }
 
-.sxtzpi0[data-state="checked"]:hover {
+.sxnodlz[data-state="checked"]:hover {
   background-color: var(--sx-colors-primaryMid);
 }
 
-.sxxf22o {
+.sx6yqld {
+  background-color: white;
+  border-radius: var(--sx-radii-round);
   display: block;
   height: var(--sx-sizes-1);
   width: var(--sx-sizes-1);
-  background-color: white;
-  border-radius: var(--sx-radii-round);
-  transition: transform 100ms;
+  transition: transform 75ms;
   will-change: transform;
 }
 
-.sxxf22o[data-state="checked"] {
+.sx6yqld[data-state="checked"] {
   transform: translateX(calc(var(--sx-sizes-2) - var(--sx-space-1)));
 }
 
@@ -183,14 +198,14 @@ exports[`Switch component renders a switch 1`] = `
   />
   <button
     aria-checked="false"
-    class="sxtzpi0"
+    class="sxnodlz"
     data-state="unchecked"
     role="switch"
     type="button"
     value="on"
   >
     <span
-      class="sxxf22o"
+      class="sx6yqld"
       data-state="unchecked"
     />
   </button>

--- a/src/components/table/TableCell.tsx
+++ b/src/components/table/TableCell.tsx
@@ -1,9 +1,9 @@
 import { styled } from '~/stitches'
 
 export const TableCell = styled('td', {
-  borderBottom: '1px solid $tonal200',
+  borderBottom: '1px solid $tonal100',
   boxSizing: 'border-box',
-  color: '$tonal600',
+  color: '$tonal300',
   fontFamily: '$body',
   lineHeight: 1.5,
   p: '$2 $3',

--- a/src/components/table/TableFooterCell.tsx
+++ b/src/components/table/TableFooterCell.tsx
@@ -1,7 +1,7 @@
 import { styled } from '~/stitches'
 
 export const TableFooterCell = styled('td', {
-  color: '$tonal500',
+  color: '$tonal300',
   fontFamily: '$body',
   fontWeight: 600,
   p: '$2 $3',

--- a/src/components/table/TableHeaderCell.tsx
+++ b/src/components/table/TableHeaderCell.tsx
@@ -1,7 +1,7 @@
 import { styled } from '~/stitches'
 
 export const TableHeaderCell = styled('th', {
-  bg: '$tertiary',
+  bg: '$primaryDark',
   color: 'white',
   fontFamily: '$body',
   fontWeight: 600,

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table component renders 1`] = `
-.sxyjtjl {
-  border-bottom: 1px solid var(--sx-colors-tonal200);
+.sx995qk {
+  border-bottom: 1px solid var(--sx-colors-tonal100);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal600);
+  color: var(--sx-colors-tonal300);
   font-family: var(--sx-fonts-body);
   line-height: 1.5;
   padding: var(--sx-space-2) var(--sx-space-3);
@@ -12,12 +12,12 @@ exports[`Table component renders 1`] = `
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sxyjtjl {
+tr:nth-child(even) .sx995qk {
   background: var(--sx-colors-tonal50);
 }
 
-.sxgmopz {
-  background: var(--sx-colors-tertiary);
+.sxzmp3v {
+  background: var(--sx-colors-primaryDark);
   color: white;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
@@ -27,28 +27,28 @@ tr:nth-child(even) .sxyjtjl {
   vertical-align: middle;
 }
 
-.sxgmopz:first-of-type {
+.sxzmp3v:first-of-type {
   border-top-left-radius: var(--sx-radii-0);
   border-bottom-left-radius: var(--sx-radii-0);
 }
 
-.sxgmopz:last-of-type {
+.sxzmp3v:last-of-type {
   border-top-right-radius: var(--sx-radii-0);
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxf58vn {
+.sx6ya0a {
   border-collapse: collapse;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
   width: 100%;
 }
 
-.sxf58vna43go--size-md .sxyjtjl {
+.sx6ya0aitr32--size-md .sx995qk {
   height: var(--sx-sizes-4);
 }
 
-.sxf58vn-a5b4a {
+.sx6ya0a-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -56,7 +56,7 @@ tr:nth-child(even) .sxyjtjl {
 
 <div>
   <table
-    class="sxf58vn sxf58vna43go--size-md sxf58vn-a5b4a"
+    class="sx6ya0a sx6ya0aitr32--size-md sx6ya0a-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -65,7 +65,7 @@ tr:nth-child(even) .sxyjtjl {
         class="sx03kze"
       >
         <th
-          class="sxgmopz"
+          class="sxzmp3v"
         >
           Column A
         </th>
@@ -78,7 +78,7 @@ tr:nth-child(even) .sxyjtjl {
         class="sx03kze"
       >
         <td
-          class="sxyjtjl"
+          class="sx995qk"
         >
           This is text
         </td>
@@ -91,7 +91,7 @@ tr:nth-child(even) .sxyjtjl {
         class="sx03kze"
       >
         <td
-          class="sxyjtjl"
+          class="sx995qk"
         >
           Footer 1
         </td>
@@ -102,10 +102,10 @@ tr:nth-child(even) .sxyjtjl {
 `;
 
 exports[`Table component renders with size set to lg 1`] = `
-.sxyjtjl {
-  border-bottom: 1px solid var(--sx-colors-tonal200);
+.sx995qk {
+  border-bottom: 1px solid var(--sx-colors-tonal100);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal600);
+  color: var(--sx-colors-tonal300);
   font-family: var(--sx-fonts-body);
   line-height: 1.5;
   padding: var(--sx-space-2) var(--sx-space-3);
@@ -113,12 +113,12 @@ exports[`Table component renders with size set to lg 1`] = `
   vertical-align: middle;
 }
 
-tr:nth-child(even) .sxyjtjl {
+tr:nth-child(even) .sx995qk {
   background: var(--sx-colors-tonal50);
 }
 
-.sxgmopz {
-  background: var(--sx-colors-tertiary);
+.sxzmp3v {
+  background: var(--sx-colors-primaryDark);
   color: white;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
@@ -128,32 +128,32 @@ tr:nth-child(even) .sxyjtjl {
   vertical-align: middle;
 }
 
-.sxgmopz:first-of-type {
+.sxzmp3v:first-of-type {
   border-top-left-radius: var(--sx-radii-0);
   border-bottom-left-radius: var(--sx-radii-0);
 }
 
-.sxgmopz:last-of-type {
+.sxzmp3v:last-of-type {
   border-top-right-radius: var(--sx-radii-0);
   border-bottom-right-radius: var(--sx-radii-0);
 }
 
-.sxf58vn {
+.sx6ya0a {
   border-collapse: collapse;
   font-family: var(--sx-fonts-sans);
   font-size: var(--sx-fontSizes-sm);
   width: 100%;
 }
 
-.sxf58vna43go--size-md .sxyjtjl {
+.sx6ya0aitr32--size-md .sx995qk {
   height: var(--sx-sizes-4);
 }
 
-.sxf58vnfj3j5--size-lg .sxyjtjl {
+.sx6ya0ae9knf--size-lg .sx995qk {
   height: var(--sx-sizes-5);
 }
 
-.sxf58vn-a5b4a {
+.sx6ya0a-a5b4a {
   height: 100px;
   width: 400px;
   color: var(--sx-colors-primary500);
@@ -161,7 +161,7 @@ tr:nth-child(even) .sxyjtjl {
 
 <div>
   <table
-    class="sxf58vn sxf58vnfj3j5--size-lg sxf58vn-a5b4a"
+    class="sx6ya0a sx6ya0ae9knf--size-lg sx6ya0a-a5b4a"
   >
     <thead
       class="sx03kze"
@@ -170,7 +170,7 @@ tr:nth-child(even) .sxyjtjl {
         class="sx03kze"
       >
         <th
-          class="sxgmopz"
+          class="sxzmp3v"
         >
           Column A
         </th>
@@ -183,7 +183,7 @@ tr:nth-child(even) .sxyjtjl {
         class="sx03kze"
       >
         <td
-          class="sxyjtjl"
+          class="sx995qk"
         >
           This is text
         </td>
@@ -196,7 +196,7 @@ tr:nth-child(even) .sxyjtjl {
         class="sx03kze"
       >
         <td
-          class="sxyjtjl"
+          class="sx995qk"
         >
           Footer 1
         </td>

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -11,7 +11,7 @@ const StyledTabTrigger = styled(Trigger, {
   p: '$4',
   userSelect: 'none',
   '&:hover': { color: '$primary' },
-  '&[data-disabled],&[data-disabled]:hover': { color: '$tonal500' },
+  '&[data-disabled],&[data-disabled]:hover': { color: '$tonal300' },
   '&[data-state="active"]': {
     color: '$primary',
     fontWeight: 'bold',

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -17,7 +17,7 @@ const StyledTabContent = styled(Content, {
 const StyledTriggerList = styled(List, {
   flexShrink: 0,
   display: 'flex',
-  borderBottom: '1px solid $tertiary'
+  borderBottom: '1px solid $primaryDark'
 })
 
 type TabsProps = React.ComponentProps<typeof StyledRoot>

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -37,7 +37,7 @@ export const textVariantSize = ({ applyCapsize = true } = {}): Record<
 })
 
 export const StyledParagraph = styled('p', {
-  color: '$tonal800',
+  color: '$tonal500',
   fontFamily: '$body',
   fontWeight: 400,
   margin: 0,

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -37,7 +37,7 @@ export const textVariantSize = ({ applyCapsize = true } = {}): Record<
 })
 
 export const StyledParagraph = styled('p', {
-  color: '$tonal500',
+  color: '$tonal600',
   fontFamily: '$body',
   fontWeight: 400,
   margin: 0,

--- a/src/components/text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/text/__snapshots__/Text.test.tsx.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Text component renders some text 1`] = `
-.sxyn8hn {
-  color: var(--sx-colors-tonal500);
+.sx8yt8k {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxyn8hn8bitc--size-md {
+.sx8yt8k8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxyn8hn8bitc--size-md::before {
+.sx8yt8k8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxyn8hn8bitc--size-md::after {
+.sx8yt8k8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -27,7 +27,7 @@ exports[`Text component renders some text 1`] = `
 
 <div>
   <p
-    class="sxyn8hn sxyn8hn8bitc--size-md"
+    class="sx8yt8k sx8yt8k8bitc--size-md"
   >
     TEXT
   </p>

--- a/src/components/text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/text/__snapshots__/Text.test.tsx.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Text component renders some text 1`] = `
-.sxj1d4e {
-  color: var(--sx-colors-tonal800);
+.sxyn8hn {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxj1d4e8bitc--size-md {
+.sxyn8hn8bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sxj1d4e8bitc--size-md::before {
+.sxyn8hn8bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sxj1d4e8bitc--size-md::after {
+.sxyn8hn8bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
@@ -27,7 +27,7 @@ exports[`Text component renders some text 1`] = `
 
 <div>
   <p
-    class="sxj1d4e sxj1d4e8bitc--size-md"
+    class="sxyn8hn sxyn8hn8bitc--size-md"
   >
     TEXT
   </p>

--- a/src/components/textarea-field/__snapshots__/TextareaField.test.tsx.snap
+++ b/src/components/textarea-field/__snapshots__/TextareaField.test.tsx.snap
@@ -11,32 +11,32 @@ exports[`TextareaField component renders 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sx5661z {
+.sxym69s {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -44,7 +44,7 @@ exports[`TextareaField component renders 1`] = `
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   line-height: 1.4;
@@ -58,15 +58,20 @@ exports[`TextareaField component renders 1`] = `
   width: 100%;
 }
 
-.sx5661z:focus {
+.sxym69s:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx5661z[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxym69s[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
+}
+
+.sxym69s::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
 }
 
 <div>
@@ -81,12 +86,12 @@ exports[`TextareaField component renders 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="description"
         />
       </div>
       <textarea
-        class="sx5661z"
+        class="sxym69s"
         id="description"
         name="description"
         placeholder="placeholder"
@@ -107,32 +112,32 @@ exports[`TextareaField component renders with an error 1`] = `
   margin-bottom: var(--sx-space-3);
 }
 
-.sx5eeij {
-  color: var(--sx-colors-tonal800);
+.sxbagj1 {
+  color: var(--sx-colors-tonal500);
   display: block;
   font-family: var(--sx-fonts-body);
   font-weight: 600;
   margin: 0;
 }
 
-.sx5eeij8bitc--size-md {
+.sxbagj18bitc--size-md {
   font-size: var(--sx-fontSizes-md);
   line-height: 1.5;
 }
 
-.sx5eeij8bitc--size-md::before {
+.sxbagj18bitc--size-md::before {
   content: '';
   margin-bottom: -0.3864em;
   display: table;
 }
 
-.sx5eeij8bitc--size-md::after {
+.sxbagj18bitc--size-md::after {
   content: '';
   margin-top: -0.3864em;
   display: table;
 }
 
-.sx5661z {
+.sxym69s {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -140,7 +145,7 @@ exports[`TextareaField component renders with an error 1`] = `
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   line-height: 1.4;
@@ -154,15 +159,20 @@ exports[`TextareaField component renders with an error 1`] = `
   width: 100%;
 }
 
-.sx5661z:focus {
+.sxym69s:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx5661z[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxym69s[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
+}
+
+.sxym69s::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
 }
 
 <div>
@@ -177,12 +187,12 @@ exports[`TextareaField component renders with an error 1`] = `
         class="sx2cs53 sx2cs53-qom1k"
       >
         <label
-          class="sx5eeij sx5eeij8bitc--size-md"
+          class="sxbagj1 sxbagj18bitc--size-md"
           for="description"
         />
       </div>
       <textarea
-        class="sx5661z"
+        class="sxym69s"
         error="Error Message"
         id="description"
         name="description"

--- a/src/components/textarea-field/__snapshots__/TextareaField.test.tsx.snap
+++ b/src/components/textarea-field/__snapshots__/TextareaField.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`TextareaField component renders 1`] = `
   display: table;
 }
 
-.sxym69s {
+.sxw9jbw {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -44,7 +44,7 @@ exports[`TextareaField component renders 1`] = `
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   line-height: 1.4;
@@ -58,19 +58,19 @@ exports[`TextareaField component renders 1`] = `
   width: 100%;
 }
 
-.sxym69s:focus {
+.sxw9jbw:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxym69s[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxw9jbw[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxym69s::placeholder {
-  color: var(--sx-colors-tonal200);
+.sxw9jbw::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
@@ -91,7 +91,7 @@ exports[`TextareaField component renders 1`] = `
         />
       </div>
       <textarea
-        class="sxym69s"
+        class="sxw9jbw"
         id="description"
         name="description"
         placeholder="placeholder"
@@ -137,7 +137,7 @@ exports[`TextareaField component renders with an error 1`] = `
   display: table;
 }
 
-.sxym69s {
+.sxw9jbw {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -145,7 +145,7 @@ exports[`TextareaField component renders with an error 1`] = `
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   line-height: 1.4;
@@ -159,19 +159,19 @@ exports[`TextareaField component renders with an error 1`] = `
   width: 100%;
 }
 
-.sxym69s:focus {
+.sxw9jbw:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxym69s[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxw9jbw[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxym69s::placeholder {
-  color: var(--sx-colors-tonal200);
+.sxw9jbw::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
@@ -192,7 +192,7 @@ exports[`TextareaField component renders with an error 1`] = `
         />
       </div>
       <textarea
-        class="sxym69s"
+        class="sxw9jbw"
         error="Error Message"
         id="description"
         name="description"

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -9,7 +9,7 @@ const StyledTextarea = styled('textarea', {
   border: '1px solid $tonal400',
   borderRadius: '$0',
   boxSizing: 'border-box',
-  color: '$tonal500',
+  color: '$tonal600',
   fontFamily: '$body',
   fontWeight: 400,
   lineHeight: 1.4,
@@ -24,12 +24,12 @@ const StyledTextarea = styled('textarea', {
     outline: 'none'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal50',
-    color: '$tonal300',
+    backgroundColor: '$tonal100',
+    color: '$tonal400',
     cursor: 'not-allowed'
   },
   '&::placeholder': {
-    color: '$tonal200',
+    color: '$tonal300',
     opacity: 1
   },
   variants: {

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -9,7 +9,7 @@ const StyledTextarea = styled('textarea', {
   border: '1px solid $tonal400',
   borderRadius: '$0',
   boxSizing: 'border-box',
-  color: '$tonal800',
+  color: '$tonal500',
   fontFamily: '$body',
   fontWeight: 400,
   lineHeight: 1.4,
@@ -24,9 +24,13 @@ const StyledTextarea = styled('textarea', {
     outline: 'none'
   },
   '&[disabled]': {
-    backgroundColor: '$tonal100',
-    color: '$tonal600',
+    backgroundColor: '$tonal50',
+    color: '$tonal300',
     cursor: 'not-allowed'
+  },
+  '&::placeholder': {
+    color: '$tonal200',
+    opacity: 1
   },
   variants: {
     state: {

--- a/src/components/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/components/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Textarea component renders a textarea 1`] = `
-.sxym69s {
+.sxw9jbw {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -9,7 +9,7 @@ exports[`Textarea component renders a textarea 1`] = `
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal500);
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   line-height: 1.4;
@@ -23,23 +23,23 @@ exports[`Textarea component renders a textarea 1`] = `
   width: 100%;
 }
 
-.sxym69s:focus {
+.sxw9jbw:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sxym69s[disabled] {
-  background-color: var(--sx-colors-tonal50);
-  color: var(--sx-colors-tonal300);
+.sxw9jbw[disabled] {
+  background-color: var(--sx-colors-tonal100);
+  color: var(--sx-colors-tonal400);
   cursor: not-allowed;
 }
 
-.sxym69s::placeholder {
-  color: var(--sx-colors-tonal200);
+.sxw9jbw::placeholder {
+  color: var(--sx-colors-tonal300);
   opacity: 1;
 }
 
-.sxym69s-6obnf {
+.sxw9jbw-6obnf {
   margin: auto;
   height: 100px;
   width: 100px;
@@ -47,7 +47,7 @@ exports[`Textarea component renders a textarea 1`] = `
 
 <div>
   <textarea
-    class="sxym69s sxym69s-6obnf"
+    class="sxw9jbw sxw9jbw-6obnf"
     placeholder="DESCRIPTION"
   />
 </div>

--- a/src/components/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/components/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Textarea component renders a textarea 1`] = `
-.sx5661z {
+.sxym69s {
   box-shadow: none;
   font-size: var(--sx-fontSizes-md);
   -webkit-appearance: none;
@@ -9,7 +9,7 @@ exports[`Textarea component renders a textarea 1`] = `
   border: 1px solid var(--sx-colors-tonal400);
   border-radius: var(--sx-radii-0);
   box-sizing: border-box;
-  color: var(--sx-colors-tonal800);
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   line-height: 1.4;
@@ -23,18 +23,23 @@ exports[`Textarea component renders a textarea 1`] = `
   width: 100%;
 }
 
-.sx5661z:focus {
+.sxym69s:focus {
   border-color: var(--sx-colors-primary);
   outline: none;
 }
 
-.sx5661z[disabled] {
-  background-color: var(--sx-colors-tonal100);
-  color: var(--sx-colors-tonal600);
+.sxym69s[disabled] {
+  background-color: var(--sx-colors-tonal50);
+  color: var(--sx-colors-tonal300);
   cursor: not-allowed;
 }
 
-.sx5661z-6obnf {
+.sxym69s::placeholder {
+  color: var(--sx-colors-tonal200);
+  opacity: 1;
+}
+
+.sxym69s-6obnf {
   margin: auto;
   height: 100px;
   width: 100px;
@@ -42,7 +47,7 @@ exports[`Textarea component renders a textarea 1`] = `
 
 <div>
   <textarea
-    class="sx5661z sx5661z-6obnf"
+    class="sxym69s sxym69s-6obnf"
     placeholder="DESCRIPTION"
   />
 </div>

--- a/src/components/tooltip/TooltipContent.tsx
+++ b/src/components/tooltip/TooltipContent.tsx
@@ -10,7 +10,7 @@ const scaleIn = keyframes({
 
 const StyledContent = styled(Content, {
   animation: `${scaleIn} 75ms ease-out`,
-  backgroundColor: '$tonal700',
+  backgroundColor: '$tonal500',
   borderRadius: '$0',
   boxShadow: '$0',
   color: 'white',
@@ -30,7 +30,7 @@ const StyledContent = styled(Content, {
 })
 
 const StyledArrow = styled(Arrow, {
-  fill: '$tonal700',
+  fill: '$tonal500',
   '[data-align="end"] &': { mr: '$2' },
   '[data-align="start"] &': { ml: '$2' }
 })

--- a/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
+++ b/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
@@ -30,31 +30,31 @@ exports[`ValidationError component renders a validation error 1`] = `
   flex-shrink: 0;
 }
 
-.sxyn8hn {
-  color: var(--sx-colors-tonal500);
+.sx8yt8k {
+  color: var(--sx-colors-tonal600);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxyn8hnid6h2--size-sm {
+.sx8yt8kid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxyn8hnid6h2--size-sm::before {
+.sx8yt8kid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxyn8hnid6h2--size-sm::after {
+.sx8yt8kid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxyn8hn-n4ol9 {
+.sx8yt8k-n4ol9 {
   color: inherit;
   transform: translateY(var(--sx-space-1));
 }
@@ -85,7 +85,7 @@ exports[`ValidationError component renders a validation error 1`] = `
       />
     </svg>
     <p
-      class="sxyn8hn sxyn8hnid6h2--size-sm sxyn8hn-n4ol9"
+      class="sx8yt8k sx8yt8kid6h2--size-sm sx8yt8k-n4ol9"
     >
       VALIDATION ERROR
     </p>

--- a/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
+++ b/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
@@ -10,51 +10,51 @@ exports[`ValidationError component renders a validation error 1`] = `
   align-items: flex-start;
 }
 
-.sxtros6 {
+.sxakl60 {
   display: inline-block;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
   vertical-align: middle;
 }
 
-.sxtros6or94y--size-sm {
+.sxakl60op5z4--size-sm {
   height: var(--sx-sizes-1);
   width: var(--sx-sizes-1);
+  stroke-width: 1.75;
 }
 
-.sxtros6-iux96 {
+.sxakl60-iux96 {
   margin-right: var(--sx-space-2);
   flex-shrink: 0;
 }
 
-.sxj1d4e {
-  color: var(--sx-colors-tonal800);
+.sxyn8hn {
+  color: var(--sx-colors-tonal500);
   font-family: var(--sx-fonts-body);
   font-weight: 400;
   margin: 0;
 }
 
-.sxj1d4eid6h2--size-sm {
+.sxyn8hnid6h2--size-sm {
   font-size: var(--sx-fontSizes-sm);
   line-height: 1.53;
 }
 
-.sxj1d4eid6h2--size-sm::before {
+.sxyn8hnid6h2--size-sm::before {
   content: '';
   margin-bottom: -0.4056em;
   display: table;
 }
 
-.sxj1d4eid6h2--size-sm::after {
+.sxyn8hnid6h2--size-sm::after {
   content: '';
   margin-top: -0.4056em;
   display: table;
 }
 
-.sxj1d4e-n4ol9 {
+.sxyn8hn-n4ol9 {
   color: inherit;
   transform: translateY(var(--sx-space-1));
 }
@@ -65,7 +65,7 @@ exports[`ValidationError component renders a validation error 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="sxtros6 sxtros6or94y--size-sm sxtros6-iux96"
+      class="sxakl60 sxakl60op5z4--size-sm sxakl60-iux96"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -85,7 +85,7 @@ exports[`ValidationError component renders a validation error 1`] = `
       />
     </svg>
     <p
-      class="sxj1d4e sxj1d4eid6h2--size-sm sxj1d4e-n4ol9"
+      class="sxyn8hn sxyn8hnid6h2--size-sm sxyn8hn-n4ol9"
     >
       VALIDATION ERROR
     </p>

--- a/src/documentation/Styling.mdx
+++ b/src/documentation/Styling.mdx
@@ -30,17 +30,21 @@ You can use these in `styled()` or `css` by prefixing the key with `@`, e.g. `@r
 
 ```tsx
 const Section = styled('section', {
+  margin: '$1',
   padding: '$2',
-  '@md': { padding: '$3' }
+  '@md': {
+    margin: '$2',
+    padding: '$3'
+  }
 })
 ```
 
 ```tsx
 <Text
   css={{
-    color: '$tonal800',
+    color: '$tonal300',
     '@md': { color: '$primary' },
-    '@lg': { color: '$tertiary' }
+    '@lg': { color: '$primaryDark' }
   }}
 >
   Hello World

--- a/src/documentation/coreconcepts.mdx
+++ b/src/documentation/coreconcepts.mdx
@@ -44,17 +44,17 @@ An additional benefit is that we can apply context specific styles to the compon
     backgroundColor: '$primary',
     padding: '$3',
 
-    // write inline responsive styles
+    // utilise shorthand utilities
+    mb: '$3',
+    size: 30
+
+    // and write responsive styles
     '@lg': {
       color: 'blue'
     },
     '@media (prefers-color-scheme: dark)': {
       color: 'white'
-    },
-
-    // and utilise shorthand utilities
-    mb: '$3',
-    size: 30
+    }
   }}
 />
 ```
@@ -74,4 +74,4 @@ These constraints are baked into our design tokens and represent design decision
 As a quick example, our tokens come in two main forms, values and scales:
 
 - For a layout property like `padding` or `margin`, the token represents the nth value on the spacing scale, e.g. `padding: '$2'` will render `padding: '8px'`.
-- For a property like `color`, it will look up the colors tokens and will use the value directly, e.g. `color: '$warning'` will render `color: 'hsl(24 ,100%, 55%)'`.
+- For a property like `color`, it will look up the colors tokens and will use the value directly, e.g. `color: '$warning'` will render `color: 'hsl(24, 100%, 55%)'`.

--- a/src/documentation/introduction.mdx
+++ b/src/documentation/introduction.mdx
@@ -19,17 +19,15 @@ All components are available as named exports from `@atom-learning/components`, 
 import { ChevronRight } from '@atom-learning/icons'
 import { Box, Heading, Icon, Text } from '@atom-learning/components'
 
-const Component = () => {
-  return (
-    <Box as="article">
-      <Heading css={{ mb: '$3' }}>
-        <Icon is={ChevronRight} css={{ mr: '$2' }} />
-        This is a heading
-      </Heading>
-      <Text>This is a paragraph of text</Text>
-    </Box>
-  )
-}
+const Component = () => (
+  <Box as="article">
+    <Heading css={{ mb: '$3' }}>
+      <Icon is={ChevronRight} css={{ mr: '$2' }} />
+      This is a heading
+    </Heading>
+    <Text>This is a paragraph of text</Text>
+  </Box>
+)
 ```
 
 Refer to the individual component documentation for recommended usage and API references for each component, as well as the theme documentation to understand the design token usage.

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
     chalk "^4.1.0"
     css "^3.0.0"
 
-"@atom-learning/theme@1.0.0-beta.0":
-  version "1.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-1.0.0-beta.0.tgz#d98dd67e7bd357f15745b535cc4314e3e005527c"
-  integrity sha512-2GoFThrPu9rvn8hNxV9GrlnsPhzOY88SRLuY/jix5MKrj3vX4/Qpzm1Jue4f1Y0RA/CAsWSLaZyj7uasYqNFJg==
+"@atom-learning/theme@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-1.0.0.tgz#d6ca9f1684165b731c490f7594a6e2f79967bee4"
+  integrity sha512-sjyzKebnppjjXkksY60EGYJj0bMplGh6GAgQHgZPlJl2jvxhrF4Kg3fm+u9cZAIc0n/MLx1enZWvGNvOQAe/+g==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"


### PR DESCRIPTION
- Updating our tokens to match the new theme
- Interactive elements now have hover/focus/active states
- Update icon sizing within buttons/action-icons, removed `xs` size from `Icon` and updated `stroke-width` across sizes
- Fixed some documentation that referenced incorrect themes/styles
- Add checks for spread `css` when used

![Screenshot 2021-08-23 at 11-56-47 Atom Learning Components](https://user-images.githubusercontent.com/3226804/130436345-0f7049cd-5c72-4c80-9b29-c9c6f27c15db.png)
