### PR TITLE
feat: adding optional uppercase to tabs

### DIFF
--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -5,7 +5,6 @@ import { opacify } from 'polished'
 import { styled, theme } from '~/stitches'
 
 const StyledTabTrigger = styled(Trigger, {
-  textTransform: 'uppercase',
   cursor: 'pointer',
   flexShrink: 0,
   fontFamily: '$body',

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -72,7 +72,7 @@ A `Tabs.Trigger` component can take a `disabled` prop, which would make it unsel
 
 ## Styling the `Tabs.TriggerList`
 
-The trigger list accepts an appearance property to apply uppercase to all tabs. Simply pass `appearance='uppercase'`. The default value is `appearance='default'`.
+The trigger list accepts an appearance property to apply uppercase to all tabs. Simply pass `appearance='uppercase'`.
 
 ```tsx preview
 <Tabs>

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -72,11 +72,11 @@ A `Tabs.Trigger` component can take a `disabled` prop, which would make it unsel
 
 ## Styling the `Tabs.TriggerList`
 
-The trigger list accepts a property to apply uppercase to all tabs. Simply pass `uppercase`. Omiting this property will result in text rendered as it is typed.
+The trigger list accepts an appearance property to apply uppercase to all tabs. Simply pass `appearance='uppercase'`. The default value is `appearance='default'`.
 
 ```tsx preview
 <Tabs>
-  <Tabs.TriggerList uppercase>
+  <Tabs.TriggerList appearance="uppercase">
     <Tabs.Trigger value="tab1">Tab 1</Tabs.Trigger>
     <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
   </Tabs.TriggerList>

--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -70,6 +70,21 @@ A `Tabs.Trigger` component can take a `disabled` prop, which would make it unsel
 </Tabs>
 ```
 
+## Styling the `Tabs.TriggerList`
+
+The trigger list accepts a property to apply uppercase to all tabs. Simply pass `uppercase`. Omiting this property will result in text rendered as it is typed.
+
+```tsx preview
+<Tabs>
+  <Tabs.TriggerList uppercase>
+    <Tabs.Trigger value="tab1">Tab 1</Tabs.Trigger>
+    <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
+  </Tabs.TriggerList>
+  <Tabs.Content value="tab1">Content for tab 1</Tabs.Content>
+  <Tabs.Content value="tab2">Content for the second tab.</Tabs.Content>
+</Tabs>
+```
+
 ## Styling the `Tabs.Trigger`
 
 In order to style the different states of a trigger, the following CSS selectors need to be used when passed to the `css` prop:

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -65,8 +65,7 @@ const StyledTriggerList = styled(List, {
     appearance: {
       uppercase: {
         textTransform: 'uppercase'
-      },
-      default: {}
+      }
     }
   }
 })
@@ -74,7 +73,7 @@ const StyledTriggerList = styled(List, {
 export const TriggerListWrapper: React.FC<ListProps> = ({
   children,
   theme,
-  appearance = 'default',
+  appearance,
   enableTabScrolling,
   ...rest
 }) => {

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -62,11 +62,11 @@ const StyledTriggerList = styled(List, {
         borderBottom: '1px solid $tonal200'
       }
     },
-    uppercase: {
-      true: {
+    appearance: {
+      uppercase: {
         textTransform: 'uppercase'
       },
-      false: {}
+      default: {}
     }
   }
 })
@@ -74,7 +74,7 @@ const StyledTriggerList = styled(List, {
 export const TriggerListWrapper: React.FC<ListProps> = ({
   children,
   theme,
-  uppercase = false,
+  appearance = 'default',
   enableTabScrolling,
   ...rest
 }) => {
@@ -165,7 +165,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         <StyledTriggerList
           {...rest}
           ref={triggerListRef}
-          uppercase={uppercase}
+          appearance={appearance}
           theme={theme}
         >
           {passPropsToChildren(children, { theme }, [TabTrigger])}
@@ -188,7 +188,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
     <StyledTriggerList
       theme={theme}
       {...rest}
-      uppercase={uppercase}
+      appearance={appearance}
       ref={triggerListRef}
     >
       {passPropsToChildren(children, { theme }, [TabTrigger])}

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -61,6 +61,12 @@ const StyledTriggerList = styled(List, {
         bg: '$primaryDark',
         borderBottom: '1px solid $tonal200'
       }
+    },
+    uppercase: {
+      true: {
+        textTransform: 'uppercase'
+      },
+      false: {}
     }
   }
 })
@@ -68,6 +74,7 @@ const StyledTriggerList = styled(List, {
 export const TriggerListWrapper: React.FC<ListProps> = ({
   children,
   theme,
+  uppercase = false,
   enableTabScrolling,
   ...rest
 }) => {
@@ -155,7 +162,12 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
         >
           <Icon is={ChevronLeft} size="lg" />
         </StyledChevronIcon>
-        <StyledTriggerList {...rest} ref={triggerListRef} theme={theme}>
+        <StyledTriggerList
+          {...rest}
+          ref={triggerListRef}
+          uppercase={uppercase}
+          theme={theme}
+        >
           {passPropsToChildren(children, { theme }, [TabTrigger])}
         </StyledTriggerList>
         <StyledChevronIcon
@@ -173,7 +185,12 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
   }
 
   return (
-    <StyledTriggerList theme={theme} {...rest} ref={triggerListRef}>
+    <StyledTriggerList
+      theme={theme}
+      {...rest}
+      uppercase={uppercase}
+      ref={triggerListRef}
+    >
       {passPropsToChildren(children, { theme }, [TabTrigger])}
     </StyledTriggerList>
   )

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -22,8 +22,7 @@ exports[`Tabs component renders 1`] = `
     scrollbar-width: none;
   }
 
-  .c-hMbQTI {
-    text-transform: uppercase;
+  .c-hOCLBl {
     cursor: pointer;
     flex-shrink: 0;
     font-family: var(--fonts-body);
@@ -49,34 +48,34 @@ exports[`Tabs component renders 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-hMbQTI-eBYslT-theme-light {
+  .c-hOCLBl-eBYslT-theme-light {
     background: white;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-state="active"] {
+  .c-hOCLBl-eBYslT-theme-light[data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-state="inactive"] {
+  .c-hOCLBl-eBYslT-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):hover {
+  .c-hOCLBl-eBYslT-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):active {
+  .c-hOCLBl-eBYslT-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-disabled],
-  .c-hMbQTI-eBYslT-theme-light[data-disabled]:hover {
+  .c-hOCLBl-eBYslT-theme-light[data-disabled],
+  .c-hOCLBl-eBYslT-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -104,7 +103,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+        class="c-hOCLBl c-hOCLBl-eBYslT-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -117,7 +116,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+        class="c-hOCLBl c-hOCLBl-eBYslT-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -175,8 +174,7 @@ exports[`Tabs component renders mobile view 1`] = `
     scrollbar-width: none;
   }
 
-  .c-hMbQTI {
-    text-transform: uppercase;
+  .c-hOCLBl {
     cursor: pointer;
     flex-shrink: 0;
     font-family: var(--fonts-body);
@@ -235,34 +233,34 @@ exports[`Tabs component renders mobile view 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-hMbQTI-eBYslT-theme-light {
+  .c-hOCLBl-eBYslT-theme-light {
     background: white;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-state="active"] {
+  .c-hOCLBl-eBYslT-theme-light[data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-state="inactive"] {
+  .c-hOCLBl-eBYslT-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):hover {
+  .c-hOCLBl-eBYslT-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):active {
+  .c-hOCLBl-eBYslT-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-disabled],
-  .c-hMbQTI-eBYslT-theme-light[data-disabled]:hover {
+  .c-hOCLBl-eBYslT-theme-light[data-disabled],
+  .c-hOCLBl-eBYslT-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -370,7 +368,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+          class="c-hOCLBl c-hOCLBl-eBYslT-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -383,7 +381,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+          class="c-hOCLBl c-hOCLBl-eBYslT-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"


### PR DESCRIPTION
Tab triggers were recently made uppercase by default, but design have said that this should be optional as we do not want all tabs to be uppercase. Simple change to allow an uppercase prop.

`<Tabs.TriggerList uppercase>...</Tabs.TriggerList>`

Uppercase:
![image](https://user-images.githubusercontent.com/66493855/143898970-092d01f6-83ab-4a66-8048-fd40bb7190b6.png)
Property not set:
![image](https://user-images.githubusercontent.com/66493855/143899061-35734f8f-d8d6-4d26-a902-6688d847e7fb.png)
