### PR TITLE
Chore: Update documentation for RC

### DIFF
--- a/src/components/checkbox-field/CheckboxField.mdx
+++ b/src/components/checkbox-field/CheckboxField.mdx
@@ -2,7 +2,7 @@
 title: Checkbox Field
 component: CheckboxField
 description: Combines a Checkbox with a Label and ValidationError
-category: Forms
+category: Form fields
 ---
 
 `CheckboxField` renders a `Checkbox` inside an `InlineFieldWrapper`, providing a consistent layout for a checkbox, label and, when applicable, an error.

--- a/src/components/checkbox/Checkbox.mdx
+++ b/src/components/checkbox/Checkbox.mdx
@@ -2,7 +2,7 @@
 title: Checkbox
 component: Checkbox
 description: Checkbox provides a styled checkbox without  a label
-category: Forms
+category: Form primitives
 ---
 
 Checkboxes should be accompanied by labels, so rather than using `Checkbox` directly in a UI,

--- a/src/components/combobox/Combobox.mdx
+++ b/src/components/combobox/Combobox.mdx
@@ -2,7 +2,7 @@
 title: Combobox
 component: Combobox,Combobox.Input,Combobox.Popover,Combobox.List,Combobox.Option,Combobox.OptionText
 description: Combobox combines a text input with a list of suggested values
-category: Forms
+category: Form primitives
 ---
 
 `Combobox` wraps Reach UI's `Combobox` component with default styling and accepts all the same props. See [the Reach UI docs](https://reach.tech/combobox/) for details.

--- a/src/components/field-wrapper/FieldWrapper.mdx
+++ b/src/components/field-wrapper/FieldWrapper.mdx
@@ -2,7 +2,7 @@
 title: Field Wrapper
 component: FieldWrapper,InlineFieldWrapper
 description: A utility component to help with composing consistent form fields
-category: Forms
+category: Form primitives
 ---
 
 `FieldWrapper` renders a `Label` and (when applicable) a `ValidationError`. Use it to wrap any type of input to create a consistent set of form fields.

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -2,7 +2,7 @@
 title: Form
 component: Form
 description: Form abstracts form validation logic away from the view code
-category: Forms
+category: Form fields
 priority: 1
 ---
 
@@ -301,7 +301,8 @@ To access field value, another render prop that can be used is `watch(fieldName:
           Submit
         </Button>
       </>
-  )}}
+    )
+  }}
 />
 ```
 
@@ -341,10 +342,11 @@ There are a few rules that need to be followed to make the dynamic fields work c
 - Each dynamic field needs to take a default value from the fields object
 - Each field name needs to be in a specific format `fieldArrayName[index].fieldName`, where index is the second arg of `map` function
 - To initialize the useFieldArray hook a control object either from `useFormContext` or a Form render prop needs to be used.
