### PR TITLE
Chore: Remove unused babel plugin - "react-remove-properties"

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -3,11 +3,6 @@
     "development": {
       "plugins": ["transform-stitches-display-name"]
     },
-    "production": {
-      "plugins": [
-        ["react-remove-properties", { "properties": ["data-testid"] }]
-      ]
-    },
     "test": {
       "compact": false,
       "presets": ["@babel/preset-react", "@babel/preset-typescript"],

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@typescript-eslint/parser": "^4.29.1",
     "@vitejs/plugin-react-refresh": "^1.3.3",
     "babel-eslint": "^10.1.0",
-    "babel-plugin-react-remove-properties": "^0.3.0",
     "babel-plugin-transform-stitches-display-name": "^0.0.1",
     "change-case": "^4.1.2",
     "chokidar": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,11 +3977,6 @@ babel-plugin-polyfill-regenerator@^0.2.2:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
 
-babel-plugin-react-remove-properties@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-remove-properties/-/babel-plugin-react-remove-properties-0.3.0.tgz#7b623fb3c424b6efb4edc9b1ae4cc50e7154b87f"
-  integrity sha512-vbxegtXGyVcUkCvayLzftU95vuvpYFV85pRpeMpohMHeEY46Qe0VNWfkVVcCbaZ12CXHzDFOj0esumATcW83ng==
-
 babel-plugin-transform-stitches-display-name@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-stitches-display-name/-/babel-plugin-transform-stitches-display-name-0.0.1.tgz#df53cd9ee74ff169dcce76d6c2d9185b6fe334cb"


### PR DESCRIPTION
No longer necessary now we've changed our test for `CSSWrapper`