### PR TITLE
feat: pass ref onto the ReactPlayer component so that we have access …

### DIFF
--- a/src/components/video/Video.tsx
+++ b/src/components/video/Video.tsx
@@ -18,33 +18,31 @@ type VideoProps = Override<
   }
 >
 
-export const Video: React.FC<VideoProps> = ({
-  id,
-  ratio = 9 / 16,
-  css,
-  ...remainingProps
-}) => (
-  <CSSWrapper css={css}>
-    <Box
-      css={{
-        borderRadius: '$0',
-        position: 'relative',
-        paddingTop: `${ratio * 100}%`,
-        overflow: 'hidden',
-        height: 0,
-        width: '100%'
-      }}
-    >
-      <StyledVideo
-        {...remainingProps}
-        role="figure"
-        url={`https://player.vimeo.com/video/${id}`}
-        height="100%"
-        width="100%"
-        css={{ position: 'absolute', top: 0, left: 0 }}
-      />
-    </Box>
-  </CSSWrapper>
+export const Video = React.forwardRef<typeof StyledVideo, VideoProps>(
+  ({ id, ratio = 9 / 16, css, ...remainingProps }, ref) => (
+    <CSSWrapper css={css}>
+      <Box
+        css={{
+          borderRadius: '$0',
+          position: 'relative',
+          paddingTop: `${ratio * 100}%`,
+          overflow: 'hidden',
+          height: 0,
+          width: '100%'
+        }}
+      >
+        <StyledVideo
+          {...remainingProps}
+          role="figure"
+          url={`https://player.vimeo.com/video/${id}`}
+          height="100%"
+          width="100%"
+          css={{ position: 'absolute', top: 0, left: 0 }}
+          ref={ref}
+        />
+      </Box>
+    </CSSWrapper>
+  )
 )
 
 Video.displayName = 'Video'


### PR DESCRIPTION
## Why?
`react-player` allows you to pass a `ref` onto the video component to get access to that video instance. Having access to that instance allows us to do use the `react-player` API (and do stuff such as tracking the amount of seconds played).

Our `Video` component didn't pass the `ref` onto the `ReactPlayer` component though, so there was no way to get access to the `ReactPlayer` instance when using the design system.

## Changes
- `ref`s on the `Video` component are now passed onto the `ReactPlayer` component

## Video
![Kapture 2021-11-12 at 11 45 07](https://user-images.githubusercontent.com/2501587/141462432-6e46bc4a-f9e8-46ee-84de-bd922c7b8ebd.gif)
