### PR TITLE
Fix: Video prop override

### DIFF
--- a/src/components/video/Video.tsx
+++ b/src/components/video/Video.tsx
@@ -36,12 +36,12 @@ export const Video: React.FC<VideoProps> = ({
       }}
     >
       <StyledVideo
-        {...remainingProps}
         role="figure"
         url={`https://player.vimeo.com/video/${id}`}
         height="100%"
         width="100%"
         css={{ position: 'absolute', top: 0, left: 0 }}
+        {...remainingProps}
       />
     </Box>
   </CSSWrapper>


### PR DESCRIPTION
Issue : 
`<Video />` component had a fixed `100%` height and width. It was not possible to override that from outside

Fix : 
Moved `{...remainingProps}` towards the end to allow prop overriding