+
 ```tsx
 const { fields } = useFieldArray({
   control,
-  name: "testArray",
+  name: 'testArray'
 })
 
 //////
@@ -367,14 +369,14 @@ Example:
 <Form
   defaultValues={{
     testArray: [
-      { field1: "test",  field2: true },
-      { field1: "test2", field2: true },
-    ],
+      { field1: 'test', field2: true },
+      { field1: 'test2', field2: true }
+    ]
   }}
   render={({ control }) => {
     const { fields, append, remove } = useFieldArray({
       control,
-      name: "testArray",
+      name: 'testArray'
     })
 
     return (
@@ -394,12 +396,10 @@ Example:
           </div>
         ))}
 
-        <button onClick={() => append({ field1: "test", field2: false })}>
+        <button onClick={() => append({ field1: 'test', field2: false })}>
           Add Item
         </button>
-        <button onClick={() => remove(0)}>
-          Remove first item
-        </button>
+        <button onClick={() => remove(0)}>Remove first item</button>
       </>
     )
   }}

--- a/src/components/input-field/InputField.mdx
+++ b/src/components/input-field/InputField.mdx
@@ -2,7 +2,7 @@
 title: Input Field
 component: InputField
 description: InputField renders a field composed of an Input, a Label and a ValidationError
-category: Forms
+category: Form fields
 ---
 
 `InputField` is the preferred way to render a form field for single-line text and number data.

--- a/src/components/input/Input.mdx
+++ b/src/components/input/Input.mdx
@@ -2,7 +2,7 @@
 title: Input
 component: Input
 description: Input is the lowest-level input component for text and number types
-category: Forms
+category: Form primitives
 ---
 
 Inputs should be accompanied by labels, so rather than using `Input` directly in a UI,

--- a/src/components/label/Label.mdx
+++ b/src/components/label/Label.mdx
@@ -2,7 +2,7 @@
 title: Label
 component: Label
 description: Label is a light wrapper around the basic HTML label element
-category: Forms
+category: Form primitives
 ---
 
 It adds default styling and the `css` prop.

--- a/src/components/password-field/PasswordField.mdx
+++ b/src/components/password-field/PasswordField.mdx
@@ -2,7 +2,7 @@
 title: Password Field
 component: PasswordField
 description: PasswordField is a specialised field for password input
-category: Forms
+category: Form fields
 ---
 
 `PasswordField` is the preferred way to render a form field for a current password (not necessarily for creating a new password).

--- a/src/components/password-input/PasswordInput.mdx
+++ b/src/components/password-input/PasswordInput.mdx
@@ -2,7 +2,7 @@
 title: Password Input
 component: PasswordInput
 description: An input for passwords with visibility toggle functionality
-category: Forms
+category: Form primitives
 ---
 
 `PasswordInput` wraps `Input` with a content visibility toggle, triggered by interaction with an eye Icon.

--- a/src/components/radio-field/RadioField.mdx
+++ b/src/components/radio-field/RadioField.mdx
@@ -2,7 +2,7 @@
 title: Radio Field
 component: RadioField
 description: Combines a RadioButton with a Label and ValidationError
-category: Forms
+category: Form fields
 ---
 
 `RadioGroupField` wraps a `RadioGroup` to provide a legend and a `ValidationError`. `RadioGroupField.Item` renders an individual `Radio` with an inline `Label`.

--- a/src/components/radio/RadioButton.mdx
+++ b/src/components/radio/RadioButton.mdx
@@ -2,7 +2,7 @@
 title: Radio button
 component: RadioButtonGroup,RadioButton
 description: The RadioButton component implements the Radio component from Radix with default styling and the css prop
-category: Forms
+category: Form primitives
 ---
 
 It needs to be wrapped with the `RadioButtonGroup` as it will not load without it. If only one `RadioButton` is needed please consider using a checkbox instead.

--- a/src/components/search-input/SearchInput.mdx
+++ b/src/components/search-input/SearchInput.mdx
@@ -1,8 +1,8 @@
 ---
 title: Search Input
 component: SearchInput
-description: A search input with matching search icon 
-category: Forms
+description: A search input with matching search icon
+category: Form primitives
 ---
 
 `SearchInput` wraps `Input` and adds an icon to visualise the specific input type, it's recommended to use this component when the user is performing a search query. It is functionally identical to the standard `Input` aside from a more specific "type" but makes it clear to the user what the action is and what potential feedback they might receive.

--- a/src/components/select-field/SelectField.mdx
+++ b/src/components/select-field/SelectField.mdx
@@ -2,7 +2,7 @@
 title: Select Field
 component: SelectField
 description: Wraps a Select with a Label and ValidationError
-category: Forms
+category: Form fields
 ---
 
 `SelectField` wraps a `Select` with a `Label` and a `ValidationError` to provide consistent behaviour and layout.

--- a/src/components/select/Select.mdx
+++ b/src/components/select/Select.mdx
@@ -2,7 +2,7 @@
 title: Select
 component: Select
 description: Select is a light wrapper around the HTML select element
-category: Forms
+category: Form primitives
 ---
 
 It adds default styling and the `css` prop.

--- a/src/components/switch/Switch.mdx
+++ b/src/components/switch/Switch.mdx
@@ -2,7 +2,7 @@
 title: Switch
 component: Switch
 description: An implementation of the Switch component from Radix with default styling and the css prop
-category: Forms
+category: Form primitives
 ---
 
 The `Switch` component implements [Radix's Switch component](https://radix-ui.com/primitives/docs/components/switch).
@@ -20,8 +20,9 @@ The `Switch` component should not be used to collect form data — use checkboxe
 The `disabled` stated can be set using the `disabled` property.
 
 ```tsx preview
-<Switch disabled/>
+<Switch disabled />
 ```
 
 ## Accessibility
+
 Adheres to the `switch` [role requirements](https://www.w3.org/TR/wai-aria-1.2/#switch)

--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -2,7 +2,7 @@
 title: Table
 component: Table, Table.Body, Table.Cell, Table.Footer, Table.FooterCell, Table.Header, Table.HeaderCell, Table.Row
 description: The Table component displays a collection of data grouped into rows
-category: Layout
+category: Content
 ---
 
 The `Table` component structure mirrors that of a regular HTML table, with the smaller `Table.Body`, `Table.Cell`, `Table.Footer`, `Table.Header`, `Table.HeaderCell` and `Table Row` components corresponding to the `<tbody>`, `<td>`, `<tfoot>`, `<thead>`, `<th>` and `<tr>` tags, respectively.

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -8,16 +8,20 @@ category: Layout
 The component provides a set of default styles, which can be overwritten by using the `css` prop. It is composed by combining smaller components, such as `Tabs.TriggerList`, `Tabs.Trigger`, and `Tabs.Content`.
 
 ```tsx preview
