### PR TITLE
feat: adding new table variants

### DIFF
--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -123,10 +123,10 @@ The `Table` component has 2 size variants that control the row height. The two a
 </Table>
 ```
 
-The `Table` component by default renders with a slight border radius. If you want to remove this, for example if you are rendering the `Table` inside another component that has border radius, you can remove this by setting `applyRadius="false"`.
+The `Table` component by default renders with a slight border radius. If you want to remove this, for example if you are rendering the `Table` inside another component that has border radius, you can remove this by setting `corners="square"`. The default is `corners="round"`.
 
 ```tsx
-<Table applyRadius="false">...</Table>
+<Table corners="square">...</Table>
 ```
 
 `Table.Header` accepts a theme prop, the current available options are `primary` and `primaryDark`. The default is `primaryDark`.

--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -122,3 +122,17 @@ The `Table` component has 2 size variants that control the row height. The two a
   </Table.Body>
 </Table>
 ```
+
+The `Table` component by default renders with a slight border radius. If you want to remove this, for example if you are rendering the `Table` inside another component that has border radius, you can remove this by setting `applyRadius="false"`.
+
+```tsx
+<Table applyRadius="false">...</Table>
+```
+
+`Table.Header` accepts a theme prop, the current available options are `primary` and `primaryDark`. The default is `primaryDark`.
+
+```tsx
+<Table>
+  <Table.Header theme="primary">...</Table.Header>
+</Table>
+```

