### PR TITLE
Fix: TS improvements and fixes

### DIFF
--- a/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
@@ -77,12 +77,14 @@ exports[`CheckboxField component renders 1`] = `
     font-weight: 400;
     max-width: max-content;
   }
+}
 
-  .c-cVSpVL-JrrAq-align-start {
+@media  {
+  .c-cVSpVL-JrrAq-cv {
     align-items: flex-start;
   }
 
-  .c-cVSpVL-ejCoEP-direction-row {
+  .c-cVSpVL-ejCoEP-cv {
     flex-direction: row;
   }
 }
@@ -103,7 +105,7 @@ exports[`CheckboxField component renders 1`] = `
       class="c-PJLV"
     >
       <label
-        class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+        class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-JrrAq-cv c-cVSpVL-ejCoEP-cv"
       >
         <div
           class="c-PJLV c-PJLV-ihmIibS-css"

--- a/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -121,14 +121,6 @@ exports[`FieldWrapper component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-gEFkc-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
@@ -207,7 +199,7 @@ exports[`FieldWrapper component renders 1`] = `
       class="c-dhzjXW c-dhzjXW-iwHglP-css"
     >
       <label
-        class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+        class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
         for="example"
       >
         Example Field

--- a/src/components/heading/Heading.tsx
+++ b/src/components/heading/Heading.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { styled } from '~/stitches'
-import { capsize, Override } from '~/utilities'
+import { capsize } from '~/utilities'
 
 export const StyledHeading = styled('h2', {
   color: '$tonal600',
@@ -46,21 +46,7 @@ export const StyledHeading = styled('h2', {
   }
 })
 
-export type HeadingProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledHeading>,
-  {
-    as?:
-      | 'h1'
-      | 'h2'
-      | 'h3'
-      | 'h4'
-      | 'h5'
-      | 'h6'
-      | React.ComponentType
-      | React.ElementType
-    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
-  }
->
+export type HeadingProps = React.ComponentPropsWithoutRef<typeof StyledHeading>
 
 export const Heading: React.FC<HeadingProps> = ({
   size = 'md',

--- a/src/components/heading/Heading.tsx
+++ b/src/components/heading/Heading.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { styled } from '~/stitches'
+import type { Override } from '~/utilities'
 import { capsize } from '~/utilities'
 
 export const StyledHeading = styled('h2', {
@@ -46,7 +47,20 @@ export const StyledHeading = styled('h2', {
   }
 })
 
-export type HeadingProps = React.ComponentPropsWithoutRef<typeof StyledHeading>
+export type HeadingProps = Override<
+  React.ComponentPropsWithoutRef<typeof StyledHeading>,
+  {
+    as?:
+      | 'h1'
+      | 'h2'
+      | 'h3'
+      | 'h4'
+      | 'h5'
+      | 'h6'
+      | React.ComponentType
+      | React.ElementType
+  }
+>
 
 export const Heading: React.FC<HeadingProps> = ({
   size = 'md',

--- a/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -91,14 +91,6 @@ exports[`InputField component renders a field in error state 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-fZTBsJ-pHZal-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
@@ -174,7 +166,7 @@ exports[`InputField component renders a field in error state 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="INPUT FIELD"
         >
           INPUT FIELD
@@ -301,14 +293,6 @@ exports[`InputField component renders a field with a number input 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-fZTBsJ-pHZal-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
@@ -341,7 +325,7 @@ exports[`InputField component renders a field with a number input 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="INPUT FIELD"
         >
           INPUT FIELD
@@ -430,14 +414,6 @@ exports[`InputField component renders a field with a text input 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-fZTBsJ-pHZal-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
@@ -470,7 +446,7 @@ exports[`InputField component renders a field with a text input 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="INPUT FIELD"
         >
           INPUT FIELD

--- a/src/components/label/Label.test.tsx
+++ b/src/components/label/Label.test.tsx
@@ -12,6 +12,17 @@ describe(`Label component`, () => {
 
     expect(container).toMatchSnapshot()
   })
+  it('renders an inline label', async () => {
+    const { container } = render(
+      <Label type="inline" align="center">
+        TEXT
+      </Label>
+    )
+
+    await screen.getByText('TEXT')
+
+    expect(container).toMatchSnapshot()
+  })
 
   it('has no programmatically detectable a11y issues', async () => {
     const { container } = render(<Label>TEXT</Label>)

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -24,15 +24,31 @@ const StyledLabel = styled('label', {
         maxWidth: 'max-content'
       }
     },
-    align: {
-      start: { alignItems: 'flex-start' },
-      center: { alignItems: 'center' }
+    align: { start: {}, center: {} },
+    direction: { reverse: {}, row: {} }
+  },
+  compoundVariants: [
+    {
+      type: 'inline',
+      align: 'start',
+      css: { alignItems: 'flex-start' }
     },
-    direction: {
-      reverse: { flexDirection: 'row-reverse' },
-      row: { flexDirection: 'row' }
+    {
+      type: 'inline',
+      align: 'center',
+      css: { alignItems: 'center' }
+    },
+    {
+      type: 'inline',
+      direction: 'reverse',
+      css: { flexDirection: 'row-reverse' }
+    },
+    {
+      type: 'inline',
+      direction: 'row',
+      css: { flexDirection: 'row' }
     }
-  }
+  ]
 })
 
 const StyledAsterisk = styled('span', {

--- a/src/components/label/__snapshots__/Label.test.tsx.snap
+++ b/src/components/label/__snapshots__/Label.test.tsx.snap
@@ -31,19 +31,69 @@ exports[`Label component renders a label 1`] = `
     display: block;
     font-weight: 600;
   }
+}
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
+<div>
+  <label
+    class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
+  >
+    TEXT
+  </label>
+</div>
+`;
+
+exports[`Label component renders an inline label 1`] = `
+@media  {
+  .c-cVSpVL {
+    color: var(--colors-tonal500);
+    font-family: var(--fonts-body);
+    margin: 0;
+  }
+}
+
+@media  {
+  .c-cVSpVL-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
   }
 
-  .c-cVSpVL-ejCoEP-direction-row {
+  .c-cVSpVL-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-cVSpVL-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-cVSpVL-grKRUr-type-block {
+    display: block;
+    font-weight: 600;
+  }
+
+  .c-cVSpVL-bsbHzT-type-inline {
+    display: flex;
+    font-weight: 400;
+    max-width: max-content;
+  }
+}
+
+@media  {
+  .c-cVSpVL-jroWjL-cv {
+    align-items: center;
+  }
+
+  .c-cVSpVL-ejCoEP-cv {
     flex-direction: row;
   }
 }
 
 <div>
   <label
-    class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+    class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-jroWjL-cv c-cVSpVL-ejCoEP-cv"
   >
     TEXT
   </label>

--- a/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -93,14 +93,6 @@ exports[`Password component renders a password field 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-fZTBsJ-pHZal-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
@@ -185,7 +177,7 @@ exports[`Password component renders a password field 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="password"
         >
           Password

--- a/src/components/radio-button-field/__snapshots__/RadioButtonField.test.tsx.snap
+++ b/src/components/radio-button-field/__snapshots__/RadioButtonField.test.tsx.snap
@@ -83,14 +83,6 @@ exports[`RadioButtonField component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-iSwBqf-iTKOFX-direction-column {
     flex-direction: column;
   }
@@ -99,6 +91,16 @@ exports[`RadioButtonField component renders 1`] = `
     display: flex;
     font-weight: 400;
     max-width: max-content;
+  }
+}
+
+@media  {
+  .c-cVSpVL-JrrAq-cv {
+    align-items: flex-start;
+  }
+
+  .c-cVSpVL-ejCoEP-cv {
+    flex-direction: row;
   }
 }
 
@@ -123,7 +125,7 @@ exports[`RadioButtonField component renders 1`] = `
       class="c-leHWbT"
     >
       <legend
-        class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row c-cVSpVL-igrvbIF-css"
+        class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-igrvbIF-css"
       >
         Example options
       </legend>
@@ -138,7 +140,7 @@ exports[`RadioButtonField component renders 1`] = `
           class="c-PJLV"
         >
           <label
-            class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+            class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-JrrAq-cv c-cVSpVL-ejCoEP-cv"
           >
             <div
               class="c-PJLV c-PJLV-ihmIibS-css"
@@ -174,7 +176,7 @@ exports[`RadioButtonField component renders 1`] = `
           class="c-PJLV"
         >
           <label
-            class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+            class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-bsbHzT-type-inline c-cVSpVL-JrrAq-cv c-cVSpVL-ejCoEP-cv"
           >
             <div
               class="c-PJLV c-PJLV-ihmIibS-css"

--- a/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
+++ b/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
@@ -73,14 +73,6 @@ exports[`SelectField component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
-
   .c-beXZpM-ggkvuX-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
@@ -111,7 +103,7 @@ exports[`SelectField component renders 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="example"
         >
           Example options

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { CSS, styled } from '~/stitches'
-import { capsize, Override } from '~/utilities'
+import { capsize } from '~/utilities'
 
 type TextSizes = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
@@ -46,24 +46,7 @@ export const StyledParagraph = styled('p', {
   }
 })
 
-type TextProps = Override<
-  React.ComponentProps<typeof StyledParagraph>,
-  {
-    as?:
-      | 'blockquote'
-      | 'caption'
-      | 'dd'
-      | 'dt'
-      | 'figcaption'
-      | 'li'
-      | 'p'
-      | 'span'
-      | 'legend'
-      | React.ComponentType
-      | React.ElementType
-    size?: TextSizes
-  }
->
+type TextProps = React.ComponentProps<typeof StyledParagraph>
 
 export const Text: React.FC<TextProps> = React.forwardRef(
   ({ size = 'md', ...remainingProps }, ref) => (

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { CSS, styled } from '~/stitches'
+import type { Override } from '~/utilities'
 import { capsize } from '~/utilities'
 
 type TextSizes = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
@@ -46,7 +47,23 @@ export const StyledParagraph = styled('p', {
   }
 })
 
-type TextProps = React.ComponentProps<typeof StyledParagraph>
+type TextProps = Override<
+  React.ComponentProps<typeof StyledParagraph>,
+  {
+    as?:
+      | 'blockquote'
+      | 'caption'
+      | 'dd'
+      | 'dt'
+      | 'figcaption'
+      | 'li'
+      | 'p'
+      | 'span'
+      | 'legend'
+      | React.ComponentType
+      | React.ElementType
+  }
+>
 
 export const Text: React.FC<TextProps> = React.forwardRef(
   ({ size = 'md', ...remainingProps }, ref) => (

--- a/src/components/textarea-field/__snapshots__/TextareaField.test.tsx.snap
+++ b/src/components/textarea-field/__snapshots__/TextareaField.test.tsx.snap
@@ -73,14 +73,6 @@ exports[`TextareaField component renders 1`] = `
     display: block;
     font-weight: 600;
   }
-
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
 }
 
 @media  {
@@ -103,7 +95,7 @@ exports[`TextareaField component renders 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="description"
         />
       </div>
@@ -191,14 +183,6 @@ exports[`TextareaField component renders with an error 1`] = `
     display: block;
     font-weight: 600;
   }
-
-  .c-cVSpVL-JrrAq-align-start {
-    align-items: flex-start;
-  }
-
-  .c-cVSpVL-ejCoEP-direction-row {
-    flex-direction: row;
-  }
 }
 
 @media  {
@@ -221,7 +205,7 @@ exports[`TextareaField component renders with an error 1`] = `
         class="c-dhzjXW c-dhzjXW-iwHglP-css"
       >
         <label
-          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-JrrAq-align-start c-cVSpVL-ejCoEP-direction-row"
+          class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block"
           for="description"
         />
       </div>


### PR DESCRIPTION
- Removed hard-coded `size` type from `Heading` and `Text` - We're constraining the valid props for `size` by using our own, and removing the ability to use media queries e.g. `<Heading size={{ '@initial': 'sm', '@md': 'lg' }} />`
- Removed unnecessary `align` and `direction` variants applying when `<Label type="block" />`