### PR TITLE
Fix: Tabs mobile view

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "react-hook-form-persist": "^2.0.0",
     "react-hot-toast": "^1.0.2",
     "react-player": "^2.9.0",
+    "throttle-debounce": "^3.0.1",
     "uid": "^2.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "glob": "^7.1.6",
     "husky": "^4.3.8",
-    "jest": "^26.6.3",
+    "jest": "^27.0.6",
     "jest-axe": "^4.1.0",
     "jest-dom": "^4.0.0",
     "lint-staged": "^10.5.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "glob": "^7.1.6",
     "husky": "^4.3.8",
-    "jest": "^27.0.6",
+    "jest": "^26.6.3",
     "jest-axe": "^4.1.0",
     "jest-dom": "^4.0.0",
     "lint-staged": "^10.5.3",

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Component lib sandbox</title>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Space+Grotesk:wght@500&display=swap" rel="stylesheet">

--- a/src/components/action-icon/ActionIcon.tsx
+++ b/src/components/action-icon/ActionIcon.tsx
@@ -82,7 +82,8 @@ const StyledButton = styled('button', {
     },
     size: {
       md: { size: '$3' },
-      lg: { size: '$4' }
+      lg: { size: '$4' },
+      xl: { size: '$5' }
     },
     isRounded: {
       true: {
@@ -225,7 +226,7 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
 
           return React.cloneElement(child, {
             css: {
-              size: size === 'lg' ? 20 : 16,
+              size: ['lg', 'xl'].includes(size as string) ? 20 : 16,
               ...(child.props.css ? child.props.css : {})
             }
           })

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -19,7 +19,8 @@ const StyledTabTrigger = styled(Trigger, {
         bg: 'white',
         '&[data-state="active"]': {
           color: '$primary',
-          textShadow: '0px 0px 1px currentColor',
+          fontWeight: 600,
+          letterSpacing: '-0.005em',
           boxShadow: 'inset 0 -2px 0 0 currentColor'
         },
         '&[data-state="inactive"]': {
@@ -42,7 +43,8 @@ const StyledTabTrigger = styled(Trigger, {
       dark: {
         color: 'white',
         '&[data-state="active"]': {
-          textShadow: '0px 0px 1px currentColor',
+          fontWeight: 600,
+          letterSpacing: '-0.005em',
           boxShadow: 'inset 0 -2px 0 0 currentColor'
         },
         '&:not([data-disabled]):hover': {

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -24,18 +24,14 @@ const StyledTabTrigger = styled(Trigger, {
         '&[data-state="inactive"]': {
           color: '$tonal500'
         },
-        '&:hover': {
+        '&:not([data-disabled]):hover': {
           color: '$primary',
           bg: opacify(-0.9, theme.colors.primary.value)
         },
-        '&:active': {
+        '&:not([data-disabled]):active': {
           color: '$primary',
           bg: opacify(-0.8, theme.colors.primary.value),
           boxShadow: 'none'
-        },
-        '&:focus': {
-          color: '$primary',
-          boxShadow: 'inset 0 0 0 2px currentColor'
         },
         '&[data-disabled],&[data-disabled]:hover': {
           color: '$tonal200',
@@ -48,10 +44,10 @@ const StyledTabTrigger = styled(Trigger, {
           textShadow: '0px 0px 1px currentColor',
           boxShadow: 'inset 0 -2px 0 0 currentColor'
         },
-        '&:hover': {
+        '&:not([data-disabled]):hover': {
           bg: opacify(-0.8, 'white')
         },
-        '&:active': {
+        '&:not([data-disabled]):active': {
           bg: opacify(-0.7, 'white'),
           boxShadow: 'none'
         },

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -10,21 +10,29 @@ const StyledTabTrigger = styled(Trigger, {
   fontFamily: '$body',
   p: '$4',
   userSelect: 'none',
-  transition: '0.3s'
+  transition: '0.3s',
+  variants: {
+    theme: {
+      light: {},
+      dark: {}
+    }
+  }
 })
 
-type TabTriggerProps = React.ComponentProps<typeof StyledTabTrigger> & {
+interface TabTriggerProps
+  extends React.ComponentProps<typeof StyledTabTrigger> {
   value: string
   disabled?: boolean
 }
 
 export const TabTrigger: React.FC<TabTriggerProps> = ({
   children,
+  theme,
   disabled = false,
   css,
   ...otherProps
 }) => (
-  <StyledTabTrigger css={css} disabled={disabled} {...otherProps}>
+  <StyledTabTrigger css={css} disabled={disabled} theme={theme} {...otherProps}>
     {children}
   </StyledTabTrigger>
 )

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -1,7 +1,8 @@
 import { Trigger } from '@radix-ui/react-tabs'
 import * as React from 'react'
+import { opacify } from 'polished'
 
-import { styled } from '~/stitches'
+import { styled, theme } from '~/stitches'
 
 const StyledTabTrigger = styled(Trigger, {
   textTransform: 'uppercase',
@@ -13,8 +14,55 @@ const StyledTabTrigger = styled(Trigger, {
   transition: '0.3s',
   variants: {
     theme: {
-      light: {},
-      dark: {}
+      light: {
+        bg: 'white',
+        '&[data-state="active"]': {
+          color: '$primary',
+          textShadow: '0px 0px 1px currentColor',
+          boxShadow: 'inset 0 -2px 0 0 currentColor'
+        },
+        '&[data-state="inactive"]': {
+          color: '$tonal500'
+        },
+        '&:hover': {
+          color: '$primary',
+          bg: opacify(-0.9, theme.colors.primary.value)
+        },
+        '&:active': {
+          color: '$primary',
+          bg: opacify(-0.8, theme.colors.primary.value),
+          boxShadow: 'none'
+        },
+        '&:focus': {
+          color: '$primary',
+          boxShadow: 'inset 0 0 0 2px currentColor'
+        },
+        '&[data-disabled],&[data-disabled]:hover': {
+          color: '$tonal200',
+          cursor: 'default'
+        }
+      },
+      dark: {
+        color: 'white',
+        '&[data-state="active"]': {
+          textShadow: '0px 0px 1px currentColor',
+          boxShadow: 'inset 0 -2px 0 0 currentColor'
+        },
+        '&:hover': {
+          bg: opacify(-0.8, 'white')
+        },
+        '&:active': {
+          bg: opacify(-0.7, 'white'),
+          boxShadow: 'none'
+        },
+        '&:focus': {
+          boxShadow: 'inset 0 0 0 2px currentColor'
+        },
+        '&[data-disabled],&[data-disabled]:hover': {
+          color: '$tonal200',
+          cursor: 'default'
+        }
+      }
     }
   }
 })

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -4,24 +4,13 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 
 const StyledTabTrigger = styled(Trigger, {
-  color: '$secondary',
+  textTransform: 'uppercase',
   cursor: 'pointer',
   flexShrink: 0,
   fontFamily: '$body',
   p: '$4',
   userSelect: 'none',
-  '&:hover': {
-    color: '$primary'
-  },
-  '&[data-disabled],&[data-disabled]:hover': {
-    color: '$tonal300',
-    cursor: 'default'
-  },
-  '&[data-state="active"]': {
-    color: '$primary',
-    fontWeight: 'bold',
-    boxShadow: 'inset 0 -3px 0 0 currentColor'
-  }
+  transition: '0.5s'
 })
 
 type TabTriggerProps = React.ComponentProps<typeof StyledTabTrigger> & {

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -71,10 +71,9 @@ export const TabTrigger: React.FC<TabTriggerProps> = ({
   children,
   theme,
   disabled = false,
-  css,
   ...otherProps
 }) => (
-  <StyledTabTrigger css={css} disabled={disabled} theme={theme} {...otherProps}>
+  <StyledTabTrigger disabled={disabled} theme={theme} {...otherProps}>
     {children}
   </StyledTabTrigger>
 )

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -10,7 +10,7 @@ const StyledTabTrigger = styled(Trigger, {
   fontFamily: '$body',
   p: '$4',
   userSelect: 'none',
-  transition: '0.5s'
+  transition: '0.3s'
 })
 
 type TabTriggerProps = React.ComponentProps<typeof StyledTabTrigger> & {

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -35,7 +35,7 @@ const StyledTabTrigger = styled(Trigger, {
         },
         '&[data-disabled],&[data-disabled]:hover': {
           color: '$tonal200',
-          cursor: 'default'
+          cursor: 'not-allowed'
         }
       },
       dark: {
@@ -51,12 +51,9 @@ const StyledTabTrigger = styled(Trigger, {
           bg: opacify(-0.7, 'white'),
           boxShadow: 'none'
         },
-        '&:focus': {
-          boxShadow: 'inset 0 0 0 2px currentColor'
-        },
         '&[data-disabled],&[data-disabled]:hover': {
           color: '$tonal200',
-          cursor: 'default'
+          cursor: 'not-allowed'
         }
       }
     }

--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -10,6 +10,7 @@ const StyledTabTrigger = styled(Trigger, {
   flexShrink: 0,
   fontFamily: '$body',
   p: '$4',
+  height: '$5',
   userSelect: 'none',
   transition: '0.3s',
   variants: {

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -33,11 +33,11 @@ It takes a `defaultValue` prop that should match one of the triggers' `value` pr
 <Tabs defaultValue="tab1">
 ```
 
-It also takes a `appearance` prop that should either be "light" or "dark".
+It also takes a `theme` prop that should either be "light" or "dark".
 
 ```tsx
-<Tabs appearance="light"></Tabs>
-<Tabs appearance="dark"></Tabs>
+<Tabs theme="light"></Tabs>
+<Tabs theme="dark"></Tabs>
 ```
 
 ## Tabs.TriggerList

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -27,10 +27,17 @@ The component provides a set of default styles, which can be overwritten by usin
 </Tabs>
 ```
 
-It also takes a `defaultValue` prop that should match one of the triggers' `value` prop.
+It takes a `defaultValue` prop that should match one of the triggers' `value` prop.
 
 ```tsx
 <Tabs defaultValue="tab1">
+```
+
+It also takes a `appearance` prop that should either be "light" or "dark".
+
+```tsx
+<Tabs appearance="light"></Tabs>
+<Tabs appearance="dark"></Tabs>
 ```
 
 ## Tabs.TriggerList

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -36,6 +36,7 @@ It also takes a `defaultValue` prop that should match one of the triggers' `valu
 ## Tabs.TriggerList
 
 The `Tabs.TriggerList` component simply holds the individual `Tabs.Trigger` components. It can also get custom styling via the `css` prop.
+`Tabs.TriggerList` will automatically show `<` & `>` buttons in case the content is overshooting the available space.
 
 ## Tabs.Trigger
 

--- a/src/components/tabs/Tabs.test.tsx
+++ b/src/components/tabs/Tabs.test.tsx
@@ -19,9 +19,32 @@ const TabsTest = ({ defaultValue = 'tab1' }) => (
   </IdProvider>
 )
 
+const MobileTabsTest = ({ defaultValue = 'tab1' }) => (
+  <IdProvider>
+    <Tabs defaultValue={defaultValue}>
+      <Tabs.TriggerList enableTabScrolling>
+        <Tabs.Trigger value="tab1">
+          Trigger 1 which is going to be long
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab2">
+          Trigger 2 which is going to be even longer
+        </Tabs.Trigger>
+      </Tabs.TriggerList>
+      <Tabs.Content value="tab1">Important content for tab 1</Tabs.Content>
+      <Tabs.Content value="tab2">Important content for tab 2</Tabs.Content>
+    </Tabs>
+  </IdProvider>
+)
+
 describe('Tabs component', () => {
   it('renders', async () => {
     const { container } = render(<TabsTest />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders mobile view', async () => {
+    const { container } = render(<MobileTabsTest />)
 
     expect(container).toMatchSnapshot()
   })

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -15,7 +15,7 @@ const StyledRoot = styled(Root, {
   pt: '$4',
   px: '$2',
   variants: {
-    appearance: {
+    theme: {
       light: {
         'div[role="tab"]': {
           bg: 'white',
@@ -108,8 +108,8 @@ export const Tabs: React.FC<TabsProps> & {
   TriggerList: typeof TriggerListWrapper
   Trigger: typeof TabTrigger
   Content: typeof StyledTabContent
-} = ({ appearance = 'light', ...remainingProps }) => (
-  <StyledRoot appearance={appearance} {...remainingProps} />
+} = ({ theme = 'light', ...remainingProps }) => (
+  <StyledRoot theme={theme} {...remainingProps} />
 )
 
 Tabs.TriggerList = TriggerListWrapper

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -54,7 +54,7 @@ const StyledRoot = styled(Root, {
           borderBottom: '1px solid $primaryDark'
         },
         'button[role="scrollbar"]': {
-          bg: 'white !important',
+          bg: 'white',
           opacity: 0.8
         }
       },
@@ -90,10 +90,10 @@ const StyledRoot = styled(Root, {
         'div[role="tablist"]': {
           borderBottom: '1px solid white'
         },
-        'button[role="scrollbar"]': {
-          bg: '$primaryDark !important',
+        'button[role="scrollbar"], button[role="scrollbar"]:focus': {
+          bg: '$primaryDark',
           opacity: 0.8,
-          color: 'white !important'
+          color: 'white'
         }
       }
     }

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -12,7 +12,6 @@ type TabsProps = React.ComponentProps<typeof StyledRoot>
 const StyledRoot = styled(Root, {
   display: 'flex',
   flexDirection: 'column',
-  pt: '$4',
   variants: {
     theme: {
       light: {

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,148 +1,115 @@
-import { Content, List, Root } from '@radix-ui/react-tabs'
-import React, { useState, useEffect, useRef, useCallback } from 'react'
-import { ChevronLeft, ChevronRight } from '@atom-learning/icons'
+import { Content, Root } from '@radix-ui/react-tabs'
+import React from 'react'
+import { opacify } from 'polished'
 
-import { styled } from '~/stitches'
-import { ActionIcon } from '~/components/action-icon'
-import { Flex } from '~/components/flex'
-import { Icon } from '~/components/icon'
+import { styled, theme } from '~/stitches'
 
 import { TabTrigger } from './TabTrigger'
+import { TriggerListWrapper } from './TabsTriggerList'
 
 type TabsProps = React.ComponentProps<typeof StyledRoot>
 
 const StyledRoot = styled(Root, {
   display: 'flex',
-  flexDirection: 'column'
+  flexDirection: 'column',
+  pt: '$4',
+  px: '$2',
+  variants: {
+    appearance: {
+      light: {
+        'div[role="tab"]': {
+          bg: 'white',
+          '&[data-state="active"]': {
+            color: '$primary',
+            fontWeight: 600,
+            boxShadow: 'inset 0 -2px 0 0 currentColor'
+          },
+          '&[data-state="inactive"]': {
+            color: '$tonal500'
+          },
+          '&:hover': {
+            color: '$primary',
+            bg: opacify(-0.9, theme.colors.primary.value)
+          },
+          '&:active': {
+            color: '$primary',
+            bg: opacify(-0.8, theme.colors.primary.value),
+            boxShadow: 'none'
+          },
+          '&:focus': {
+            color: '$primary',
+            boxShadow: 'inset 0 0 0 2px currentColor'
+          },
+          '&[data-disabled],&[data-disabled]:hover': {
+            color: '$tonal200',
+            cursor: 'default'
+          }
+        },
+        'div[role="tabpanel"]': {
+          bg: 'white',
+          color: '$textForeground',
+          fontFamily: '$body'
+        },
+        'div[role="tablist"]': {
+          borderBottom: '1px solid $primaryDark'
+        },
+        'button[role="scrollbar"]': {
+          bg: 'white !important',
+          opacity: 0.8
+        }
+      },
+      dark: {
+        bg: '$primaryDark',
+        color: 'white',
+        'div[role="tab"]': {
+          color: 'white',
+          '&[data-state="active"]': {
+            fontWeight: 600,
+            boxShadow: 'inset 0 -2px 0 0 currentColor'
+          },
+          '&:hover': {
+            bg: opacify(-0.8, 'white')
+          },
+          '&:active': {
+            bg: opacify(-0.7, 'white'),
+            boxShadow: 'none'
+          },
+          '&:focus': {
+            boxShadow: 'inset 0 0 0 2px currentColor'
+          },
+          '&[data-disabled],&[data-disabled]:hover': {
+            color: '$tonal200',
+            cursor: 'default'
+          }
+        },
+        'div[role="tabpanel"]': {
+          bg: '$primaryDark',
+          color: 'white',
+          fontFamily: '$body'
+        },
+        'div[role="tablist"]': {
+          borderBottom: '1px solid white'
+        },
+        'button[role="scrollbar"]': {
+          bg: '$primaryDark !important',
+          opacity: 0.8,
+          color: 'white !important'
+        }
+      }
+    }
+  }
 })
 
 const StyledTabContent = styled(Content, {
   flexGrow: 1
 })
 
-const StyledTriggerList = styled(List, {
-  flexShrink: 0,
-  display: 'flex',
-  borderBottom: '1px solid $primaryDark'
-})
-
-const StyledActionIcon = styled(ActionIcon, {
-  position: 'absolute',
-  top: 'calc(50% - 20px)',
-  bg: 'white !important',
-  opacity: 0.8
-})
-
-type ListProps = React.ComponentProps<typeof StyledTriggerList> & {
-  enableTabScrolling?: boolean
-}
-
-const TriggerListWrapper: React.FC<ListProps> = ({
-  css,
-  enableTabScrolling,
-  ...rest
-}) => {
-  const triggerListRef = useRef<HTMLDivElement>(null)
-  const [showLeftScroller, setShowLeftScroller] = useState<boolean>(false)
-  const [showRightScroller, setShowRightScroller] = useState<boolean>(false)
-
-  const scrollTriggerListTo = useCallback((direction: 'left' | 'right') => {
-    const triggerList = triggerListRef.current
-    if (triggerList) {
-      const { scrollWidth, scrollLeft, offsetWidth } = triggerList
-      const scrollAmount = scrollWidth / 4 // 25% of whole scroll width
-      if (direction === 'right') {
-        if (triggerList.scrollLeft + scrollAmount <= scrollWidth) {
-          triggerList.scroll({
-            left: triggerList.scrollLeft + scrollAmount,
-            behavior: 'smooth'
-          })
-        }
-      } else {
-        triggerList.scroll({
-          left:
-            triggerList.scrollLeft - scrollAmount > 0
-              ? triggerList.scrollLeft - scrollAmount
-              : 0,
-          behavior: 'smooth'
-        })
-      }
-
-      // Relying on setTimeout since scroll does not have a callback / doesn't return a promise :(
-      setTimeout(() => {
-        const { scrollWidth, scrollLeft, offsetWidth } = triggerList
-        if (scrollLeft === 0) {
-          setShowLeftScroller(false)
-          setShowRightScroller(true)
-        } else if (scrollLeft + offsetWidth === scrollWidth) {
-          setShowRightScroller(false)
-          setShowLeftScroller(true)
-        } else {
-          setShowLeftScroller(true)
-          setShowRightScroller(true)
-        }
-      }, 300)
-    }
-  }, [])
-
-  useEffect(() => {
-    const triggerList = triggerListRef.current
-    if (triggerList) {
-      const { offsetWidth, scrollWidth } = triggerList
-
-      const shouldShowScroller = scrollWidth > offsetWidth
-      if (shouldShowScroller) {
-        setShowRightScroller(true)
-      }
-    }
-  }, [])
-
-  const showScroller = showLeftScroller || showRightScroller
-
-  return showScroller || enableTabScrolling ? (
-    <Flex css={{ position: 'relative' }}>
-      {showLeftScroller && (
-        <StyledActionIcon
-          size="lg"
-          label="scroll-left"
-          onClick={() => scrollTriggerListTo('left')}
-          css={{ left: 0 }}
-        >
-          <Icon is={ChevronLeft} size="lg" />
-        </StyledActionIcon>
-      )}
-      <StyledTriggerList
-        {...rest}
-        ref={triggerListRef}
-        css={{
-          ...css,
-          width: '100%',
-          overflowX: 'auto',
-          '&::-webkit-scrollbar': { display: 'none' }
-        }}
-      />
-      {showRightScroller && (
-        <StyledActionIcon
-          size="lg"
-          label="scroll-right"
-          onClick={() => scrollTriggerListTo('right')}
-          css={{ right: 0 }}
-        >
-          <Icon is={ChevronRight} size="lg" />
-        </StyledActionIcon>
-      )}
-    </Flex>
-  ) : (
-    <StyledTriggerList css={css} {...rest} ref={triggerListRef} />
-  )
-}
-
 export const Tabs: React.FC<TabsProps> & {
   TriggerList: typeof TriggerListWrapper
   Trigger: typeof TabTrigger
   Content: typeof StyledTabContent
-} = ({ children, ...remainingProps }) => (
-  <StyledRoot {...remainingProps}>{children}</StyledRoot>
+} = ({ appearance = 'light', ...remainingProps }) => (
+  <StyledRoot appearance={appearance} {...remainingProps} />
 )
 
 Tabs.TriggerList = TriggerListWrapper

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,6 +1,5 @@
 import { Content, Root } from '@radix-ui/react-tabs'
 import React from 'react'
-import { opacify } from 'polished'
 
 import { styled, theme } from '~/stitches'
 
@@ -30,15 +29,14 @@ const StyledRoot = styled(Root, {
 
 const StyledTabContent = styled(Content, {
   flexGrow: 1,
+  fontFamily: '$body',
   variants: {
     theme: {
       light: {
-        color: '$textForeground',
-        fontFamily: '$body'
+        color: '$textForeground'
       },
       dark: {
-        color: 'white',
-        fontFamily: '$body'
+        color: 'white'
       }
     }
   }

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -21,7 +21,7 @@ const StyledRoot = styled(Root, {
           bg: 'white',
           '&[data-state="active"]': {
             color: '$primary',
-            fontWeight: 600,
+            textShadow: '0px 0px 1px currentColor',
             boxShadow: 'inset 0 -2px 0 0 currentColor'
           },
           '&[data-state="inactive"]': {
@@ -64,7 +64,7 @@ const StyledRoot = styled(Root, {
         'div[role="tab"]': {
           color: 'white',
           '&[data-state="active"]': {
-            fontWeight: 600,
+            textShadow: '0px 0px 1px currentColor',
             boxShadow: 'inset 0 -2px 0 0 currentColor'
           },
           '&:hover': {

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -43,12 +43,13 @@ const TriggerListWrapper: React.FC<ListProps> = ({
   ...rest
 }) => {
   const triggerListRef = useRef<HTMLDivElement>(null)
-  const [showScroller, setShowScroller] = useState<boolean>(false)
+  const [showLeftScroller, setShowLeftScroller] = useState<boolean>(false)
+  const [showRightScroller, setShowRightScroller] = useState<boolean>(false)
 
   const scrollTriggerListTo = useCallback((direction: 'left' | 'right') => {
     const triggerList = triggerListRef.current
     if (triggerList) {
-      const { scrollWidth } = triggerList
+      const { scrollWidth, scrollLeft, offsetWidth } = triggerList
       const scrollAmount = scrollWidth / 4 // 25% of whole scroll width
       if (direction === 'right') {
         if (triggerList.scrollLeft + scrollAmount <= scrollWidth) {
@@ -66,6 +67,21 @@ const TriggerListWrapper: React.FC<ListProps> = ({
           behavior: 'smooth'
         })
       }
+
+      // Relying on setTimeout since scroll does not have a callback / doesn't return a promise :(
+      setTimeout(() => {
+        const { scrollWidth, scrollLeft, offsetWidth } = triggerList
+        if (scrollLeft === 0) {
+          setShowLeftScroller(false)
+          setShowRightScroller(true)
+        } else if (scrollLeft + offsetWidth === scrollWidth) {
+          setShowRightScroller(false)
+          setShowLeftScroller(true)
+        } else {
+          setShowLeftScroller(true)
+          setShowRightScroller(true)
+        }
+      }, 300)
     }
   }, [])
 
@@ -75,22 +91,26 @@ const TriggerListWrapper: React.FC<ListProps> = ({
       const { offsetWidth, scrollWidth } = triggerList
 
       const shouldShowScroller = scrollWidth > offsetWidth
-      if (showScroller !== shouldShowScroller) {
-        setShowScroller(shouldShowScroller)
+      if (shouldShowScroller) {
+        setShowRightScroller(true)
       }
     }
   }, [])
 
+  const showScroller = showLeftScroller || showRightScroller
+
   return showScroller || enableTabScrolling ? (
     <Flex css={{ position: 'relative' }}>
-      <StyledActionIcon
-        size="lg"
-        label="scroll-left"
-        onClick={() => scrollTriggerListTo('left')}
-        css={{ left: 0 }}
-      >
-        <Icon is={ChevronLeft} size="lg" />
-      </StyledActionIcon>
+      {showLeftScroller && (
+        <StyledActionIcon
+          size="lg"
+          label="scroll-left"
+          onClick={() => scrollTriggerListTo('left')}
+          css={{ left: 0 }}
+        >
+          <Icon is={ChevronLeft} size="lg" />
+        </StyledActionIcon>
+      )}
       <StyledTriggerList
         {...rest}
         ref={triggerListRef}
@@ -103,14 +123,16 @@ const TriggerListWrapper: React.FC<ListProps> = ({
           'div:last-child': { pr: '$6' }
         }}
       />
-      <StyledActionIcon
-        size="lg"
-        label="scroll-right"
-        onClick={() => scrollTriggerListTo('right')}
-        css={{ right: 0 }}
-      >
-        <Icon is={ChevronRight} size="lg" />
-      </StyledActionIcon>
+      {showRightScroller && (
+        <StyledActionIcon
+          size="lg"
+          label="scroll-right"
+          onClick={() => scrollTriggerListTo('right')}
+          css={{ right: 0 }}
+        >
+          <Icon is={ChevronRight} size="lg" />
+        </StyledActionIcon>
+      )}
     </Flex>
   ) : (
     <StyledTriggerList css={css} {...rest} ref={triggerListRef} />

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import { Content, Root } from '@radix-ui/react-tabs'
-import React from 'react'
+import * as React from 'react'
 
-import { styled, theme } from '~/stitches'
+import { styled } from '~/stitches'
 
 import { TabTrigger } from './TabTrigger'
 import { TriggerListWrapper } from './TabsTriggerList'

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,9 +1,15 @@
 import { Content, List, Root } from '@radix-ui/react-tabs'
-import * as React from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from '@atom-learning/icons'
 
 import { styled } from '~/stitches'
+import { ActionIcon } from '~/components/action-icon'
+import { Flex } from '~/components/flex'
+import { Icon } from '~/components/icon'
 
 import { TabTrigger } from './TabTrigger'
+
+type TabsProps = React.ComponentProps<typeof StyledRoot>
 
 const StyledRoot = styled(Root, {
   display: 'flex',
@@ -20,17 +26,106 @@ const StyledTriggerList = styled(List, {
   borderBottom: '1px solid $primaryDark'
 })
 
-type TabsProps = React.ComponentProps<typeof StyledRoot>
+const StyledActionIcon = styled(ActionIcon, {
+  position: 'absolute',
+  top: 'calc(50% - 20px)',
+  bg: 'white !important',
+  opacity: 0.8
+})
+
+type ListProps = React.ComponentProps<typeof StyledTriggerList> & {
+  enableTabScrolling?: boolean
+}
+
+const TriggerListWrapper: React.FC<ListProps> = ({
+  css,
+  enableTabScrolling,
+  ...rest
+}) => {
+  const triggerListRef = useRef<HTMLDivElement>(null)
+  const [showScroller, setShowScroller] = useState<boolean>(false)
+
+  const scrollTriggerListTo = useCallback((direction: 'left' | 'right') => {
+    const triggerList = triggerListRef.current
+    if (triggerList) {
+      const { scrollWidth } = triggerList
+      const scrollAmount = scrollWidth / 4 // 25% of whole scroll width
+      if (direction === 'right') {
+        if (triggerList.scrollLeft + scrollAmount <= scrollWidth) {
+          triggerList.scroll({
+            left: triggerList.scrollLeft + scrollAmount,
+            behavior: 'smooth'
+          })
+        }
+      } else {
+        triggerList.scroll({
+          left:
+            triggerList.scrollLeft - scrollAmount > 0
+              ? triggerList.scrollLeft - scrollAmount
+              : 0,
+          behavior: 'smooth'
+        })
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    const triggerList = triggerListRef.current
+    if (triggerList) {
+      const { offsetWidth, scrollWidth } = triggerList
+
+      const shouldShowScroller = scrollWidth > offsetWidth
+      if (showScroller !== shouldShowScroller) {
+        setShowScroller(shouldShowScroller)
+      }
+    }
+  }, [])
+
+  return showScroller || enableTabScrolling ? (
+    <Flex css={{ position: 'relative' }}>
+      <StyledActionIcon
+        size="lg"
+        label="scroll-left"
+        onClick={() => scrollTriggerListTo('left')}
+        css={{ left: 0 }}
+      >
+        <Icon is={ChevronLeft} size="lg" />
+      </StyledActionIcon>
+      <StyledTriggerList
+        {...rest}
+        ref={triggerListRef}
+        css={{
+          ...css,
+          width: '100%',
+          overflowX: 'auto',
+          '&::-webkit-scrollbar': { display: 'none' },
+          'div:first-child': { pl: '$6' },
+          'div:last-child': { pr: '$6' }
+        }}
+      />
+      <StyledActionIcon
+        size="lg"
+        label="scroll-right"
+        onClick={() => scrollTriggerListTo('right')}
+        css={{ right: 0 }}
+      >
+        <Icon is={ChevronRight} size="lg" />
+      </StyledActionIcon>
+    </Flex>
+  ) : (
+    <StyledTriggerList css={css} {...rest} ref={triggerListRef} />
+  )
+}
 
 export const Tabs: React.FC<TabsProps> & {
-  TriggerList: typeof StyledTriggerList
+  TriggerList: typeof TriggerListWrapper
   Trigger: typeof TabTrigger
   Content: typeof StyledTabContent
 } = ({ children, ...remainingProps }) => (
   <StyledRoot {...remainingProps}>{children}</StyledRoot>
 )
 
-Tabs.TriggerList = StyledTriggerList
+Tabs.TriggerList = TriggerListWrapper
 Tabs.Trigger = TabTrigger
 Tabs.Content = StyledTabContent
 

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -118,9 +118,7 @@ const TriggerListWrapper: React.FC<ListProps> = ({
           ...css,
           width: '100%',
           overflowX: 'auto',
-          '&::-webkit-scrollbar': { display: 'none' },
-          'div:first-child': { pl: '$6' },
-          'div:last-child': { pr: '$6' }
+          '&::-webkit-scrollbar': { display: 'none' }
         }}
       />
       {showRightScroller && (

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -6,6 +6,7 @@ import { styled, theme } from '~/stitches'
 
 import { TabTrigger } from './TabTrigger'
 import { TriggerListWrapper } from './TabsTriggerList'
+import { passPropsToChildren } from './utils'
 
 type TabsProps = React.ComponentProps<typeof StyledRoot>
 
@@ -108,8 +109,13 @@ export const Tabs: React.FC<TabsProps> & {
   TriggerList: typeof TriggerListWrapper
   Trigger: typeof TabTrigger
   Content: typeof StyledTabContent
-} = ({ theme = 'light', ...remainingProps }) => (
-  <StyledRoot theme={theme} {...remainingProps} />
+} = ({ theme = 'light', children, ...remainingProps }) => (
+  <StyledRoot theme={theme} {...remainingProps}>
+    {passPropsToChildren(children, { theme }, [
+      TriggerListWrapper,
+      StyledTabContent
+    ])}
+  </StyledRoot>
 )
 
 Tabs.TriggerList = TriggerListWrapper

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -18,91 +18,31 @@ const StyledRoot = styled(Root, {
   variants: {
     theme: {
       light: {
-        'div[role="tab"]': {
-          bg: 'white',
-          '&[data-state="active"]': {
-            color: '$primary',
-            textShadow: '0px 0px 1px currentColor',
-            boxShadow: 'inset 0 -2px 0 0 currentColor'
-          },
-          '&[data-state="inactive"]': {
-            color: '$tonal500'
-          },
-          '&:hover': {
-            color: '$primary',
-            bg: opacify(-0.9, theme.colors.primary.value)
-          },
-          '&:active': {
-            color: '$primary',
-            bg: opacify(-0.8, theme.colors.primary.value),
-            boxShadow: 'none'
-          },
-          '&:focus': {
-            color: '$primary',
-            boxShadow: 'inset 0 0 0 2px currentColor'
-          },
-          '&[data-disabled],&[data-disabled]:hover': {
-            color: '$tonal200',
-            cursor: 'default'
-          }
-        },
-        'div[role="tabpanel"]': {
-          bg: 'white',
-          color: '$textForeground',
-          fontFamily: '$body'
-        },
-        'div[role="tablist"]': {
-          borderBottom: '1px solid $primaryDark'
-        },
-        'button[role="scrollbar"]': {
-          bg: 'white',
-          opacity: 0.8
-        }
+        bg: 'white',
+        color: '$primary'
       },
       dark: {
         bg: '$primaryDark',
-        color: 'white',
-        'div[role="tab"]': {
-          color: 'white',
-          '&[data-state="active"]': {
-            textShadow: '0px 0px 1px currentColor',
-            boxShadow: 'inset 0 -2px 0 0 currentColor'
-          },
-          '&:hover': {
-            bg: opacify(-0.8, 'white')
-          },
-          '&:active': {
-            bg: opacify(-0.7, 'white'),
-            boxShadow: 'none'
-          },
-          '&:focus': {
-            boxShadow: 'inset 0 0 0 2px currentColor'
-          },
-          '&[data-disabled],&[data-disabled]:hover': {
-            color: '$tonal200',
-            cursor: 'default'
-          }
-        },
-        'div[role="tabpanel"]': {
-          bg: '$primaryDark',
-          color: 'white',
-          fontFamily: '$body'
-        },
-        'div[role="tablist"]': {
-          borderBottom: '1px solid white'
-        },
-        'button[role="scrollbar"], button[role="scrollbar"]:focus': {
-          bg: '$primaryDark',
-          opacity: 0.8,
-          color: 'white'
-        }
+        color: 'white'
       }
     }
   }
 })
 
 const StyledTabContent = styled(Content, {
-  flexGrow: 1
+  flexGrow: 1,
+  variants: {
+    theme: {
+      light: {
+        color: '$textForeground',
+        fontFamily: '$body'
+      },
+      dark: {
+        color: 'white',
+        fontFamily: '$body'
+      }
+    }
+  }
 })
 
 export const Tabs: React.FC<TabsProps> & {

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -14,7 +14,6 @@ const StyledRoot = styled(Root, {
   display: 'flex',
   flexDirection: 'column',
   pt: '$4',
-  px: '$2',
   variants: {
     theme: {
       light: {

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -1,0 +1,121 @@
+import { List } from '@radix-ui/react-tabs'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from '@atom-learning/icons'
+
+import { styled } from '~/stitches'
+import { ActionIcon } from '~/components/action-icon'
+import { Flex } from '~/components/flex'
+import { Icon } from '~/components/icon'
+
+type ListProps = React.ComponentProps<typeof StyledTriggerList> & {
+  enableTabScrolling?: boolean
+}
+
+const StyledActionIcon = styled(ActionIcon, {
+  position: 'absolute',
+  top: 'calc(50% - 20px)'
+})
+
+const StyledTriggerList = styled(List, {
+  flexShrink: 0,
+  display: 'flex'
+})
+
+export const TriggerListWrapper: React.FC<ListProps> = ({
+  css,
+  enableTabScrolling,
+  ...rest
+}) => {
+  const triggerListRef = useRef<HTMLDivElement>(null)
+  const [showLeftScroller, setShowLeftScroller] = useState<boolean>(false)
+  const [showRightScroller, setShowRightScroller] = useState<boolean>(false)
+
+  const scrollTriggerListTo = useCallback((direction: 'left' | 'right') => {
+    const triggerList = triggerListRef.current
+    if (triggerList) {
+      const { scrollWidth, scrollLeft } = triggerList
+      const scrollAmount = Math.round(scrollWidth / 4) // 25% of whole scroll width
+      if (direction === 'right') {
+        if (triggerList.scrollLeft + scrollAmount <= scrollWidth) {
+          triggerList.scroll({
+            left: triggerList.scrollLeft + scrollAmount,
+            behavior: 'smooth'
+          })
+        }
+      } else {
+        triggerList.scroll({
+          left: scrollLeft - scrollAmount > 0 ? scrollLeft - scrollAmount : 0,
+          behavior: 'smooth'
+        })
+      }
+
+      // Relying on setTimeout since scroll does not have a callback / doesn't return a promise :(
+      setTimeout(() => {
+        const { scrollWidth, scrollLeft, offsetWidth } = triggerList
+        if (scrollLeft === 0) {
+          setShowLeftScroller(false)
+          setShowRightScroller(true)
+        } else if (scrollLeft + offsetWidth === scrollWidth) {
+          setShowRightScroller(false)
+          setShowLeftScroller(true)
+        } else {
+          setShowLeftScroller(true)
+          setShowRightScroller(true)
+        }
+      }, 300)
+    }
+  }, [])
+
+  useEffect(() => {
+    const triggerList = triggerListRef.current
+    if (triggerList) {
+      const { offsetWidth, scrollWidth } = triggerList
+
+      const shouldShowScroller = scrollWidth > offsetWidth
+      if (shouldShowScroller) {
+        setShowRightScroller(true)
+      }
+    }
+  }, [])
+
+  const showScroller = showLeftScroller || showRightScroller
+
+  return showScroller || enableTabScrolling ? (
+    <Flex css={{ position: 'relative' }}>
+      {showLeftScroller && (
+        <StyledActionIcon
+          size="lg"
+          role="scrollbar"
+          label="scroll-left"
+          onClick={() => scrollTriggerListTo('left')}
+          css={{ left: 0 }}
+        >
+          <Icon is={ChevronLeft} size="lg" />
+        </StyledActionIcon>
+      )}
+      <StyledTriggerList
+        {...rest}
+        ref={triggerListRef}
+        css={{
+          ...css,
+          width: '100%',
+          overflowX: 'auto',
+          '&::-webkit-scrollbar': { display: 'none' }
+        }}
+      />
+      {showRightScroller && (
+        <StyledActionIcon
+          size="lg"
+          role="scrollbar"
+          label="scroll-right"
+          onClick={() => scrollTriggerListTo('right')}
+          css={{ right: 0 }}
+        >
+          <Icon is={ChevronRight} size="lg" />
+        </StyledActionIcon>
+      )}
+    </Flex>
+  ) : (
+    <StyledTriggerList css={css} {...rest} ref={triggerListRef} />
+  )
+}

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -6,8 +6,9 @@ import { styled } from '~/stitches'
 import { ActionIcon } from '~/components/action-icon'
 import { Flex } from '~/components/flex'
 import { Icon } from '~/components/icon'
-
-type ListProps = React.ComponentProps<typeof StyledTriggerList> & {
+import { TabTrigger } from './TabTrigger'
+import { passPropsToChildren } from './utils'
+interface ListProps extends React.ComponentProps<typeof StyledTriggerList> {
   enableTabScrolling?: boolean
 }
 
@@ -18,11 +19,19 @@ const StyledChevronIcon = styled(ActionIcon, {
 
 const StyledTriggerList = styled(List, {
   flexShrink: 0,
-  display: 'flex'
+  display: 'flex',
+  variants: {
+    theme: {
+      light: {},
+      dark: {}
+    }
+  }
 })
 
 export const TriggerListWrapper: React.FC<ListProps> = ({
   css,
+  children,
+  theme,
   enableTabScrolling,
   ...rest
 }) => {
@@ -82,7 +91,11 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
     showLeftScroller || showRightScroller || enableTabScrolling
 
   if (!showScroller) {
-    return <StyledTriggerList css={css} {...rest} ref={triggerListRef} />
+    return (
+      <StyledTriggerList css={css} {...rest} ref={triggerListRef}>
+        {passPropsToChildren(children, { theme }, [TabTrigger])}
+      </StyledTriggerList>
+    )
   }
 
   return (
@@ -107,7 +120,9 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           overflowX: 'auto',
           '&::-webkit-scrollbar': { display: 'none' }
         }}
-      />
+      >
+        {passPropsToChildren(children, { theme }, [TabTrigger])}
+      </StyledTriggerList>
       {showRightScroller && (
         <StyledChevronIcon
           size="lg"

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -23,13 +23,13 @@ const StyledChevronIcon = styled(ActionIcon, {
     theme: {
       light: {
         '&, &:not(:disabled):hover, &:not(:disabled):focus, &:not(:disabled):active': {
-          bg: fadedWhite,
-          color: 'currentColor'
+          bg: `${fadedWhite} !important`,
+          color: 'currentColor !important'
         }
       },
       dark: {
         '&, &:not(:disabled):hover, &:not(:disabled):focus, &:not(:disabled):active': {
-          bg: fadedPrimaryDark,
+          bg: `${fadedPrimaryDark} !important`,
           color: 'currentColor !important'
         }
       }
@@ -136,31 +136,27 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
   if (showScroller) {
     return (
       <Flex css={{ position: 'relative' }}>
-        {showLeftScroller && (
-          <StyledChevronIcon
-            size="xl"
-            label="Scroll Left"
-            theme={theme}
-            onClick={() => scrollTriggerListTo('left')}
-            css={{ left: 0 }}
-          >
-            <Icon is={ChevronLeft} size="lg" />
-          </StyledChevronIcon>
-        )}
+        <StyledChevronIcon
+          size="xl"
+          label="Scroll Left"
+          theme={theme}
+          onClick={() => scrollTriggerListTo('left')}
+          css={{ left: 0, display: showLeftScroller ? 'block' : 'none' }}
+        >
+          <Icon is={ChevronLeft} size="lg" />
+        </StyledChevronIcon>
         <StyledTriggerList {...rest} ref={triggerListRef} theme={theme}>
           {passPropsToChildren(children, { theme }, [TabTrigger])}
         </StyledTriggerList>
-        {showRightScroller && (
-          <StyledChevronIcon
-            size="xl"
-            label="Scroll right"
-            theme={theme}
-            onClick={() => scrollTriggerListTo('right')}
-            css={{ right: 0 }}
-          >
-            <Icon is={ChevronRight} size="lg" />
-          </StyledChevronIcon>
-        )}
+        <StyledChevronIcon
+          size="xl"
+          label="Scroll right"
+          theme={theme}
+          onClick={() => scrollTriggerListTo('right')}
+          css={{ right: 0, display: showRightScroller ? 'block' : 'none' }}
+        >
+          <Icon is={ChevronRight} size="lg" />
+        </StyledChevronIcon>
       </Flex>
     )
   }

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -35,19 +35,19 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
     if (triggerList) {
       const { scrollWidth, scrollLeft } = triggerList
       const scrollAmount = Math.round(scrollWidth / 4) // 25% of whole scroll width
+      let left = scrollLeft
       if (direction === 'right') {
-        if (triggerList.scrollLeft + scrollAmount <= scrollWidth) {
-          triggerList.scroll({
-            left: triggerList.scrollLeft + scrollAmount,
-            behavior: 'smooth'
-          })
-        }
+        const newScrollAmount = triggerList.scrollLeft + scrollAmount
+        left = newScrollAmount <= scrollWidth ? newScrollAmount : scrollLeft
       } else {
-        triggerList.scroll({
-          left: scrollLeft - scrollAmount > 0 ? scrollLeft - scrollAmount : 0,
-          behavior: 'smooth'
-        })
+        const newScrollAmount = scrollLeft - scrollAmount
+        left = newScrollAmount > 0 ? newScrollAmount : 0
       }
+
+      triggerList.scroll({
+        left,
+        behavior: 'smooth'
+      })
 
       // Relying on setTimeout since scroll does not have a callback / doesn't return a promise :(
       setTimeout(() => {

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -78,9 +78,14 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
     }
   }, [])
 
-  const showScroller = showLeftScroller || showRightScroller
+  const showScroller =
+    showLeftScroller || showRightScroller || enableTabScrolling
 
-  return showScroller || enableTabScrolling ? (
+  if (!showScroller) {
+    return <StyledTriggerList css={css} {...rest} ref={triggerListRef} />
+  }
+
+  return (
     <Flex css={{ position: 'relative' }}>
       {showLeftScroller && (
         <StyledActionIcon
@@ -115,7 +120,5 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         </StyledActionIcon>
       )}
     </Flex>
-  ) : (
-    <StyledTriggerList css={css} {...rest} ref={triggerListRef} />
   )
 }

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -18,7 +18,7 @@ const fadedPrimaryDark = opacify(-0.2, theme.colors.primaryDark.value)
 
 const StyledChevronIcon = styled(ActionIcon, {
   position: 'absolute',
-  top: 'calc(50% - 20px)',
+  top: 'calc(50% - ($4 + $1))',
   variants: {
     theme: {
       light: {
@@ -114,53 +114,53 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
   const showScroller =
     showLeftScroller || showRightScroller || enableTabScrolling
 
-  if (!showScroller) {
+  if (showScroller) {
     return (
-      <StyledTriggerList css={css} theme={theme} {...rest} ref={triggerListRef}>
-        {passPropsToChildren(children, { theme }, [TabTrigger])}
-      </StyledTriggerList>
+      <Flex css={{ position: 'relative' }}>
+        {showLeftScroller && (
+          <StyledChevronIcon
+            size="lg"
+            role="scrollbar"
+            label="scroll-left"
+            theme={theme}
+            onClick={() => scrollTriggerListTo('left')}
+            css={{ left: 0 }}
+          >
+            <Icon is={ChevronLeft} size="lg" />
+          </StyledChevronIcon>
+        )}
+        <StyledTriggerList
+          {...rest}
+          ref={triggerListRef}
+          theme={theme}
+          css={{
+            ...css,
+            width: '100%',
+            overflowX: 'auto',
+            '&::-webkit-scrollbar': { display: 'none' }
+          }}
+        >
+          {passPropsToChildren(children, { theme }, [TabTrigger])}
+        </StyledTriggerList>
+        {showRightScroller && (
+          <StyledChevronIcon
+            size="lg"
+            role="scrollbar"
+            label="scroll-right"
+            theme={theme}
+            onClick={() => scrollTriggerListTo('right')}
+            css={{ right: 0 }}
+          >
+            <Icon is={ChevronRight} size="lg" />
+          </StyledChevronIcon>
+        )}
+      </Flex>
     )
   }
 
   return (
-    <Flex css={{ position: 'relative' }}>
-      {showLeftScroller && (
-        <StyledChevronIcon
-          size="lg"
-          role="scrollbar"
-          label="scroll-left"
-          theme={theme}
-          onClick={() => scrollTriggerListTo('left')}
-          css={{ left: 0 }}
-        >
-          <Icon is={ChevronLeft} size="lg" />
-        </StyledChevronIcon>
-      )}
-      <StyledTriggerList
-        {...rest}
-        ref={triggerListRef}
-        theme={theme}
-        css={{
-          ...css,
-          width: '100%',
-          overflowX: 'auto',
-          '&::-webkit-scrollbar': { display: 'none' }
-        }}
-      >
-        {passPropsToChildren(children, { theme }, [TabTrigger])}
-      </StyledTriggerList>
-      {showRightScroller && (
-        <StyledChevronIcon
-          size="lg"
-          role="scrollbar"
-          label="scroll-right"
-          theme={theme}
-          onClick={() => scrollTriggerListTo('right')}
-          css={{ right: 0 }}
-        >
-          <Icon is={ChevronRight} size="lg" />
-        </StyledChevronIcon>
-      )}
-    </Flex>
+    <StyledTriggerList css={css} theme={theme} {...rest} ref={triggerListRef}>
+      {passPropsToChildren(children, { theme }, [TabTrigger])}
+    </StyledTriggerList>
   )
 }

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -58,7 +58,6 @@ const StyledTriggerList = styled(List, {
 })
 
 export const TriggerListWrapper: React.FC<ListProps> = ({
-  css,
   children,
   theme,
   enableTabScrolling,
@@ -170,7 +169,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
   }
 
   return (
-    <StyledTriggerList css={css} theme={theme} {...rest} ref={triggerListRef}>
+    <StyledTriggerList theme={theme} {...rest} ref={triggerListRef}>
       {passPropsToChildren(children, { theme }, [TabTrigger])}
     </StyledTriggerList>
   )

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -19,6 +19,7 @@ const fadedPrimaryDark = opacify(-0.2, theme.colors.primaryDark.value)
 
 const StyledChevronIcon = styled(ActionIcon, {
   position: 'absolute',
+  transition: 'all 125ms',
   variants: {
     theme: {
       light: {

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -22,16 +22,23 @@ const StyledChevronIcon = styled(ActionIcon, {
   variants: {
     theme: {
       light: {
-        '&, &:not(:disabled):hover, &:not(:disabled):focus, &:not(:disabled):active': {
-          bg: `${fadedWhite} !important`,
-          color: 'currentColor !important'
-        }
+        bg: `${fadedWhite} !important`
       },
       dark: {
-        '&, &:not(:disabled):hover, &:not(:disabled):focus, &:not(:disabled):active': {
-          bg: `${fadedPrimaryDark} !important`,
-          color: 'currentColor !important'
-        }
+        bg: `${fadedPrimaryDark} !important`,
+        color: 'currentColor !important'
+      }
+    },
+    visible: {
+      true: {
+        opacity: 1,
+        visibility: 'visible',
+        pointerEvents: 'all'
+      },
+      false: {
+        opacity: 0,
+        visibility: 'hidden',
+        pointerEvents: 'none'
       }
     }
   }
@@ -141,7 +148,8 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           label="Scroll Left"
           theme={theme}
           onClick={() => scrollTriggerListTo('left')}
-          css={{ left: 0, display: showLeftScroller ? 'block' : 'none' }}
+          visible={showLeftScroller}
+          css={{ left: 0 }}
         >
           <Icon is={ChevronLeft} size="lg" />
         </StyledChevronIcon>
@@ -153,7 +161,8 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           label="Scroll right"
           theme={theme}
           onClick={() => scrollTriggerListTo('right')}
-          css={{ right: 0, display: showRightScroller ? 'block' : 'none' }}
+          visible={showRightScroller}
+          css={{ right: 0 }}
         >
           <Icon is={ChevronRight} size="lg" />
         </StyledChevronIcon>

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -11,7 +11,7 @@ type ListProps = React.ComponentProps<typeof StyledTriggerList> & {
   enableTabScrolling?: boolean
 }
 
-const StyledActionIcon = styled(ActionIcon, {
+const StyledChevronIcon = styled(ActionIcon, {
   position: 'absolute',
   top: 'calc(50% - 20px)'
 })
@@ -88,7 +88,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
   return (
     <Flex css={{ position: 'relative' }}>
       {showLeftScroller && (
-        <StyledActionIcon
+        <StyledChevronIcon
           size="lg"
           role="scrollbar"
           label="scroll-left"
@@ -96,7 +96,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           css={{ left: 0 }}
         >
           <Icon is={ChevronLeft} size="lg" />
-        </StyledActionIcon>
+        </StyledChevronIcon>
       )}
       <StyledTriggerList
         {...rest}
@@ -109,7 +109,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         }}
       />
       {showRightScroller && (
-        <StyledActionIcon
+        <StyledChevronIcon
           size="lg"
           role="scrollbar"
           label="scroll-right"
@@ -117,7 +117,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           css={{ right: 0 }}
         >
           <Icon is={ChevronRight} size="lg" />
-        </StyledActionIcon>
+        </StyledChevronIcon>
       )}
     </Flex>
   )

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -1,8 +1,9 @@
 import { List } from '@radix-ui/react-tabs'
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { ChevronLeft, ChevronRight } from '@atom-learning/icons'
+import { opacify } from 'polished'
 
-import { styled } from '~/stitches'
+import { styled, theme } from '~/stitches'
 import { ActionIcon } from '~/components/action-icon'
 import { Flex } from '~/components/flex'
 import { Icon } from '~/components/icon'
@@ -12,9 +13,27 @@ interface ListProps extends React.ComponentProps<typeof StyledTriggerList> {
   enableTabScrolling?: boolean
 }
 
+const fadedWhite = opacify(-0.2, 'white')
+const fadedPrimaryDark = opacify(-0.2, theme.colors.primaryDark.value)
+
 const StyledChevronIcon = styled(ActionIcon, {
   position: 'absolute',
-  top: 'calc(50% - 20px)'
+  top: 'calc(50% - 20px)',
+  variants: {
+    theme: {
+      light: {
+        bg: `${fadedWhite} !important`
+      },
+      dark: {
+        bg: `${fadedPrimaryDark} !important`,
+        color: 'white !important',
+        '&:focus': {
+          bg: `${fadedPrimaryDark} !important`,
+          color: 'white'
+        }
+      }
+    }
+  }
 })
 
 const StyledTriggerList = styled(List, {
@@ -22,8 +41,12 @@ const StyledTriggerList = styled(List, {
   display: 'flex',
   variants: {
     theme: {
-      light: {},
-      dark: {}
+      light: {
+        borderBottom: '1px solid $tonal300'
+      },
+      dark: {
+        borderBottom: '1px solid $tonal200'
+      }
     }
   }
 })
@@ -92,7 +115,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
 
   if (!showScroller) {
     return (
-      <StyledTriggerList css={css} {...rest} ref={triggerListRef}>
+      <StyledTriggerList css={css} theme={theme} {...rest} ref={triggerListRef}>
         {passPropsToChildren(children, { theme }, [TabTrigger])}
       </StyledTriggerList>
     )
@@ -105,6 +128,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           size="lg"
           role="scrollbar"
           label="scroll-left"
+          theme={theme}
           onClick={() => scrollTriggerListTo('left')}
           css={{ left: 0 }}
         >
@@ -114,6 +138,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
       <StyledTriggerList
         {...rest}
         ref={triggerListRef}
+        theme={theme}
         css={{
           ...css,
           width: '100%',
@@ -128,6 +153,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
           size="lg"
           role="scrollbar"
           label="scroll-right"
+          theme={theme}
           onClick={() => scrollTriggerListTo('right')}
           css={{ right: 0 }}
         >

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -22,14 +22,15 @@ const StyledChevronIcon = styled(ActionIcon, {
   variants: {
     theme: {
       light: {
-        bg: `${fadedWhite} !important`
+        '&[role="scrollbar"], &[role="scrollbar"]:not(:disabled):hover, &[role="scrollbar"]:not(:disabled):focus, &[role="scrollbar"]:not(:disabled):active': {
+          bg: fadedWhite,
+          color: 'currentColor'
+        }
       },
       dark: {
-        bg: `${fadedPrimaryDark} !important`,
-        color: 'white !important',
-        '&:focus': {
-          bg: `${fadedPrimaryDark} !important`,
-          color: 'white'
+        '&[role="scrollbar"], &[role="scrollbar"]:not(:disabled):hover, &[role="scrollbar"]:not(:disabled):focus, &[role="scrollbar"]:not(:disabled):active': {
+          bg: fadedPrimaryDark,
+          color: 'currentColor'
         }
       }
     }

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -22,15 +22,15 @@ const StyledChevronIcon = styled(ActionIcon, {
   variants: {
     theme: {
       light: {
-        '&[role="scrollbar"], &[role="scrollbar"]:not(:disabled):hover, &[role="scrollbar"]:not(:disabled):focus, &[role="scrollbar"]:not(:disabled):active': {
+        '&, &:not(:disabled):hover, &:not(:disabled):focus, &:not(:disabled):active': {
           bg: fadedWhite,
           color: 'currentColor'
         }
       },
       dark: {
-        '&[role="scrollbar"], &[role="scrollbar"]:not(:disabled):hover, &[role="scrollbar"]:not(:disabled):focus, &[role="scrollbar"]:not(:disabled):active': {
+        '&, &:not(:disabled):hover, &:not(:disabled):focus, &:not(:disabled):active': {
           bg: fadedPrimaryDark,
-          color: 'currentColor'
+          color: 'currentColor !important'
         }
       }
     }
@@ -139,7 +139,6 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         {showLeftScroller && (
           <StyledChevronIcon
             size="xl"
-            role="scrollbar"
             label="Scroll Left"
             theme={theme}
             onClick={() => scrollTriggerListTo('left')}
@@ -154,7 +153,6 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         {showRightScroller && (
           <StyledChevronIcon
             size="xl"
-            role="scrollbar"
             label="Scroll right"
             theme={theme}
             onClick={() => scrollTriggerListTo('right')}

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -19,7 +19,6 @@ const fadedPrimaryDark = opacify(-0.2, theme.colors.primaryDark.value)
 
 const StyledChevronIcon = styled(ActionIcon, {
   position: 'absolute',
-  top: 'calc(50% - ($4 + $1))',
   variants: {
     theme: {
       light: {
@@ -139,7 +138,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
       <Flex css={{ position: 'relative' }}>
         {showLeftScroller && (
           <StyledChevronIcon
-            size="lg"
+            size="xl"
             role="scrollbar"
             label="Scroll Left"
             theme={theme}
@@ -154,7 +153,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         </StyledTriggerList>
         {showRightScroller && (
           <StyledChevronIcon
-            size="lg"
+            size="xl"
             role="scrollbar"
             label="Scroll right"
             theme={theme}

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -2,7 +2,7 @@ import { List } from '@radix-ui/react-tabs'
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { ChevronLeft, ChevronRight } from '@atom-learning/icons'
 import { opacify } from 'polished'
-import { debounce } from 'lodash'
+import { debounce } from 'throttle-debounce'
 
 import { styled, theme } from '~/stitches'
 import { ActionIcon } from '~/components/action-icon'

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -23,12 +23,13 @@ exports[`Tabs component renders 1`] = `
     scrollbar-width: none;
   }
 
-  .c-ehnQBI {
+  .c-hMbQTI {
     text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
     font-family: var(--fonts-body);
     padding: var(--space-4);
+    height: var(--sizes-5);
     -webkit-user-select: none;
     user-select: none;
     transition: 0.3s;
@@ -50,33 +51,33 @@ exports[`Tabs component renders 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-ehnQBI-hibzPz-theme-light {
+  .c-hMbQTI-hibzPz-theme-light {
     background: white;
   }
 
-  .c-ehnQBI-hibzPz-theme-light[data-state="active"] {
+  .c-hMbQTI-hibzPz-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-ehnQBI-hibzPz-theme-light[data-state="inactive"] {
+  .c-hMbQTI-hibzPz-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):hover {
+  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):active {
+  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-ehnQBI-hibzPz-theme-light[data-disabled],
-  .c-ehnQBI-hibzPz-theme-light[data-disabled]:hover {
+  .c-hMbQTI-hibzPz-theme-light[data-disabled],
+  .c-hMbQTI-hibzPz-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -103,7 +104,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
+        class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -116,7 +117,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
+        class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -175,12 +176,13 @@ exports[`Tabs component renders mobile view 1`] = `
     scrollbar-width: none;
   }
 
-  .c-ehnQBI {
+  .c-hMbQTI {
     text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
     font-family: var(--fonts-body);
     padding: var(--space-4);
+    height: var(--sizes-5);
     -webkit-user-select: none;
     user-select: none;
     transition: 0.3s;
@@ -206,33 +208,33 @@ exports[`Tabs component renders mobile view 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-ehnQBI-hibzPz-theme-light {
+  .c-hMbQTI-hibzPz-theme-light {
     background: white;
   }
 
-  .c-ehnQBI-hibzPz-theme-light[data-state="active"] {
+  .c-hMbQTI-hibzPz-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-ehnQBI-hibzPz-theme-light[data-state="inactive"] {
+  .c-hMbQTI-hibzPz-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):hover {
+  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):active {
+  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-ehnQBI-hibzPz-theme-light[data-disabled],
-  .c-ehnQBI-hibzPz-theme-light[data-disabled]:hover {
+  .c-hMbQTI-hibzPz-theme-light[data-disabled],
+  .c-hMbQTI-hibzPz-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -268,7 +270,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
+          class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -281,7 +283,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
+          class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -2,12 +2,10 @@
 
 exports[`Tabs component renders 1`] = `
 @media  {
-  .c-fkcdpq {
+  .c-caRXJy {
     display: flex;
     flex-direction: column;
     padding-top: var(--space-4);
-    padding-left: var(--space-2);
-    padding-right: var(--space-2);
   }
 
   .c-bVBcpu {
@@ -32,7 +30,7 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-eOLnUW-theme-light {
+  .c-caRXJy-eOLnUW-theme-light {
     background: white;
     color: var(--colors-primary);
   }
@@ -85,7 +83,7 @@ exports[`Tabs component renders 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-eOLnUW-theme-light"
+    class="c-caRXJy c-caRXJy-eOLnUW-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -151,12 +149,10 @@ exports[`Tabs component renders 1`] = `
 
 exports[`Tabs component renders mobile view 1`] = `
 @media  {
-  .c-fkcdpq {
+  .c-caRXJy {
     display: flex;
     flex-direction: column;
     padding-top: var(--space-4);
-    padding-left: var(--space-2);
-    padding-right: var(--space-2);
   }
 
   .c-bVBcpu {
@@ -185,7 +181,7 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-eOLnUW-theme-light {
+  .c-caRXJy-eOLnUW-theme-light {
     background: white;
     color: var(--colors-primary);
   }
@@ -253,7 +249,7 @@ exports[`Tabs component renders mobile view 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-eOLnUW-theme-light"
+    class="c-caRXJy c-caRXJy-eOLnUW-theme-light"
     data-orientation="horizontal"
   >
     <div

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -8,9 +8,19 @@ exports[`Tabs component renders 1`] = `
     padding-top: var(--space-4);
   }
 
-  .c-bVBcpu {
+  .c-gZZKZD {
     flex-shrink: 0;
     display: flex;
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .c-gZZKZD::-webkit-scrollbar {
+    display: none;
+  }
+
+  .c-gZZKZD {
+    scrollbar-width: none;
   }
 
   .c-ehnQBI {
@@ -36,7 +46,7 @@ exports[`Tabs component renders 1`] = `
     color: var(--colors-primary);
   }
 
-  .c-bVBcpu-eFavRf-theme-light {
+  .c-gZZKZD-eFavRf-theme-light {
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
@@ -83,7 +93,7 @@ exports[`Tabs component renders 1`] = `
   >
     <div
       aria-orientation="horizontal"
-      class="c-bVBcpu c-bVBcpu-eFavRf-theme-light"
+      class="c-gZZKZD c-gZZKZD-eFavRf-theme-light"
       data-orientation="horizontal"
       dir="ltr"
       role="tablist"
@@ -150,9 +160,19 @@ exports[`Tabs component renders mobile view 1`] = `
     padding-top: var(--space-4);
   }
 
-  .c-bVBcpu {
+  .c-gZZKZD {
     flex-shrink: 0;
     display: flex;
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .c-gZZKZD::-webkit-scrollbar {
+    display: none;
+  }
+
+  .c-gZZKZD {
+    scrollbar-width: none;
   }
 
   .c-ehnQBI {
@@ -182,7 +202,7 @@ exports[`Tabs component renders mobile view 1`] = `
     color: var(--colors-primary);
   }
 
-  .c-bVBcpu-eFavRf-theme-light {
+  .c-gZZKZD-eFavRf-theme-light {
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
@@ -226,15 +246,6 @@ exports[`Tabs component renders mobile view 1`] = `
   .c-dhzjXW-icmpvrW-css {
     position: relative;
   }
-
-  .c-bVBcpu-ifwuxZe-css {
-    width: 100%;
-    overflow-x: auto;
-  }
-
-  .c-bVBcpu-ifwuxZe-css::-webkit-scrollbar {
-    display: none;
-  }
 }
 
 <div>
@@ -247,7 +258,7 @@ exports[`Tabs component renders mobile view 1`] = `
     >
       <div
         aria-orientation="horizontal"
-        class="c-bVBcpu c-bVBcpu-eFavRf-theme-light c-bVBcpu-ifwuxZe-css"
+        class="c-gZZKZD c-gZZKZD-eFavRf-theme-light"
         data-orientation="horizontal"
         dir="ltr"
         role="tablist"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -32,61 +32,61 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"] {
     background: white;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="active"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="inactive"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:hover {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:active {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:focus {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled],
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled]:hover {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled],
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tabpanel"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tabpanel"] {
     background: white;
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tablist"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tablist"] {
     border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light button[role="scrollbar"] {
-    background: white !important;
+  .c-fkcdpq-eFTdAS-theme-light button[role="scrollbar"] {
+    background: white;
     opacity: 0.8;
   }
 }
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-fGxsFx-theme-light"
+    class="c-fkcdpq c-fkcdpq-eFTdAS-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -186,54 +186,54 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"] {
     background: white;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="active"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="inactive"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:hover {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:active {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:focus {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled],
-  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled]:hover {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled],
+  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tabpanel"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tabpanel"] {
     background: white;
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light div[role="tablist"] {
+  .c-fkcdpq-eFTdAS-theme-light div[role="tablist"] {
     border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-fkcdpq-fGxsFx-theme-light button[role="scrollbar"] {
-    background: white !important;
+  .c-fkcdpq-eFTdAS-theme-light button[role="scrollbar"] {
+    background: white;
     opacity: 0.8;
   }
 }
@@ -255,7 +255,7 @@ exports[`Tabs component renders mobile view 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-fGxsFx-theme-light"
+    class="c-fkcdpq c-fkcdpq-eFTdAS-theme-light"
     data-orientation="horizontal"
   >
     <div

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -2,10 +2,9 @@
 
 exports[`Tabs component renders 1`] = `
 @media  {
-  .c-caRXJy {
+  .c-fixGjY {
     display: flex;
     flex-direction: column;
-    padding-top: var(--space-4);
   }
 
   .c-gZZKZD {
@@ -42,7 +41,7 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-caRXJy-eOLnUW-theme-light {
+  .c-fixGjY-eOLnUW-theme-light {
     background: white;
     color: var(--colors-primary);
   }
@@ -90,7 +89,7 @@ exports[`Tabs component renders 1`] = `
 
 <div>
   <div
-    class="c-caRXJy c-caRXJy-eOLnUW-theme-light"
+    class="c-fixGjY c-fixGjY-eOLnUW-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -156,10 +155,9 @@ exports[`Tabs component renders 1`] = `
 
 exports[`Tabs component renders mobile view 1`] = `
 @media  {
-  .c-caRXJy {
+  .c-fixGjY {
     display: flex;
     flex-direction: column;
-    padding-top: var(--space-4);
   }
 
   .c-gZZKZD {
@@ -198,8 +196,9 @@ exports[`Tabs component renders mobile view 1`] = `
     display: flex;
   }
 
-  .c-bMCfDd {
+  .c-fDwKcF {
     position: absolute;
+    transition: all 125ms;
   }
 
   .c-fDzwZw {
@@ -228,7 +227,7 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-caRXJy-eOLnUW-theme-light {
+  .c-fixGjY-eOLnUW-theme-light {
     background: white;
     color: var(--colors-primary);
   }
@@ -273,11 +272,11 @@ exports[`Tabs component renders mobile view 1`] = `
     color: var(--colors-textForeground);
   }
 
-  .c-bMCfDd-faCgme-theme-light {
+  .c-fDwKcF-faCgme-theme-light {
     background: rgba(255,255,255,0.8) !important;
   }
 
-  .c-bMCfDd-ejYaUA-visible-false {
+  .c-fDwKcF-ejYaUA-visible-false {
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
@@ -321,7 +320,7 @@ exports[`Tabs component renders mobile view 1`] = `
     position: relative;
   }
 
-  .c-bMCfDd-icezigA-css {
+  .c-fDwKcF-icezigA-css {
     left: 0;
   }
 
@@ -330,14 +329,14 @@ exports[`Tabs component renders mobile view 1`] = `
     width: 20px;
   }
 
-  .c-bMCfDd-iczsSGP-css {
+  .c-fDwKcF-iczsSGP-css {
     right: 0;
   }
 }
 
 <div>
   <div
-    class="c-caRXJy c-caRXJy-eOLnUW-theme-light"
+    class="c-fixGjY c-fixGjY-eOLnUW-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -345,7 +344,7 @@ exports[`Tabs component renders mobile view 1`] = `
     >
       <button
         aria-label="Scroll Left"
-        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-faCgme-theme-light c-bMCfDd-ejYaUA-visible-false c-bMCfDd-icezigA-css"
+        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-fDwKcF c-fDwKcF-faCgme-theme-light c-fDwKcF-ejYaUA-visible-false c-fDwKcF-icezigA-css"
         type="button"
       >
         <svg
@@ -397,7 +396,7 @@ exports[`Tabs component renders mobile view 1`] = `
       </div>
       <button
         aria-label="Scroll right"
-        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-faCgme-theme-light c-bMCfDd-ejYaUA-visible-false c-bMCfDd-iczsSGP-css"
+        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-fDwKcF c-fDwKcF-faCgme-theme-light c-fDwKcF-ejYaUA-visible-false c-fDwKcF-iczsSGP-css"
         type="button"
       >
         <svg

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -156,85 +156,11 @@ exports[`Tabs component renders mobile view 1`] = `
   .c-dhzjXW {
     display: flex;
   }
-
-  .c-CYaOB {
-    position: absolute;
-    top: calc(50% - 20px);
-    background: white !important;
-    opacity: 0.8;
-  }
-
-  .c-fDzwZw {
-    align-items: center;
-    -webkit-appearance: none;
-    appearance: none;
-    background: white;
-    border: unset;
-    border-radius: var(--radii-0);
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    padding: unset;
-    transition: all 100ms ease-out;
-  }
-
-  .c-dbrbZt {
-    display: inline-block;
-    fill: none;
-    stroke: currentcolor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    vertical-align: middle;
-  }
-}
-
-@media  {
-  .c-fDzwZw-PrXKS-size-lg {
-    height: var(--sizes-4);
-    width: var(--sizes-4);
-  }
-
-  .c-dbrbZt-fLGGKn-size-lg {
-    height: var(--sizes-3);
-    width: var(--sizes-3);
-    stroke-width: 2;
-  }
-}
-
-@media  {
-  .c-fDzwZw-cmVfvW-cv {
-    background: transparent;
-    color: var(--colors-primary);
-  }
-
-  .c-fDzwZw-cmVfvW-cv:not(:disabled):hover,
-  .c-fDzwZw-cmVfvW-cv:not(:disabled):focus {
-    color: var(--colors-primaryMid);
-  }
-
-  .c-fDzwZw-cmVfvW-cv:not(:disabled):active {
-    color: var(--colors-primaryDark);
-  }
-
-  .c-fDzwZw-cmVfvW-cv[disabled] {
-    color: var(--colors-tonal400);
-    cursor: not-allowed;
-  }
 }
 
 @media  {
   .c-dhzjXW-icmpvrW-css {
     position: relative;
-  }
-
-  .c-CYaOB-icezigA-css {
-    left: 0;
-  }
-
-  .c-dbrbZt-ihFPSGE-css {
-    height: 20px;
-    width: 20px;
   }
 
   .c-MQgzr-ifTJoPk-css {
@@ -253,10 +179,6 @@ exports[`Tabs component renders mobile view 1`] = `
   .c-MQgzr-ifTJoPk-css div:last-child {
     padding-right: var(--space-6);
   }
-
-  .c-CYaOB-iczsSGP-css {
-    right: 0;
-  }
 }
 
 <div>
@@ -267,22 +189,6 @@ exports[`Tabs component renders mobile view 1`] = `
     <div
       class="c-dhzjXW c-dhzjXW-icmpvrW-css"
     >
-      <button
-        aria-label="scroll-left"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-lg c-fDzwZw-cmVfvW-cv c-CYaOB c-CYaOB-icezigA-css"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-fLGGKn-size-lg c-dbrbZt-ihFPSGE-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <polyline
-            points="14 18 8 12 14 6 14 6"
-          />
-        </svg>
-      </button>
       <div
         aria-orientation="horizontal"
         class="c-MQgzr c-MQgzr-ifTJoPk-css"
@@ -319,22 +225,6 @@ exports[`Tabs component renders mobile view 1`] = `
           Trigger 2 which is going to be even longer
         </div>
       </div>
-      <button
-        aria-label="scroll-right"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-lg c-fDzwZw-cmVfvW-cv c-CYaOB c-CYaOB-iczsSGP-css"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-fLGGKn-size-lg c-dbrbZt-ihFPSGE-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <polyline
-            points="10 6 16 12 10 18 10 18"
-          />
-        </svg>
-      </button>
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -32,66 +32,65 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-clEueN-theme-light div[role="tab"] {
+  .c-fkcdpq-eOLnUW-theme-light {
+    background: white;
+    color: var(--colors-primary);
+  }
+
+  .c-bVBcpu-eFavRf-theme-light {
+    border-bottom: 1px solid var(--colors-tonal300);
+  }
+
+  .c-ehnQBI-uKSRl-theme-light {
     background: white;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="active"] {
+  .c-ehnQBI-uKSRl-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="inactive"] {
+  .c-ehnQBI-uKSRl-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"]:hover {
+  .c-ehnQBI-uKSRl-theme-light:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"]:active {
+  .c-ehnQBI-uKSRl-theme-light:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"]:focus {
+  .c-ehnQBI-uKSRl-theme-light:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled],
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled]:hover {
+  .c-ehnQBI-uKSRl-theme-light[data-disabled],
+  .c-ehnQBI-uKSRl-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tabpanel"] {
-    background: white;
+  .c-eGaVeY-jWVCRL-theme-light {
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
-  }
-
-  .c-fkcdpq-clEueN-theme-light div[role="tablist"] {
-    border-bottom: 1px solid var(--colors-primaryDark);
-  }
-
-  .c-fkcdpq-clEueN-theme-light button[role="scrollbar"] {
-    background: white;
-    opacity: 0.8;
   }
 }
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-clEueN-theme-light"
+    class="c-fkcdpq c-fkcdpq-eOLnUW-theme-light"
     data-orientation="horizontal"
   >
     <div
       aria-orientation="horizontal"
-      class="c-bVBcpu"
+      class="c-bVBcpu c-bVBcpu-eFavRf-theme-light"
       data-orientation="horizontal"
       dir="ltr"
       role="tablist"
@@ -101,7 +100,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-ehnQBI"
+        class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -114,7 +113,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-ehnQBI"
+        class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -127,26 +126,24 @@ exports[`Tabs component renders 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"
-      class="c-eGaVeY"
+      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
       data-orientation="horizontal"
       data-state="active"
       id="radix-id-0-1-content-tab1"
       role="tabpanel"
       tabindex="0"
-      theme="light"
     >
       Important content for tab 1
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab2"
-      class="c-eGaVeY"
+      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
       data-orientation="horizontal"
       data-state="inactive"
       hidden=""
       id="radix-id-0-1-content-tab2"
       role="tabpanel"
       tabindex="0"
-      theme="light"
     />
   </div>
 </div>
@@ -188,55 +185,54 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-clEueN-theme-light div[role="tab"] {
+  .c-fkcdpq-eOLnUW-theme-light {
+    background: white;
+    color: var(--colors-primary);
+  }
+
+  .c-bVBcpu-eFavRf-theme-light {
+    border-bottom: 1px solid var(--colors-tonal300);
+  }
+
+  .c-ehnQBI-uKSRl-theme-light {
     background: white;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="active"] {
+  .c-ehnQBI-uKSRl-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="inactive"] {
+  .c-ehnQBI-uKSRl-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"]:hover {
+  .c-ehnQBI-uKSRl-theme-light:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"]:active {
+  .c-ehnQBI-uKSRl-theme-light:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"]:focus {
+  .c-ehnQBI-uKSRl-theme-light:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled],
-  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled]:hover {
+  .c-ehnQBI-uKSRl-theme-light[data-disabled],
+  .c-ehnQBI-uKSRl-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-clEueN-theme-light div[role="tabpanel"] {
-    background: white;
+  .c-eGaVeY-jWVCRL-theme-light {
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
-  }
-
-  .c-fkcdpq-clEueN-theme-light div[role="tablist"] {
-    border-bottom: 1px solid var(--colors-primaryDark);
-  }
-
-  .c-fkcdpq-clEueN-theme-light button[role="scrollbar"] {
-    background: white;
-    opacity: 0.8;
   }
 }
 
@@ -257,7 +253,7 @@ exports[`Tabs component renders mobile view 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-clEueN-theme-light"
+    class="c-fkcdpq c-fkcdpq-eOLnUW-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -265,7 +261,7 @@ exports[`Tabs component renders mobile view 1`] = `
     >
       <div
         aria-orientation="horizontal"
-        class="c-bVBcpu c-bVBcpu-ifwuxZe-css"
+        class="c-bVBcpu c-bVBcpu-eFavRf-theme-light c-bVBcpu-ifwuxZe-css"
         data-orientation="horizontal"
         dir="ltr"
         role="tablist"
@@ -275,7 +271,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-ehnQBI"
+          class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -288,7 +284,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-ehnQBI"
+          class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"
@@ -302,26 +298,24 @@ exports[`Tabs component renders mobile view 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"
-      class="c-eGaVeY"
+      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
       data-orientation="horizontal"
       data-state="active"
       id="radix-id-0-1-content-tab1"
       role="tabpanel"
       tabindex="0"
-      theme="light"
     >
       Important content for tab 1
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab2"
-      class="c-eGaVeY"
+      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
       data-orientation="horizontal"
       data-state="inactive"
       hidden=""
       id="radix-id-0-1-content-tab2"
       role="tabpanel"
       tabindex="0"
-      theme="light"
     />
   </div>
 </div>

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -163,21 +163,13 @@ exports[`Tabs component renders mobile view 1`] = `
     position: relative;
   }
 
-  .c-MQgzr-ifTJoPk-css {
+  .c-MQgzr-ifwuxZe-css {
     width: 100%;
     overflow-x: auto;
   }
 
-  .c-MQgzr-ifTJoPk-css::-webkit-scrollbar {
+  .c-MQgzr-ifwuxZe-css::-webkit-scrollbar {
     display: none;
-  }
-
-  .c-MQgzr-ifTJoPk-css div:first-child {
-    padding-left: var(--space-6);
-  }
-
-  .c-MQgzr-ifTJoPk-css div:last-child {
-    padding-right: var(--space-6);
   }
 }
 
@@ -191,7 +183,7 @@ exports[`Tabs component renders mobile view 1`] = `
     >
       <div
         aria-orientation="horizontal"
-        class="c-MQgzr c-MQgzr-ifTJoPk-css"
+        class="c-MQgzr c-MQgzr-ifwuxZe-css"
         data-orientation="horizontal"
         dir="ltr"
         role="tablist"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -196,6 +196,34 @@ exports[`Tabs component renders mobile view 1`] = `
   .c-dhzjXW {
     display: flex;
   }
+
+  .c-bMCfDd {
+    position: absolute;
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
 }
 
 @media  {
@@ -242,11 +270,66 @@ exports[`Tabs component renders mobile view 1`] = `
   .c-cWMaKf-fwFiEo-theme-light {
     color: var(--colors-textForeground);
   }
+
+  .c-bMCfDd-fPEWfa-theme-light,
+  .c-bMCfDd-fPEWfa-theme-light:not(:disabled):hover,
+  .c-bMCfDd-fPEWfa-theme-light:not(:disabled):focus,
+  .c-bMCfDd-fPEWfa-theme-light:not(:disabled):active {
+    background: rgba(255,255,255,0.8) !important;
+    color: currentColor !important;
+  }
+
+  .c-fDzwZw-kMhpXP-size-xl {
+    height: var(--sizes-5);
+    width: var(--sizes-5);
+  }
+
+  .c-dbrbZt-fLGGKn-size-lg {
+    height: var(--sizes-3);
+    width: var(--sizes-3);
+    stroke-width: 2;
+  }
+}
+
+@media  {
+  .c-fDzwZw-cmVfvW-cv {
+    background: transparent;
+    color: var(--colors-primary);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):hover,
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-cmVfvW-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
 }
 
 @media  {
   .c-dhzjXW-icmpvrW-css {
     position: relative;
+  }
+
+  .c-bMCfDd-idoKZhy-css {
+    left: 0;
+    display: none;
+  }
+
+  .c-dbrbZt-ihFPSGE-css {
+    height: 20px;
+    width: 20px;
+  }
+
+  .c-bMCfDd-ihLdYJt-css {
+    right: 0;
+    display: none;
   }
 }
 
@@ -258,6 +341,22 @@ exports[`Tabs component renders mobile view 1`] = `
     <div
       class="c-dhzjXW c-dhzjXW-icmpvrW-css"
     >
+      <button
+        aria-label="Scroll Left"
+        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-fPEWfa-theme-light c-bMCfDd-idoKZhy-css"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-fLGGKn-size-lg c-dbrbZt-ihFPSGE-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="14 18 8 12 14 6 14 6"
+          />
+        </svg>
+      </button>
       <div
         aria-orientation="horizontal"
         class="c-gZZKZD c-gZZKZD-eFavRf-theme-light"
@@ -294,6 +393,22 @@ exports[`Tabs component renders mobile view 1`] = `
           Trigger 2 which is going to be even longer
         </div>
       </div>
+      <button
+        aria-label="Scroll right"
+        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-fPEWfa-theme-light c-bMCfDd-ihLdYJt-css"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-fLGGKn-size-lg c-dbrbZt-ihFPSGE-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="10 6 16 12 10 18 10 18"
+          />
+        </svg>
+      </button>
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -39,38 +39,33 @@ exports[`Tabs component renders 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-ehnQBI-uKSRl-theme-light {
+  .c-ehnQBI-kLQAjc-theme-light {
     background: white;
   }
 
-  .c-ehnQBI-uKSRl-theme-light[data-state="active"] {
+  .c-ehnQBI-kLQAjc-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-ehnQBI-uKSRl-theme-light[data-state="inactive"] {
+  .c-ehnQBI-kLQAjc-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-ehnQBI-uKSRl-theme-light:hover {
+  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-ehnQBI-uKSRl-theme-light:active {
+  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-ehnQBI-uKSRl-theme-light:focus {
-    color: var(--colors-primary);
-    box-shadow: inset 0 0 0 2px currentColor;
-  }
-
-  .c-ehnQBI-uKSRl-theme-light[data-disabled],
-  .c-ehnQBI-uKSRl-theme-light[data-disabled]:hover {
+  .c-ehnQBI-kLQAjc-theme-light[data-disabled],
+  .c-ehnQBI-kLQAjc-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
@@ -98,7 +93,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
+        class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -111,7 +106,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
+        class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -190,38 +185,33 @@ exports[`Tabs component renders mobile view 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-ehnQBI-uKSRl-theme-light {
+  .c-ehnQBI-kLQAjc-theme-light {
     background: white;
   }
 
-  .c-ehnQBI-uKSRl-theme-light[data-state="active"] {
+  .c-ehnQBI-kLQAjc-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-ehnQBI-uKSRl-theme-light[data-state="inactive"] {
+  .c-ehnQBI-kLQAjc-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-ehnQBI-uKSRl-theme-light:hover {
+  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-ehnQBI-uKSRl-theme-light:active {
+  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-ehnQBI-uKSRl-theme-light:focus {
-    color: var(--colors-primary);
-    box-shadow: inset 0 0 0 2px currentColor;
-  }
-
-  .c-ehnQBI-uKSRl-theme-light[data-disabled],
-  .c-ehnQBI-uKSRl-theme-light[data-disabled]:hover {
+  .c-ehnQBI-kLQAjc-theme-light[data-disabled],
+  .c-ehnQBI-kLQAjc-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
@@ -267,7 +257,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
+          class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -280,7 +270,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-ehnQBI c-ehnQBI-uKSRl-theme-light"
+          class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -32,53 +32,53 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"] {
     background: white;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="active"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="active"] {
     color: var(--colors-primary);
-    font-weight: 600;
+    text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="inactive"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:hover {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"]:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:active {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"]:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:focus {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"]:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled],
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled]:hover {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled],
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tabpanel"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tabpanel"] {
     background: white;
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tablist"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tablist"] {
     border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light button[role="scrollbar"] {
+  .c-fkcdpq-clEueN-theme-light button[role="scrollbar"] {
     background: white;
     opacity: 0.8;
   }
@@ -86,7 +86,7 @@ exports[`Tabs component renders 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-eFTdAS-theme-light"
+    class="c-fkcdpq c-fkcdpq-clEueN-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -186,53 +186,53 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"] {
     background: white;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="active"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="active"] {
     color: var(--colors-primary);
-    font-weight: 600;
+    text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-state="inactive"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:hover {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"]:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:active {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"]:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"]:focus {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"]:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled],
-  .c-fkcdpq-eFTdAS-theme-light div[role="tab"][data-disabled]:hover {
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled],
+  .c-fkcdpq-clEueN-theme-light div[role="tab"][data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tabpanel"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tabpanel"] {
     background: white;
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light div[role="tablist"] {
+  .c-fkcdpq-clEueN-theme-light div[role="tablist"] {
     border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-fkcdpq-eFTdAS-theme-light button[role="scrollbar"] {
+  .c-fkcdpq-clEueN-theme-light button[role="scrollbar"] {
     background: white;
     opacity: 0.8;
   }
@@ -255,7 +255,7 @@ exports[`Tabs component renders mobile view 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-eFTdAS-theme-light"
+    class="c-fkcdpq c-fkcdpq-clEueN-theme-light"
     data-orientation="horizontal"
   >
     <div

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`Tabs component renders 1`] = `
       id="radix-id-0-1-content-tab1"
       role="tabpanel"
       tabindex="0"
+      theme="light"
     >
       Important content for tab 1
     </div>
@@ -145,6 +146,7 @@ exports[`Tabs component renders 1`] = `
       id="radix-id-0-1-content-tab2"
       role="tabpanel"
       tabindex="0"
+      theme="light"
     />
   </div>
 </div>
@@ -306,6 +308,7 @@ exports[`Tabs component renders mobile view 1`] = `
       id="radix-id-0-1-content-tab1"
       role="tabpanel"
       tabindex="0"
+      theme="light"
     >
       Important content for tab 1
     </div>
@@ -318,6 +321,7 @@ exports[`Tabs component renders mobile view 1`] = `
       id="radix-id-0-1-content-tab2"
       role="tabpanel"
       tabindex="0"
+      theme="light"
     />
   </div>
 </div>

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Tabs component renders 1`] = `
     display: flex;
   }
 
-  .c-kUWTIa {
+  .c-ehnQBI {
     text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
@@ -23,7 +23,7 @@ exports[`Tabs component renders 1`] = `
     padding: var(--space-4);
     -webkit-user-select: none;
     user-select: none;
-    transition: 0.5s;
+    transition: 0.3s;
   }
 
   .c-eGaVeY {
@@ -32,53 +32,53 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"] {
     background: white;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="active"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="inactive"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:hover {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:active {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:focus {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled],
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled]:hover {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled],
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tabpanel"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tabpanel"] {
     background: white;
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tablist"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tablist"] {
     border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light button[role="scrollbar"] {
+  .c-fkcdpq-fGxsFx-theme-light button[role="scrollbar"] {
     background: white !important;
     opacity: 0.8;
   }
@@ -86,7 +86,7 @@ exports[`Tabs component renders 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-fGxsFx-appearance-light"
+    class="c-fkcdpq c-fkcdpq-fGxsFx-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -101,7 +101,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-kUWTIa"
+        class="c-ehnQBI"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -114,7 +114,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-kUWTIa"
+        class="c-ehnQBI"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -165,7 +165,7 @@ exports[`Tabs component renders mobile view 1`] = `
     display: flex;
   }
 
-  .c-kUWTIa {
+  .c-ehnQBI {
     text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
@@ -173,7 +173,7 @@ exports[`Tabs component renders mobile view 1`] = `
     padding: var(--space-4);
     -webkit-user-select: none;
     user-select: none;
-    transition: 0.5s;
+    transition: 0.3s;
   }
 
   .c-eGaVeY {
@@ -186,53 +186,53 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"] {
     background: white;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="active"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="inactive"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:hover {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:active {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:focus {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"]:focus {
     color: var(--colors-primary);
     box-shadow: inset 0 0 0 2px currentColor;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled],
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled]:hover {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled],
+  .c-fkcdpq-fGxsFx-theme-light div[role="tab"][data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: default;
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tabpanel"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tabpanel"] {
     background: white;
     color: var(--colors-textForeground);
     font-family: var(--fonts-body);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light div[role="tablist"] {
+  .c-fkcdpq-fGxsFx-theme-light div[role="tablist"] {
     border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-fkcdpq-fGxsFx-appearance-light button[role="scrollbar"] {
+  .c-fkcdpq-fGxsFx-theme-light button[role="scrollbar"] {
     background: white !important;
     opacity: 0.8;
   }
@@ -255,7 +255,7 @@ exports[`Tabs component renders mobile view 1`] = `
 
 <div>
   <div
-    class="c-fkcdpq c-fkcdpq-fGxsFx-appearance-light"
+    class="c-fkcdpq c-fkcdpq-fGxsFx-theme-light"
     data-orientation="horizontal"
   >
     <div
@@ -273,7 +273,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-kUWTIa"
+          class="c-ehnQBI"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -286,7 +286,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-kUWTIa"
+          class="c-ehnQBI"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -2,41 +2,28 @@
 
 exports[`Tabs component renders 1`] = `
 @media  {
-  .c-fixGjY {
+  .c-fkcdpq {
     display: flex;
     flex-direction: column;
+    padding-top: var(--space-4);
+    padding-left: var(--space-2);
+    padding-right: var(--space-2);
   }
 
-  .c-MQgzr {
+  .c-bVBcpu {
     flex-shrink: 0;
     display: flex;
-    border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-hUDFHn {
-    color: var(--colors-secondary);
+  .c-kUWTIa {
+    text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
     font-family: var(--fonts-body);
     padding: var(--space-4);
     -webkit-user-select: none;
     user-select: none;
-  }
-
-  .c-hUDFHn:hover {
-    color: var(--colors-primary);
-  }
-
-  .c-hUDFHn[data-disabled],
-  .c-hUDFHn[data-disabled]:hover {
-    color: var(--colors-tonal300);
-    cursor: default;
-  }
-
-  .c-hUDFHn[data-state="active"] {
-    color: var(--colors-primary);
-    font-weight: bold;
-    box-shadow: inset 0 -3px 0 0 currentColor;
+    transition: 0.5s;
   }
 
   .c-eGaVeY {
@@ -44,14 +31,67 @@ exports[`Tabs component renders 1`] = `
   }
 }
 
+@media  {
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"] {
+    background: white;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="active"] {
+    color: var(--colors-primary);
+    font-weight: 600;
+    box-shadow: inset 0 -2px 0 0 currentColor;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="inactive"] {
+    color: var(--colors-tonal500);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:hover {
+    color: var(--colors-primary);
+    background: rgba(30,113,246,0.1);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:active {
+    color: var(--colors-primary);
+    background: rgba(30,113,246,0.2);
+    box-shadow: none;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:focus {
+    color: var(--colors-primary);
+    box-shadow: inset 0 0 0 2px currentColor;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled],
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled]:hover {
+    color: var(--colors-tonal200);
+    cursor: default;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tabpanel"] {
+    background: white;
+    color: var(--colors-textForeground);
+    font-family: var(--fonts-body);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tablist"] {
+    border-bottom: 1px solid var(--colors-primaryDark);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light button[role="scrollbar"] {
+    background: white !important;
+    opacity: 0.8;
+  }
+}
+
 <div>
   <div
-    class="c-fixGjY"
+    class="c-fkcdpq c-fkcdpq-fGxsFx-appearance-light"
     data-orientation="horizontal"
   >
     <div
       aria-orientation="horizontal"
-      class="c-MQgzr"
+      class="c-bVBcpu"
       data-orientation="horizontal"
       dir="ltr"
       role="tablist"
@@ -61,7 +101,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-hUDFHn"
+        class="c-kUWTIa"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -74,7 +114,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-hUDFHn"
+        class="c-kUWTIa"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -112,41 +152,28 @@ exports[`Tabs component renders 1`] = `
 
 exports[`Tabs component renders mobile view 1`] = `
 @media  {
-  .c-fixGjY {
+  .c-fkcdpq {
     display: flex;
     flex-direction: column;
+    padding-top: var(--space-4);
+    padding-left: var(--space-2);
+    padding-right: var(--space-2);
   }
 
-  .c-MQgzr {
+  .c-bVBcpu {
     flex-shrink: 0;
     display: flex;
-    border-bottom: 1px solid var(--colors-primaryDark);
   }
 
-  .c-hUDFHn {
-    color: var(--colors-secondary);
+  .c-kUWTIa {
+    text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
     font-family: var(--fonts-body);
     padding: var(--space-4);
     -webkit-user-select: none;
     user-select: none;
-  }
-
-  .c-hUDFHn:hover {
-    color: var(--colors-primary);
-  }
-
-  .c-hUDFHn[data-disabled],
-  .c-hUDFHn[data-disabled]:hover {
-    color: var(--colors-tonal300);
-    cursor: default;
-  }
-
-  .c-hUDFHn[data-state="active"] {
-    color: var(--colors-primary);
-    font-weight: bold;
-    box-shadow: inset 0 -3px 0 0 currentColor;
+    transition: 0.5s;
   }
 
   .c-eGaVeY {
@@ -159,23 +186,76 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"] {
+    background: white;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="active"] {
+    color: var(--colors-primary);
+    font-weight: 600;
+    box-shadow: inset 0 -2px 0 0 currentColor;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-state="inactive"] {
+    color: var(--colors-tonal500);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:hover {
+    color: var(--colors-primary);
+    background: rgba(30,113,246,0.1);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:active {
+    color: var(--colors-primary);
+    background: rgba(30,113,246,0.2);
+    box-shadow: none;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"]:focus {
+    color: var(--colors-primary);
+    box-shadow: inset 0 0 0 2px currentColor;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled],
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tab"][data-disabled]:hover {
+    color: var(--colors-tonal200);
+    cursor: default;
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tabpanel"] {
+    background: white;
+    color: var(--colors-textForeground);
+    font-family: var(--fonts-body);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light div[role="tablist"] {
+    border-bottom: 1px solid var(--colors-primaryDark);
+  }
+
+  .c-fkcdpq-fGxsFx-appearance-light button[role="scrollbar"] {
+    background: white !important;
+    opacity: 0.8;
+  }
+}
+
+@media  {
   .c-dhzjXW-icmpvrW-css {
     position: relative;
   }
 
-  .c-MQgzr-ifwuxZe-css {
+  .c-bVBcpu-ifwuxZe-css {
     width: 100%;
     overflow-x: auto;
   }
 
-  .c-MQgzr-ifwuxZe-css::-webkit-scrollbar {
+  .c-bVBcpu-ifwuxZe-css::-webkit-scrollbar {
     display: none;
   }
 }
 
 <div>
   <div
-    class="c-fixGjY"
+    class="c-fkcdpq c-fkcdpq-fGxsFx-appearance-light"
     data-orientation="horizontal"
   >
     <div
@@ -183,7 +263,7 @@ exports[`Tabs component renders mobile view 1`] = `
     >
       <div
         aria-orientation="horizontal"
-        class="c-MQgzr c-MQgzr-ifwuxZe-css"
+        class="c-bVBcpu c-bVBcpu-ifwuxZe-css"
         data-orientation="horizontal"
         dir="ltr"
         role="tablist"
@@ -193,7 +273,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-hUDFHn"
+          class="c-kUWTIa"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -206,7 +286,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-hUDFHn"
+          class="c-kUWTIa"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -24,8 +24,9 @@ exports[`Tabs component renders 1`] = `
     transition: 0.3s;
   }
 
-  .c-eGaVeY {
+  .c-cWMaKf {
     flex-grow: 1;
+    font-family: var(--fonts-body);
   }
 }
 
@@ -39,40 +40,39 @@ exports[`Tabs component renders 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-ehnQBI-kLQAjc-theme-light {
+  .c-ehnQBI-hibzPz-theme-light {
     background: white;
   }
 
-  .c-ehnQBI-kLQAjc-theme-light[data-state="active"] {
+  .c-ehnQBI-hibzPz-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-ehnQBI-kLQAjc-theme-light[data-state="inactive"] {
+  .c-ehnQBI-hibzPz-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):hover {
+  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):active {
+  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-ehnQBI-kLQAjc-theme-light[data-disabled],
-  .c-ehnQBI-kLQAjc-theme-light[data-disabled]:hover {
+  .c-ehnQBI-hibzPz-theme-light[data-disabled],
+  .c-ehnQBI-hibzPz-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
-    cursor: default;
+    cursor: not-allowed;
   }
 
-  .c-eGaVeY-jWVCRL-theme-light {
+  .c-cWMaKf-fwFiEo-theme-light {
     color: var(--colors-textForeground);
-    font-family: var(--fonts-body);
   }
 }
 
@@ -93,7 +93,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
+        class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -106,7 +106,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
+        class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -119,7 +119,7 @@ exports[`Tabs component renders 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"
-      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="active"
       id="radix-id-0-1-content-tab1"
@@ -130,7 +130,7 @@ exports[`Tabs component renders 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab2"
-      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="inactive"
       hidden=""
@@ -166,8 +166,9 @@ exports[`Tabs component renders mobile view 1`] = `
     transition: 0.3s;
   }
 
-  .c-eGaVeY {
+  .c-cWMaKf {
     flex-grow: 1;
+    font-family: var(--fonts-body);
   }
 
   .c-dhzjXW {
@@ -185,40 +186,39 @@ exports[`Tabs component renders mobile view 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-ehnQBI-kLQAjc-theme-light {
+  .c-ehnQBI-hibzPz-theme-light {
     background: white;
   }
 
-  .c-ehnQBI-kLQAjc-theme-light[data-state="active"] {
+  .c-ehnQBI-hibzPz-theme-light[data-state="active"] {
     color: var(--colors-primary);
     text-shadow: 0px 0px 1px currentColor;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-ehnQBI-kLQAjc-theme-light[data-state="inactive"] {
+  .c-ehnQBI-hibzPz-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):hover {
+  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-ehnQBI-kLQAjc-theme-light:not([data-disabled]):active {
+  .c-ehnQBI-hibzPz-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-ehnQBI-kLQAjc-theme-light[data-disabled],
-  .c-ehnQBI-kLQAjc-theme-light[data-disabled]:hover {
+  .c-ehnQBI-hibzPz-theme-light[data-disabled],
+  .c-ehnQBI-hibzPz-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
-    cursor: default;
+    cursor: not-allowed;
   }
 
-  .c-eGaVeY-jWVCRL-theme-light {
+  .c-cWMaKf-fwFiEo-theme-light {
     color: var(--colors-textForeground);
-    font-family: var(--fonts-body);
   }
 }
 
@@ -257,7 +257,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
+          class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -270,7 +270,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-ehnQBI c-ehnQBI-kLQAjc-theme-light"
+          class="c-ehnQBI c-ehnQBI-hibzPz-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"
@@ -284,7 +284,7 @@ exports[`Tabs component renders mobile view 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"
-      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="active"
       id="radix-id-0-1-content-tab1"
@@ -295,7 +295,7 @@ exports[`Tabs component renders mobile view 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab2"
-      class="c-eGaVeY c-eGaVeY-jWVCRL-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="inactive"
       hidden=""

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -51,33 +51,34 @@ exports[`Tabs component renders 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-hMbQTI-hibzPz-theme-light {
+  .c-hMbQTI-eBYslT-theme-light {
     background: white;
   }
 
-  .c-hMbQTI-hibzPz-theme-light[data-state="active"] {
+  .c-hMbQTI-eBYslT-theme-light[data-state="active"] {
     color: var(--colors-primary);
-    text-shadow: 0px 0px 1px currentColor;
+    font-weight: 600;
+    letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-hMbQTI-hibzPz-theme-light[data-state="inactive"] {
+  .c-hMbQTI-eBYslT-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):hover {
+  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):active {
+  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-hMbQTI-hibzPz-theme-light[data-disabled],
-  .c-hMbQTI-hibzPz-theme-light[data-disabled]:hover {
+  .c-hMbQTI-eBYslT-theme-light[data-disabled],
+  .c-hMbQTI-eBYslT-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -104,7 +105,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
+        class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -117,7 +118,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
+        class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -236,33 +237,34 @@ exports[`Tabs component renders mobile view 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-hMbQTI-hibzPz-theme-light {
+  .c-hMbQTI-eBYslT-theme-light {
     background: white;
   }
 
-  .c-hMbQTI-hibzPz-theme-light[data-state="active"] {
+  .c-hMbQTI-eBYslT-theme-light[data-state="active"] {
     color: var(--colors-primary);
-    text-shadow: 0px 0px 1px currentColor;
+    font-weight: 600;
+    letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-hMbQTI-hibzPz-theme-light[data-state="inactive"] {
+  .c-hMbQTI-eBYslT-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):hover {
+  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-hMbQTI-hibzPz-theme-light:not([data-disabled]):active {
+  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-hMbQTI-hibzPz-theme-light[data-disabled],
-  .c-hMbQTI-hibzPz-theme-light[data-disabled]:hover {
+  .c-hMbQTI-eBYslT-theme-light[data-disabled],
+  .c-hMbQTI-eBYslT-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -271,12 +273,14 @@ exports[`Tabs component renders mobile view 1`] = `
     color: var(--colors-textForeground);
   }
 
-  .c-bMCfDd-fPEWfa-theme-light,
-  .c-bMCfDd-fPEWfa-theme-light:not(:disabled):hover,
-  .c-bMCfDd-fPEWfa-theme-light:not(:disabled):focus,
-  .c-bMCfDd-fPEWfa-theme-light:not(:disabled):active {
+  .c-bMCfDd-faCgme-theme-light {
     background: rgba(255,255,255,0.8) !important;
-    color: currentColor !important;
+  }
+
+  .c-bMCfDd-ejYaUA-visible-false {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .c-fDzwZw-kMhpXP-size-xl {
@@ -317,9 +321,8 @@ exports[`Tabs component renders mobile view 1`] = `
     position: relative;
   }
 
-  .c-bMCfDd-idoKZhy-css {
+  .c-bMCfDd-icezigA-css {
     left: 0;
-    display: none;
   }
 
   .c-dbrbZt-ihFPSGE-css {
@@ -327,9 +330,8 @@ exports[`Tabs component renders mobile view 1`] = `
     width: 20px;
   }
 
-  .c-bMCfDd-ihLdYJt-css {
+  .c-bMCfDd-iczsSGP-css {
     right: 0;
-    display: none;
   }
 }
 
@@ -343,7 +345,7 @@ exports[`Tabs component renders mobile view 1`] = `
     >
       <button
         aria-label="Scroll Left"
-        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-fPEWfa-theme-light c-bMCfDd-idoKZhy-css"
+        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-faCgme-theme-light c-bMCfDd-ejYaUA-visible-false c-bMCfDd-icezigA-css"
         type="button"
       >
         <svg
@@ -369,7 +371,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
+          class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -382,7 +384,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-hMbQTI c-hMbQTI-hibzPz-theme-light"
+          class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"
@@ -395,7 +397,7 @@ exports[`Tabs component renders mobile view 1`] = `
       </div>
       <button
         aria-label="Scroll right"
-        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-fPEWfa-theme-light c-bMCfDd-ihLdYJt-css"
+        class="c-fDzwZw c-fDzwZw-kMhpXP-size-xl c-fDzwZw-cmVfvW-cv c-bMCfDd c-bMCfDd-faCgme-theme-light c-bMCfDd-ejYaUA-visible-false c-bMCfDd-iczsSGP-css"
         type="button"
       >
         <svg

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -109,3 +109,254 @@ exports[`Tabs component renders 1`] = `
   </div>
 </div>
 `;
+
+exports[`Tabs component renders mobile view 1`] = `
+@media  {
+  .c-fixGjY {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .c-MQgzr {
+    flex-shrink: 0;
+    display: flex;
+    border-bottom: 1px solid var(--colors-primaryDark);
+  }
+
+  .c-hUDFHn {
+    color: var(--colors-secondary);
+    cursor: pointer;
+    flex-shrink: 0;
+    font-family: var(--fonts-body);
+    padding: var(--space-4);
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  .c-hUDFHn:hover {
+    color: var(--colors-primary);
+  }
+
+  .c-hUDFHn[data-disabled],
+  .c-hUDFHn[data-disabled]:hover {
+    color: var(--colors-tonal300);
+    cursor: default;
+  }
+
+  .c-hUDFHn[data-state="active"] {
+    color: var(--colors-primary);
+    font-weight: bold;
+    box-shadow: inset 0 -3px 0 0 currentColor;
+  }
+
+  .c-eGaVeY {
+    flex-grow: 1;
+  }
+
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-CYaOB {
+    position: absolute;
+    top: calc(50% - 20px);
+    background: white !important;
+    opacity: 0.8;
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+}
+
+@media  {
+  .c-fDzwZw-PrXKS-size-lg {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-fLGGKn-size-lg {
+    height: var(--sizes-3);
+    width: var(--sizes-3);
+    stroke-width: 2;
+  }
+}
+
+@media  {
+  .c-fDzwZw-cmVfvW-cv {
+    background: transparent;
+    color: var(--colors-primary);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):hover,
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-cmVfvW-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-dhzjXW-icmpvrW-css {
+    position: relative;
+  }
+
+  .c-CYaOB-icezigA-css {
+    left: 0;
+  }
+
+  .c-dbrbZt-ihFPSGE-css {
+    height: 20px;
+    width: 20px;
+  }
+
+  .c-MQgzr-ifTJoPk-css {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .c-MQgzr-ifTJoPk-css::-webkit-scrollbar {
+    display: none;
+  }
+
+  .c-MQgzr-ifTJoPk-css div:first-child {
+    padding-left: var(--space-6);
+  }
+
+  .c-MQgzr-ifTJoPk-css div:last-child {
+    padding-right: var(--space-6);
+  }
+
+  .c-CYaOB-iczsSGP-css {
+    right: 0;
+  }
+}
+
+<div>
+  <div
+    class="c-fixGjY"
+    data-orientation="horizontal"
+  >
+    <div
+      class="c-dhzjXW c-dhzjXW-icmpvrW-css"
+    >
+      <button
+        aria-label="scroll-left"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-lg c-fDzwZw-cmVfvW-cv c-CYaOB c-CYaOB-icezigA-css"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-fLGGKn-size-lg c-dbrbZt-ihFPSGE-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="14 18 8 12 14 6 14 6"
+          />
+        </svg>
+      </button>
+      <div
+        aria-orientation="horizontal"
+        class="c-MQgzr c-MQgzr-ifTJoPk-css"
+        data-orientation="horizontal"
+        dir="ltr"
+        role="tablist"
+        style="outline: none;"
+        tabindex="0"
+      >
+        <div
+          aria-controls="radix-id-0-1-content-tab1"
+          aria-selected="true"
+          class="c-hUDFHn"
+          data-orientation="horizontal"
+          data-radix-collection-item=""
+          data-state="active"
+          id="radix-id-0-1-trigger-tab1"
+          role="tab"
+          tabindex="-1"
+        >
+          Trigger 1 which is going to be long
+        </div>
+        <div
+          aria-controls="radix-id-0-1-content-tab2"
+          aria-selected="false"
+          class="c-hUDFHn"
+          data-orientation="horizontal"
+          data-radix-collection-item=""
+          data-state="inactive"
+          id="radix-id-0-1-trigger-tab2"
+          role="tab"
+          tabindex="-1"
+        >
+          Trigger 2 which is going to be even longer
+        </div>
+      </div>
+      <button
+        aria-label="scroll-right"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-lg c-fDzwZw-cmVfvW-cv c-CYaOB c-CYaOB-iczsSGP-css"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-fLGGKn-size-lg c-dbrbZt-ihFPSGE-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="10 6 16 12 10 18 10 18"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      aria-labelledby="radix-id-0-1-trigger-tab1"
+      class="c-eGaVeY"
+      data-orientation="horizontal"
+      data-state="active"
+      id="radix-id-0-1-content-tab1"
+      role="tabpanel"
+      tabindex="0"
+    >
+      Important content for tab 1
+    </div>
+    <div
+      aria-labelledby="radix-id-0-1-trigger-tab2"
+      class="c-eGaVeY"
+      data-orientation="horizontal"
+      data-state="inactive"
+      hidden=""
+      id="radix-id-0-1-content-tab2"
+      role="tabpanel"
+      tabindex="0"
+    />
+  </div>
+</div>
+`;

--- a/src/components/tabs/utils.ts
+++ b/src/components/tabs/utils.ts
@@ -1,16 +1,18 @@
-import React from 'react'
+import React, { JSXElementConstructor } from 'react'
 
 export const passPropsToChildren = (
   children,
   props: Record<string, any>,
-  allowedChildNodeTypes: any[] = []
+  allowedChildNodeTypes: JSXElementConstructor<any>[] = []
 ) => {
   return React.Children.map(children, (child) => {
     if (!React.isValidElement(child)) {
       return child
     }
 
-    if (allowedChildNodeTypes.includes(child?.type)) {
+    if (
+      allowedChildNodeTypes.includes(child?.type as JSXElementConstructor<any>)
+    ) {
       return React.cloneElement(child, { ...props })
     }
 

--- a/src/components/tabs/utils.ts
+++ b/src/components/tabs/utils.ts
@@ -3,9 +3,13 @@ import React from 'react'
 export const passPropsToChildren = (
   children,
   props: Record<string, any>,
-  allowedChildNodeTypes: React.FunctionComponent[] = []
+  allowedChildNodeTypes: any[] = []
 ) => {
   return React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return child
+    }
+
     if (allowedChildNodeTypes.includes(child?.type)) {
       return React.cloneElement(child, { ...props })
     }

--- a/src/components/tabs/utils.ts
+++ b/src/components/tabs/utils.ts
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export const passPropsToChildren = (
+  children,
+  props: Record<string, any>,
+  allowedChildNodeTypes: React.FunctionComponent[] = []
+) => {
+  return React.Children.map(children, (child) => {
+    if (allowedChildNodeTypes.includes(child?.type)) {
+      return React.cloneElement(child, { ...props })
+    }
+
+    return child
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12721,6 +12721,11 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
+throttle-debounce@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
+  integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
+
 through2@^2.0.0, through2@^2.0.2, through2@~2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"


### PR DESCRIPTION
## Tabs Mobile View

### Tasks Undertaken
1. Based on total width of tab container and screen size, show `<` & `>` buttons to allow easy scrolling of tabs.
2. Scroll amount is at 25% of tab container width
3. Conditionally show / hide scroll buttons
4. Bring the components up to new design - supporting two variations

```typescript
<Tabs appearance="light"></Tabs>
<Tabs appearance="dark"></Tabs>
```

### Demo

#### Desktop
https://user-images.githubusercontent.com/1936119/142402905-7f749c94-1704-4724-b0a5-5ae5db754703.mov

#### Mobile
https://user-images.githubusercontent.com/1936119/142402968-9b3edec9-949a-44e0-a218-59de1c583e55.mov