--- a/src/components/table/Table.test.tsx
+++ b/src/components/table/Table.test.tsx
@@ -7,7 +7,7 @@ import { Table } from './Table'
 describe(`Table component`, () => {
   it('renders', async () => {
     const { container } = await render(
-      <Table css={{ height: '100px', width: '400px', color: '$primary500' }}>
+      <Table css={{ height: '100px', width: '400px' }}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Column A</Table.HeaderCell>
@@ -30,10 +30,7 @@ describe(`Table component`, () => {
 
   it('renders with size set to lg', async () => {
     const { container } = await render(
-      <Table
-        size="lg"
-        css={{ height: '100px', width: '400px', color: '$primary500' }}
-      >
+      <Table size="lg" css={{ height: '100px', width: '400px' }}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Column A</Table.HeaderCell>
@@ -54,12 +51,9 @@ describe(`Table component`, () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('renders with no radius', async () => {
+  it('renders with square corners', async () => {
     const { container } = await render(
-      <Table
-        applyRadius="false"
-        css={{ height: '100px', width: '400px', color: '$primary500' }}
-      >
+      <Table corners="square" css={{ height: '100px', width: '400px' }}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Column A</Table.HeaderCell>
@@ -82,7 +76,7 @@ describe(`Table component`, () => {
 
   it('renders with a themed header', async () => {
     const { container } = await render(
-      <Table css={{ height: '100px', width: '400px', color: '$primary500' }}>
+      <Table css={{ height: '100px', width: '400px' }}>
         <Table.Header theme="primary">
           <Table.Row>
             <Table.HeaderCell>Column A</Table.HeaderCell>

--- a/src/components/table/Table.test.tsx
+++ b/src/components/table/Table.test.tsx
@@ -54,6 +54,55 @@ describe(`Table component`, () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders with no radius', async () => {
+    const { container } = await render(
+      <Table
+        applyRadius="false"
+        css={{ height: '100px', width: '400px', color: '$primary500' }}
+      >
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Column A</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>This is text</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer>
+          <Table.Row>
+            <Table.Cell>Footer 1</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders with a themed header', async () => {
+    const { container } = await render(
+      <Table css={{ height: '100px', width: '400px', color: '$primary500' }}>
+        <Table.Header theme="primary">
+          <Table.Row>
+            <Table.HeaderCell>Column A</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>This is text</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer>
+          <Table.Row>
+            <Table.Cell>Footer 1</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
   it('has no programmatically detectable a11y issues', async () => {
     const { container } = render(
       <Table>

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -40,16 +40,17 @@ const StyledTable = styled('table', {
       }
     },
     corners: {
-      round: {},
-      square: {
-        [`${TableHeaderCell}, ${TableRow}`]: {
-          borderRadius: '0',
-          '&:last-child': {
-            'td:first-child': { borderBottomLeftRadius: '0' },
-            'td:last-child': { borderBottomRightRadius: '0' }
-          }
+      round: {
+        [`${TableHeaderCell}`]: {
+          '&:first-of-type': { borderTopLeftRadius: '$0' },
+          '&:last-of-type': { borderTopRightRadius: '$0' }
+        },
+        [`${TableRow}:last-child`]: {
+          [`${TableCell}:first-child`]: { borderBottomLeftRadius: '$0' },
+          [`${TableCell}:last-child`]: { borderBottomRightRadius: '$0' }
         }
-      }
+      },
+      square: {}
     }
   }
 })

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -38,6 +38,18 @@ const StyledTable = styled('table', {
           height: '$5'
         }
       }
+    },
+    applyRadius: {
+      true: {},
+      false: {
+        [`${TableHeaderCell}, ${TableRow}`]: {
+          borderRadius: '0',
+          '&:last-child': {
+            'td:first-child': { borderBottomLeftRadius: '0' },
+            'td:last-child': { borderBottomRightRadius: '0' }
+          }
+        }
+      }
     }
   }
 })
@@ -46,8 +58,11 @@ type TableProps = React.ComponentProps<typeof StyledTable>
 
 export const Table: React.FC<TableProps> & TableSubComponents = ({
   size = 'md',
+  applyRadius = 'true',
   ...rest
-}: TableProps) => <StyledTable size={size} {...rest} />
+}: TableProps) => (
+  <StyledTable size={size} applyRadius={applyRadius} {...rest} />
+)
 
 Table.Body = TableBody
 Table.Cell = TableCell

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -39,9 +39,9 @@ const StyledTable = styled('table', {
         }
       }
     },
-    applyRadius: {
-      true: {},
-      false: {
+    corners: {
+      round: {},
+      square: {
         [`${TableHeaderCell}, ${TableRow}`]: {
           borderRadius: '0',
           '&:last-child': {
@@ -58,11 +58,9 @@ type TableProps = React.ComponentProps<typeof StyledTable>
 
 export const Table: React.FC<TableProps> & TableSubComponents = ({
   size = 'md',
-  applyRadius = 'true',
+  corners = 'round',
   ...rest
-}: TableProps) => (
-  <StyledTable size={size} applyRadius={applyRadius} {...rest} />
-)
+}: TableProps) => <StyledTable size={size} corners={corners} {...rest} />
 
 Table.Body = TableBody
 Table.Cell = TableCell

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -1,5 +1,28 @@
 import { styled } from '~/stitches'
+import React from 'react'
 
-export const TableHeader = styled('thead', {})
+const StyledTableHeader = styled('thead', {
+  variants: {
+    theme: {
+      primary: {
+        '& th': {
+          bg: '$primary'
+        }
+      },
+      primaryDark: {
+        '& th': {
+          bg: '$primaryDark'
+        }
+      }
+    }
+  }
+})
+
+type TableHeaderProps = React.ComponentProps<typeof StyledTableHeader>
+
+export const TableHeader: React.FC<TableHeaderProps> = ({
+  theme = 'primaryDark',
+  ...rest
+}: TableHeaderProps) => <StyledTableHeader theme={theme} {...rest} />
 
 TableHeader.displayName = 'TableHeader'

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -1,16 +1,17 @@
 import { styled } from '~/stitches'
 import React from 'react'
+import { TableHeaderCell } from './TableHeaderCell'
 
 const StyledTableHeader = styled('thead', {
   variants: {
     theme: {
       primary: {
-        '& th': {
+        [`${TableHeaderCell}`]: {
           bg: '$primary'
         }
       },
       primaryDark: {
-        '& th': {
+        [`${TableHeaderCell}`]: {
           bg: '$primaryDark'
         }
       }

--- a/src/components/table/TableHeaderCell.tsx
+++ b/src/components/table/TableHeaderCell.tsx
@@ -7,13 +7,7 @@ export const TableHeaderCell = styled('th', {
   lineHeight: 1.5,
   p: '$2 $3',
   textAlign: 'left',
-  verticalAlign: 'middle',
-  '&:first-of-type': {
-    borderTopLeftRadius: '$0'
-  },
-  '&:last-of-type': {
-    borderTopRightRadius: '$0'
-  }
+  verticalAlign: 'middle'
 })
 
 TableHeaderCell.displayName = 'TableHeaderCell'

--- a/src/components/table/TableHeaderCell.tsx
+++ b/src/components/table/TableHeaderCell.tsx
@@ -1,7 +1,6 @@
 import { styled } from '~/stitches'
 
 export const TableHeaderCell = styled('th', {
-  bg: '$primaryDark',
   color: 'white',
   fontFamily: '$body',
   fontWeight: 600,

--- a/src/components/table/TableRow.tsx
+++ b/src/components/table/TableRow.tsx
@@ -1,10 +1,5 @@
 import { styled } from '~/stitches'
 
-export const TableRow = styled('tr', {
-  '&:last-child': {
-    'td:first-child': { borderBottomLeftRadius: '$0' },
-    'td:last-child': { borderBottomRightRadius: '$0' }
-  }
-})
+export const TableRow = styled('tr', {})
 
 TableRow.displayName = 'TableRow'

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -73,16 +73,15 @@ exports[`Table component renders 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-iliYStP-css {
+  .c-cwQMhQ-icnGIKd-css {
     height: 100px;
     width: 400px;
-    color: var(--colors-primary500);
   }
 }
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-iliYStP-css"
+    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
@@ -204,18 +203,18 @@ exports[`Table component renders with a themed header 1`] = `
     height: var(--sizes-5);
   }
 
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF,
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf {
+  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF,
+  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf {
     border-radius: 0;
   }
 
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:first-child,
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:first-child {
+  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:first-child,
+  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:first-child {
     border-bottom-left-radius: 0;
   }
 
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:last-child,
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:last-child {
+  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:last-child,
+  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:last-child {
     border-bottom-right-radius: 0;
   }
 
@@ -225,167 +224,18 @@ exports[`Table component renders with a themed header 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-iliYStP-css {
+  .c-cwQMhQ-icnGIKd-css {
     height: 100px;
     width: 400px;
-    color: var(--colors-primary500);
   }
 }
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-iliYStP-css"
+    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-jbaVbo-theme-primary"
-    >
-      <tr
-        class="c-gkKNzf"
-      >
-        <th
-          class="c-gNZPWF"
-        >
-          Column A
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c-PJLV"
-    >
-      <tr
-        class="c-gkKNzf"
-      >
-        <td
-          class="c-dOcJjJ"
-        >
-          This is text
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class="c-PJLV"
-    >
-      <tr
-        class="c-gkKNzf"
-      >
-        <td
-          class="c-dOcJjJ"
-        >
-          Footer 1
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-</div>
-`;
-
-exports[`Table component renders with no radius 1`] = `
-@media  {
-  .c-cwQMhQ {
-    border-collapse: separate;
-    border-spacing: 0;
-    font-family: var(--fonts-sans);
-    font-size: var(--fontSizes-sm);
-    width: 100%;
-  }
-
-  .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: var(--radii-0);
-  }
-
-  .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF {
-    color: white;
-    font-family: var(--fonts-body);
-    font-weight: 600;
-    line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
-    text-align: left;
-    vertical-align: middle;
-  }
-
-  .c-gNZPWF:first-of-type {
-    border-top-left-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF:last-of-type {
-    border-top-right-radius: var(--radii-0);
-  }
-
-  .c-dOcJjJ {
-    border-bottom: 1px solid var(--colors-tonal100);
-    box-sizing: border-box;
-    color: var(--colors-tonal400);
-    font-family: var(--fonts-body);
-    line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
-    text-align: left;
-    vertical-align: middle;
-  }
-
-  .c-dOcJjJ:first-child {
-    font-weight: bold;
-  }
-
-  tr:nth-child(odd) .c-dOcJjJ {
-    background: white;
-  }
-
-  tr:nth-child(even) .c-dOcJjJ {
-    background: var(--colors-tonal50);
-  }
-}
-
-@media  {
-  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
-  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
-    height: var(--sizes-4);
-  }
-
-  .c-PJLV-dmDtdc-theme-primaryDark th {
-    background: var(--colors-primaryDark);
-  }
-
-  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
-  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
-    height: var(--sizes-5);
-  }
-
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF,
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf {
-    border-radius: 0;
-  }
-
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:first-child,
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: 0;
-  }
-
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:last-child,
-  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: 0;
-  }
-}
-
-@media  {
-  .c-cwQMhQ-iliYStP-css {
-    height: 100px;
-    width: 400px;
-    color: var(--colors-primary500);
-  }
-}
-
-<div>
-  <table
-    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-dfUUxG-applyRadius-false c-cwQMhQ-iliYStP-css"
-  >
-    <thead
-      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
     >
       <tr
         class="c-gkKNzf"
@@ -506,16 +356,162 @@ exports[`Table component renders with size set to lg 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-iliYStP-css {
+  .c-cwQMhQ-icnGIKd-css {
     height: 100px;
     width: 400px;
-    color: var(--colors-primary500);
   }
 }
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-fUfzxR-size-lg c-cwQMhQ-iliYStP-css"
+    class="c-cwQMhQ c-cwQMhQ-fUfzxR-size-lg c-cwQMhQ-icnGIKd-css"
+  >
+    <thead
+      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <th
+          class="c-gNZPWF"
+        >
+          Column A
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c-PJLV"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <td
+          class="c-dOcJjJ"
+        >
+          This is text
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class="c-PJLV"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <td
+          class="c-dOcJjJ"
+        >
+          Footer 1
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;
+
+exports[`Table component renders with square corners 1`] = `
+@media  {
+  .c-cwQMhQ {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-family: var(--fonts-sans);
+    font-size: var(--fontSizes-sm);
+    width: 100%;
+  }
+
+  .c-gkKNzf:last-child td:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-gkKNzf:last-child td:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-gNZPWF {
+    color: white;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    line-height: 1.5;
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-gNZPWF:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-gNZPWF:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-dOcJjJ {
+    border-bottom: 1px solid var(--colors-tonal100);
+    box-sizing: border-box;
+    color: var(--colors-tonal400);
+    font-family: var(--fonts-body);
+    line-height: 1.5;
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-dOcJjJ:first-child {
+    font-weight: bold;
+  }
+
+  tr:nth-child(odd) .c-dOcJjJ {
+    background: white;
+  }
+
+  tr:nth-child(even) .c-dOcJjJ {
+    background: var(--colors-tonal50);
+  }
+}
+
+@media  {
+  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
+  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+    height: var(--sizes-4);
+  }
+
+  .c-PJLV-dmDtdc-theme-primaryDark th {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
+  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
+    height: var(--sizes-5);
+  }
+
+  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF,
+  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf {
+    border-radius: 0;
+  }
+
+  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:first-child,
+  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:first-child {
+    border-bottom-left-radius: 0;
+  }
+
+  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:last-child,
+  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:last-child {
+    border-bottom-right-radius: 0;
+  }
+}
+
+@media  {
+  .c-cwQMhQ-icnGIKd-css {
+    height: 100px;
+    width: 400px;
+  }
+}
+
+<div>
+  <table
+    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-dfUUxG-corners-square c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -10,15 +10,7 @@ exports[`Table component renders 1`] = `
     width: 100%;
   }
 
-  .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: var(--radii-0);
-  }
-
-  .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF {
+  .c-GSaiK {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
@@ -26,14 +18,6 @@ exports[`Table component renders 1`] = `
     padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
-  }
-
-  .c-gNZPWF:first-of-type {
-    border-top-left-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF:last-of-type {
-    border-top-right-radius: var(--radii-0);
   }
 
   .c-dOcJjJ {
@@ -61,13 +45,29 @@ exports[`Table component renders 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
-  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
+  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-PJLV-dmDtdc-theme-primaryDark th {
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
     background: var(--colors-primaryDark);
   }
 }
@@ -81,16 +81,16 @@ exports[`Table component renders 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-bgSNGZ-size-md c-cwQMhQ-gCFJjl-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
+      class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <th
-          class="c-gNZPWF"
+          class="c-GSaiK"
         >
           Column A
         </th>
@@ -100,7 +100,7 @@ exports[`Table component renders 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -113,7 +113,7 @@ exports[`Table component renders 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -136,15 +136,7 @@ exports[`Table component renders with a themed header 1`] = `
     width: 100%;
   }
 
-  .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: var(--radii-0);
-  }
-
-  .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF {
+  .c-GSaiK {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
@@ -152,14 +144,6 @@ exports[`Table component renders with a themed header 1`] = `
     padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
-  }
-
-  .c-gNZPWF:first-of-type {
-    border-top-left-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF:last-of-type {
-    border-top-right-radius: var(--radii-0);
   }
 
   .c-dOcJjJ {
@@ -187,38 +171,39 @@ exports[`Table component renders with a themed header 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
-  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
+  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-PJLV-dmDtdc-theme-primaryDark th {
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
     background: var(--colors-primaryDark);
   }
 
-  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
-  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
+  .c-cwQMhQ-lhkyUQ-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-lhkyUQ-size-lg .c-GSaiK,
+  .c-cwQMhQ-lhkyUQ-size-lg .c-hYjVQ {
     height: var(--sizes-5);
   }
 
-  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF,
-  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf {
-    border-radius: 0;
-  }
-
-  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:first-child,
-  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: 0;
-  }
-
-  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:last-child,
-  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: 0;
-  }
-
-  .c-PJLV-jbaVbo-theme-primary th {
+  .c-PJLV-gmYsCp-theme-primary .c-GSaiK {
     background: var(--colors-primary);
   }
 }
@@ -232,16 +217,16 @@ exports[`Table component renders with a themed header 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-bgSNGZ-size-md c-cwQMhQ-gCFJjl-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-jbaVbo-theme-primary"
+      class="c-PJLV c-PJLV-gmYsCp-theme-primary"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <th
-          class="c-gNZPWF"
+          class="c-GSaiK"
         >
           Column A
         </th>
@@ -251,7 +236,7 @@ exports[`Table component renders with a themed header 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -264,7 +249,7 @@ exports[`Table component renders with a themed header 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -287,15 +272,7 @@ exports[`Table component renders with size set to lg 1`] = `
     width: 100%;
   }
 
-  .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: var(--radii-0);
-  }
-
-  .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF {
+  .c-GSaiK {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
@@ -303,14 +280,6 @@ exports[`Table component renders with size set to lg 1`] = `
     padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
-  }
-
-  .c-gNZPWF:first-of-type {
-    border-top-left-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF:last-of-type {
-    border-top-right-radius: var(--radii-0);
   }
 
   .c-dOcJjJ {
@@ -338,19 +307,35 @@ exports[`Table component renders with size set to lg 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
-  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
+  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-PJLV-dmDtdc-theme-primaryDark th {
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
     background: var(--colors-primaryDark);
   }
 
-  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
-  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
+  .c-cwQMhQ-lhkyUQ-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-lhkyUQ-size-lg .c-GSaiK,
+  .c-cwQMhQ-lhkyUQ-size-lg .c-hYjVQ {
     height: var(--sizes-5);
   }
 }
@@ -364,16 +349,16 @@ exports[`Table component renders with size set to lg 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-fUfzxR-size-lg c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-lhkyUQ-size-lg c-cwQMhQ-gCFJjl-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
+      class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <th
-          class="c-gNZPWF"
+          class="c-GSaiK"
         >
           Column A
         </th>
@@ -383,7 +368,7 @@ exports[`Table component renders with size set to lg 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -396,7 +381,7 @@ exports[`Table component renders with size set to lg 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -419,15 +404,7 @@ exports[`Table component renders with square corners 1`] = `
     width: 100%;
   }
 
-  .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: var(--radii-0);
-  }
-
-  .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF {
+  .c-GSaiK {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
@@ -435,14 +412,6 @@ exports[`Table component renders with square corners 1`] = `
     padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
-  }
-
-  .c-gNZPWF:first-of-type {
-    border-top-left-radius: var(--radii-0);
-  }
-
-  .c-gNZPWF:last-of-type {
-    border-top-right-radius: var(--radii-0);
   }
 
   .c-dOcJjJ {
@@ -470,35 +439,36 @@ exports[`Table component renders with square corners 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
-  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
+  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-PJLV-dmDtdc-theme-primaryDark th {
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
     background: var(--colors-primaryDark);
   }
 
-  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
-  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
+  .c-cwQMhQ-lhkyUQ-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-lhkyUQ-size-lg .c-GSaiK,
+  .c-cwQMhQ-lhkyUQ-size-lg .c-hYjVQ {
     height: var(--sizes-5);
-  }
-
-  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF,
-  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf {
-    border-radius: 0;
-  }
-
-  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:first-child,
-  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:first-child {
-    border-bottom-left-radius: 0;
-  }
-
-  .c-cwQMhQ-dfUUxG-corners-square .c-gNZPWF:last-child td:last-child,
-  .c-cwQMhQ-dfUUxG-corners-square .c-gkKNzf:last-child td:last-child {
-    border-bottom-right-radius: 0;
   }
 }
 
@@ -511,16 +481,16 @@ exports[`Table component renders with square corners 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-dfUUxG-corners-square c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-bgSNGZ-size-md c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
+      class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <th
-          class="c-gNZPWF"
+          class="c-GSaiK"
         >
           Column A
         </th>
@@ -530,7 +500,7 @@ exports[`Table component renders with square corners 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"
@@ -543,7 +513,7 @@ exports[`Table component renders with square corners 1`] = `
       class="c-PJLV"
     >
       <tr
-        class="c-gkKNzf"
+        class="c-PJLV"
       >
         <td
           class="c-dOcJjJ"

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -18,8 +18,7 @@ exports[`Table component renders 1`] = `
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-ejZzIq {
-    background: var(--colors-primaryDark);
+  .c-gNZPWF {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
@@ -29,11 +28,11 @@ exports[`Table component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-ejZzIq:first-of-type {
+  .c-gNZPWF:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-ejZzIq:last-of-type {
+  .c-gNZPWF:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
@@ -62,10 +61,14 @@ exports[`Table component renders 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-jVAARh-size-md .c-dOcJjJ,
-  .c-cwQMhQ-jVAARh-size-md .c-ejZzIq,
-  .c-cwQMhQ-jVAARh-size-md .c-hYjVQ {
+  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
+  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
     height: var(--sizes-4);
+  }
+
+  .c-PJLV-dmDtdc-theme-primaryDark th {
+    background: var(--colors-primaryDark);
   }
 }
 
@@ -79,16 +82,316 @@ exports[`Table component renders 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-jVAARh-size-md c-cwQMhQ-iliYStP-css"
+    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-iliYStP-css"
   >
     <thead
-      class="c-PJLV"
+      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
     >
       <tr
         class="c-gkKNzf"
       >
         <th
-          class="c-ejZzIq"
+          class="c-gNZPWF"
+        >
+          Column A
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c-PJLV"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <td
+          class="c-dOcJjJ"
+        >
+          This is text
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class="c-PJLV"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <td
+          class="c-dOcJjJ"
+        >
+          Footer 1
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;
+
+exports[`Table component renders with a themed header 1`] = `
+@media  {
+  .c-cwQMhQ {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-family: var(--fonts-sans);
+    font-size: var(--fontSizes-sm);
+    width: 100%;
+  }
+
+  .c-gkKNzf:last-child td:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-gkKNzf:last-child td:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-gNZPWF {
+    color: white;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    line-height: 1.5;
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-gNZPWF:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-gNZPWF:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-dOcJjJ {
+    border-bottom: 1px solid var(--colors-tonal100);
+    box-sizing: border-box;
+    color: var(--colors-tonal400);
+    font-family: var(--fonts-body);
+    line-height: 1.5;
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-dOcJjJ:first-child {
+    font-weight: bold;
+  }
+
+  tr:nth-child(odd) .c-dOcJjJ {
+    background: white;
+  }
+
+  tr:nth-child(even) .c-dOcJjJ {
+    background: var(--colors-tonal50);
+  }
+}
+
+@media  {
+  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
+  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+    height: var(--sizes-4);
+  }
+
+  .c-PJLV-dmDtdc-theme-primaryDark th {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
+  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
+    height: var(--sizes-5);
+  }
+
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF,
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf {
+    border-radius: 0;
+  }
+
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:first-child,
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:first-child {
+    border-bottom-left-radius: 0;
+  }
+
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:last-child,
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:last-child {
+    border-bottom-right-radius: 0;
+  }
+
+  .c-PJLV-jbaVbo-theme-primary th {
+    background: var(--colors-primary);
+  }
+}
+
+@media  {
+  .c-cwQMhQ-iliYStP-css {
+    height: 100px;
+    width: 400px;
+    color: var(--colors-primary500);
+  }
+}
+
+<div>
+  <table
+    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-iliYStP-css"
+  >
+    <thead
+      class="c-PJLV c-PJLV-jbaVbo-theme-primary"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <th
+          class="c-gNZPWF"
+        >
+          Column A
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c-PJLV"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <td
+          class="c-dOcJjJ"
+        >
+          This is text
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class="c-PJLV"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <td
+          class="c-dOcJjJ"
+        >
+          Footer 1
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;
+
+exports[`Table component renders with no radius 1`] = `
+@media  {
+  .c-cwQMhQ {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-family: var(--fonts-sans);
+    font-size: var(--fontSizes-sm);
+    width: 100%;
+  }
+
+  .c-gkKNzf:last-child td:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-gkKNzf:last-child td:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-gNZPWF {
+    color: white;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    line-height: 1.5;
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-gNZPWF:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-gNZPWF:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-dOcJjJ {
+    border-bottom: 1px solid var(--colors-tonal100);
+    box-sizing: border-box;
+    color: var(--colors-tonal400);
+    font-family: var(--fonts-body);
+    line-height: 1.5;
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-dOcJjJ:first-child {
+    font-weight: bold;
+  }
+
+  tr:nth-child(odd) .c-dOcJjJ {
+    background: white;
+  }
+
+  tr:nth-child(even) .c-dOcJjJ {
+    background: var(--colors-tonal50);
+  }
+}
+
+@media  {
+  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
+  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
+    height: var(--sizes-4);
+  }
+
+  .c-PJLV-dmDtdc-theme-primaryDark th {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
+  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
+    height: var(--sizes-5);
+  }
+
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF,
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf {
+    border-radius: 0;
+  }
+
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:first-child,
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:first-child {
+    border-bottom-left-radius: 0;
+  }
+
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gNZPWF:last-child td:last-child,
+  .c-cwQMhQ-dfUUxG-applyRadius-false .c-gkKNzf:last-child td:last-child {
+    border-bottom-right-radius: 0;
+  }
+}
+
+@media  {
+  .c-cwQMhQ-iliYStP-css {
+    height: 100px;
+    width: 400px;
+    color: var(--colors-primary500);
+  }
+}
+
+<div>
+  <table
+    class="c-cwQMhQ c-cwQMhQ-bZDCAE-size-md c-cwQMhQ-dfUUxG-applyRadius-false c-cwQMhQ-iliYStP-css"
+  >
+    <thead
+      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
+    >
+      <tr
+        class="c-gkKNzf"
+      >
+        <th
+          class="c-gNZPWF"
         >
           Column A
         </th>
@@ -142,8 +445,7 @@ exports[`Table component renders with size set to lg 1`] = `
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-ejZzIq {
-    background: var(--colors-primaryDark);
+  .c-gNZPWF {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
@@ -153,11 +455,11 @@ exports[`Table component renders with size set to lg 1`] = `
     vertical-align: middle;
   }
 
-  .c-ejZzIq:first-of-type {
+  .c-gNZPWF:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-ejZzIq:last-of-type {
+  .c-gNZPWF:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
@@ -186,15 +488,19 @@ exports[`Table component renders with size set to lg 1`] = `
 }
 
 @media  {
-  .c-cwQMhQ-jVAARh-size-md .c-dOcJjJ,
-  .c-cwQMhQ-jVAARh-size-md .c-ejZzIq,
-  .c-cwQMhQ-jVAARh-size-md .c-hYjVQ {
+  .c-cwQMhQ-bZDCAE-size-md .c-dOcJjJ,
+  .c-cwQMhQ-bZDCAE-size-md .c-gNZPWF,
+  .c-cwQMhQ-bZDCAE-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-cwQMhQ-gJEyOc-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-gJEyOc-size-lg .c-ejZzIq,
-  .c-cwQMhQ-gJEyOc-size-lg .c-hYjVQ {
+  .c-PJLV-dmDtdc-theme-primaryDark th {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-cwQMhQ-fUfzxR-size-lg .c-dOcJjJ,
+  .c-cwQMhQ-fUfzxR-size-lg .c-gNZPWF,
+  .c-cwQMhQ-fUfzxR-size-lg .c-hYjVQ {
     height: var(--sizes-5);
   }
 }
@@ -209,16 +515,16 @@ exports[`Table component renders with size set to lg 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gJEyOc-size-lg c-cwQMhQ-iliYStP-css"
+    class="c-cwQMhQ c-cwQMhQ-fUfzxR-size-lg c-cwQMhQ-iliYStP-css"
   >
     <thead
-      class="c-PJLV"
+      class="c-PJLV c-PJLV-dmDtdc-theme-primaryDark"
     >
       <tr
         class="c-gkKNzf"
       >
         <th
-          class="c-ejZzIq"
+          class="c-gNZPWF"
         >
           Column A
         </th>


### PR DESCRIPTION
Added a few options to the table as they were needed for use with Accordions, and will likely be useful in the future elsewhere.

- `<Table applyRadius="false">` stops borderRadius being applied, useful if your container has a radius and multiple radiuses look odd. Default is `true`.
- `<Table.Header theme="primary">` changes the colour of the header rows. Options are `primary` and `primaryDark`. Default is `primaryDark`.

![image](https://user-images.githubusercontent.com/66493855/142883482-3172197c-6e30-4357-a125-3360814a913b.png)