### PR TITLE
fix: add typings to package.json to explicitly refer index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@atom-learning/components",
   "source": "src/index.ts",
   "main": "dist/index.cjs.js",
+  "typings": "dist/index.d.ts",
   "module": "dist/index.js",
   "version": "1.2.2",
   "description": "",


### PR DESCRIPTION
Issue : 

Intellisense did not work for Typescript imports / props from `@atom-learning/components`.

Fix : 

Added `"typings": "dist/index.d.ts"` to `package.json`