### PR TITLE
feat: no light bg for tabs

### DIFF
--- a/src/components/tabs/TabTrigger.tsx
+++ b/src/components/tabs/TabTrigger.tsx
@@ -16,7 +16,6 @@ const StyledTabTrigger = styled(Trigger, {
   variants: {
     theme: {
       light: {
-        bg: 'white',
         '&[data-state="active"]': {
           color: '$primary',
           fontWeight: 600,

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -30,7 +30,6 @@ const StyledTabContent = styled(Content, {
   variants: {
     theme: {
       light: {
-        bg: 'white',
         color: '$textForeground'
       },
       dark: {

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -49,40 +49,35 @@ exports[`Tabs component renders 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-hMbQTI-eBYslT-theme-light {
-    background: white;
-  }
-
-  .c-hMbQTI-eBYslT-theme-light[data-state="active"] {
+  .c-hMbQTI-hPUmPP-theme-light[data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-state="inactive"] {
+  .c-hMbQTI-hPUmPP-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):hover {
+  .c-hMbQTI-hPUmPP-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):active {
+  .c-hMbQTI-hPUmPP-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-disabled],
-  .c-hMbQTI-eBYslT-theme-light[data-disabled]:hover {
+  .c-hMbQTI-hPUmPP-theme-light[data-disabled],
+  .c-hMbQTI-hPUmPP-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
 
-  .c-cWMaKf-bPagfo-theme-light {
-    background: white;
+  .c-cWMaKf-fwFiEo-theme-light {
     color: var(--colors-textForeground);
   }
 }
@@ -104,7 +99,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab1"
         aria-selected="true"
-        class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+        class="c-hMbQTI c-hMbQTI-hPUmPP-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -117,7 +112,7 @@ exports[`Tabs component renders 1`] = `
       <div
         aria-controls="radix-id-0-1-content-tab2"
         aria-selected="false"
-        class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+        class="c-hMbQTI c-hMbQTI-hPUmPP-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -130,7 +125,7 @@ exports[`Tabs component renders 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"
-      class="c-cWMaKf c-cWMaKf-bPagfo-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="active"
       id="radix-id-0-1-content-tab1"
@@ -141,7 +136,7 @@ exports[`Tabs component renders 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab2"
-      class="c-cWMaKf c-cWMaKf-bPagfo-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="inactive"
       hidden=""
@@ -235,40 +230,35 @@ exports[`Tabs component renders mobile view 1`] = `
     border-bottom: 1px solid var(--colors-tonal300);
   }
 
-  .c-hMbQTI-eBYslT-theme-light {
-    background: white;
-  }
-
-  .c-hMbQTI-eBYslT-theme-light[data-state="active"] {
+  .c-hMbQTI-hPUmPP-theme-light[data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-state="inactive"] {
+  .c-hMbQTI-hPUmPP-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):hover {
+  .c-hMbQTI-hPUmPP-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.1);
   }
 
-  .c-hMbQTI-eBYslT-theme-light:not([data-disabled]):active {
+  .c-hMbQTI-hPUmPP-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
     background: rgba(30,113,246,0.2);
     box-shadow: none;
   }
 
-  .c-hMbQTI-eBYslT-theme-light[data-disabled],
-  .c-hMbQTI-eBYslT-theme-light[data-disabled]:hover {
+  .c-hMbQTI-hPUmPP-theme-light[data-disabled],
+  .c-hMbQTI-hPUmPP-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
 
-  .c-cWMaKf-bPagfo-theme-light {
-    background: white;
+  .c-cWMaKf-fwFiEo-theme-light {
     color: var(--colors-textForeground);
   }
 
@@ -370,7 +360,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab1"
           aria-selected="true"
-          class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+          class="c-hMbQTI c-hMbQTI-hPUmPP-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -383,7 +373,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <div
           aria-controls="radix-id-0-1-content-tab2"
           aria-selected="false"
-          class="c-hMbQTI c-hMbQTI-eBYslT-theme-light"
+          class="c-hMbQTI c-hMbQTI-hPUmPP-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"
@@ -413,7 +403,7 @@ exports[`Tabs component renders mobile view 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab1"
-      class="c-cWMaKf c-cWMaKf-bPagfo-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="active"
       id="radix-id-0-1-content-tab1"
@@ -424,7 +414,7 @@ exports[`Tabs component renders mobile view 1`] = `
     </div>
     <div
       aria-labelledby="radix-id-0-1-trigger-tab2"
-      class="c-cWMaKf c-cWMaKf-bPagfo-theme-light"
+      class="c-cWMaKf c-cWMaKf-fwFiEo-theme-light"
       data-orientation="horizontal"
       data-state="inactive"
       hidden=""


### PR DESCRIPTION
New styling on the Tabs component assumes a white background for its light theme. I do not believe this should be assumed by the component, and removing the background makes this work with other light colours well, such as `$primaryLight` which we use a lot as a background. Hover background is still applied fine, so there's no real downside, it simply passes the responsibility of background colour to wherever is more appropriate.

with changes:
![image](https://user-images.githubusercontent.com/66493855/144309554-865e4997-f4cb-4d21-b17b-38d8442f1ba6.png)

without (thing that prompted me this was an issue):
![image](https://user-images.githubusercontent.com/66493855/144309656-b4f4d3e3-ae3c-4ccd-bc6f-1414e96df9d3.png)