-<Tabs defaultValue="tab1" css={{ height: '400px', border: '1px solid black' }}>
+<Tabs defaultValue="tab1" css={{ height: '400px' }}>
   <Tabs.TriggerList>
     <Tabs.Trigger value="tab1">
       <Text>Nested component under the Tabs.Trigger component</Text>
     </Tabs.Trigger>
     <Tabs.Trigger value="tab2">Simple text</Tabs.Trigger>
   </Tabs.TriggerList>
-  <Tabs.Content value="tab1">Content for tab1.</Tabs.Content>
-  <Tabs.Content value="tab2">
-    Content for the second tab. It can also hold other components, like a{' '}
+  <Tabs.Content css={{ p: '$3' }} value="tab1">
+    <Text>Content for tab1.</Text>
+  </Tabs.Content>
+  <Tabs.Content css={{ p: '$3' }} value="tab2">
+    <Text>
+      Content for the second tab. It can also hold other components, like a
+    </Text>
     <Button>Button</Button>
   </Tabs.Content>
 </Tabs>
@@ -33,19 +37,6 @@ It also takes a `defaultValue` prop that should match one of the triggers' `valu
 
 The `Tabs.TriggerList` component simply holds the individual `Tabs.Trigger` components. It can also get custom styling via the `css` prop.
 
-```tsx preview
-<Tabs>
-  <Tabs.TriggerList css={{ borderBottom: '1px solid gray' }}>
-    <Tabs.Trigger value="tab1">Tab 1</Tabs.Trigger>
-    <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
-    <Tabs.Trigger value="tab3">Tab 3</Tabs.Trigger>
-  </Tabs.TriggerList>
-  <Tabs.Content value="tab1">Tab 1 content</Tabs.Content>
-  <Tabs.Content value="tab2">Tab 2 content</Tabs.Content>
-  <Tabs.Content value="tab3">Tab 3 content</Tabs.Content>
-</Tabs>
-```
-
 ## Tabs.Trigger
 
 The `Tabs.Trigger` component holds the content that will be displayed inside the button that the user would click in order to switch tabs. In can hold either a string, or some other component. It needs to be passed a `value` prop, that would be identical to the `value` prop passed to its corresponding `Tabs.Content` component.
@@ -53,20 +44,6 @@ The `Tabs.Trigger` component holds the content that will be displayed inside the
 ## Tabs.Content
 
 The `Tabs.Content` component, as the name suggests, holds the content for that particular section of the tabs component. It takes a `value` prop that needs to match the `value` prop passed to its corresponding trigger. Its content can be any text or valid component.
-
-```tsx preview
-<Tabs>
-  <Tabs.TriggerList>
-    <Tabs.Trigger value="tab1">Tab 1</Tabs.Trigger>
-    <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
-  </Tabs.TriggerList>
-  <Tabs.Content value="tab1">Content for tab 1</Tabs.Content>
-  <Tabs.Content value="tab2">
-    Content for the second tab. It can also hold other components, like a{' '}
-    <Button>Button</Button>
-  </Tabs.Content>
-</Tabs>
-```
 
 ## Disabled tab
 

--- a/src/components/textarea-field/TextareaField.mdx
+++ b/src/components/textarea-field/TextareaField.mdx
@@ -2,7 +2,7 @@
 title: Textarea Field
 component: TextareaField
 description: TextareaField renders a field composed of a Textarea, a Label and a ValidationError
-category: Forms
+category: Form fields
 ---
 
 TextareaField is the preferred way to render a form field for multi-line text.

--- a/src/components/textarea/Textarea.mdx
+++ b/src/components/textarea/Textarea.mdx
@@ -2,7 +2,7 @@
 title: Textarea
 component: Textarea
 description: Textarea is the lowest-level textarea component for longer text
-category: Forms
+category: Form primitives
 ---
 
 Textareas should be accompanied by labels, so rather than using `Textarea` directly in a UI, it’s normally best to use a `field` component, which combines an `Textarea` with a `Label` and displays validation errors. If none of the existing field components suit your needs, it might be worth adding a new one.

--- a/src/components/validation-error/ValidationError.mdx
+++ b/src/components/validation-error/ValidationError.mdx
@@ -2,7 +2,7 @@
 title: Validation Error
 component: ValidationError
 description: ValidationError renders text styled to communicate an error
-category: Forms
+category: Form primitives
 ---
 
 `ValidationError` just adds styling to our `Text` component. Use it when composing form field components so that our error messages are always consistent.


### PR DESCRIPTION
- Separate `Forms` category into `Form primitives` and `Form fields`, this should help when using the docs to find the specific primitive form component (`Input`, `Select`, `Checkbox`, `Label` etc.) or field component (`InputField`, `TextareaField`, etc.)
- Simplify our `Tabs` documentation as we had a few repeated code examples
- Moved `Table` to `Content` instead of `Layout`