### PR TITLE
feat: slider value label

### DIFF
--- a/src/components/slider-field/SliderField.mdx
+++ b/src/components/slider-field/SliderField.mdx
@@ -5,7 +5,7 @@ description: Combines a Slider with a label and form integration.
 category: Form fields
 ---
 
-`SliderField` renders a `Slider` with a label, and easy implementation with `Form`.
+`SliderField` renders a `Slider` with a label, and easy implementation with `Form`. It also renders a `Slider.Value` label underneath the slider.
 
 In it's most simple form, a slider allows one value to be set between two given values (default 0 and 100).
 
@@ -14,5 +14,20 @@ Please note: the `value` or `defaultValue` passed in should always be an array.
 ```tsx preview
 <Form>
   <SliderField name="slider" label="Select a value" defaultValue={[50]} />
+</Form>
+```
+
+## Value Labels
+
+The `Slider.Value` output label is displayed by default with the `SliderField`. Should you wish to remove this, you can pass `showValue={false}`.
+
+```tsx preview
+<Form>
+  <SliderField
+    name="slider"
+    label="Select a value"
+    defaultValue={[50]}
+    showValue={false}
+  />
 </Form>
 ```

--- a/src/components/slider-field/SliderField.mdx
+++ b/src/components/slider-field/SliderField.mdx
@@ -5,7 +5,7 @@ description: Combines a Slider with a label and form integration.
 category: Form fields
 ---
 
-`SliderField` renders a `Slider` with a label, and easy implementation with `Form`. It also renders a `Slider.Value` label underneath the slider.
+`SliderField` renders a `Slider` with a label, and easy implementation with `Form`. It also renders a `Slider.Value` label underneath the slider, and a `Slider.Steps` component should steps be passed in.
 
 In it's most simple form, a slider allows one value to be set between two given values (default 0 and 100).
 
@@ -17,17 +17,19 @@ Please note: the `value` or `defaultValue` passed in should always be an array.
 </Form>
 ```
 
-## Value Labels
-
-The `Slider.Value` output label is displayed by default with the `SliderField`. Should you wish to remove this, you can pass `showValue={false}`.
+With optional `Slider.Steps`:
 
 ```tsx preview
 <Form>
   <SliderField
     name="slider"
-    label="Select a value"
+    label="Select a value (now with steps)"
     defaultValue={[50]}
-    showValue={false}
+    steps={[
+      { value: 0, label: 'min' },
+      { value: 50, label: 'mid' },
+      { value: 100, label: 'max' }
+    ]}
   />
 </Form>
 ```

--- a/src/components/slider-field/SliderField.test.tsx
+++ b/src/components/slider-field/SliderField.test.tsx
@@ -1,21 +1,37 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import * as React from 'react'
 import { axe } from 'jest-axe'
 
 import { SliderField } from '.'
 import { Form } from '../'
 
-const ExampleSliderField = () => (
-  <Form onSubmit={() => null}>
-    <SliderField name="sliderTest" label="Slider Test" defaultValue={[50]} />
-  </Form>
-)
+const props = {
+  name: 'sliderTest',
+  label: 'Slider Test',
+  defaultValue: [50]
+}
 
 describe('SliderField component', () => {
   it('renders', async () => {
-    const { container } = render(<ExampleSliderField />)
+    const { container } = render(
+      <Form onSubmit={jest.fn()}>
+        <SliderField {...props} />
+      </Form>
+    )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders without a value label', async () => {
+    render(
+      <Form onSubmit={jest.fn()}>
+        <SliderField {...props} showValue={false} />
+      </Form>
+    )
+
+    expect(
+      await screen.queryByText('Current value is 50')
+    ).not.toBeInTheDocument()
   })
 
   //TODO: figure out how to pass aria-label properly so that there are no a11y issues
@@ -23,7 +39,11 @@ describe('SliderField component', () => {
   //thumb, which would require a lot of drilling, and doesn't seem the right solution.
   //In the future we hope to find a better solution.
   it.skip('has no programmatically detectable a11y issues', async () => {
-    const { container } = render(<ExampleSliderField />)
+    const { container } = render(
+      <Form onSubmit={jest.fn()}>
+        <SliderField {...props} />
+      </Form>
+    )
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/src/components/slider-field/SliderField.test.tsx
+++ b/src/components/slider-field/SliderField.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import * as React from 'react'
 import { axe } from 'jest-axe'
 
@@ -20,18 +20,6 @@ describe('SliderField component', () => {
     )
 
     expect(container).toMatchSnapshot()
-  })
-
-  it('renders without a value label', async () => {
-    render(
-      <Form onSubmit={jest.fn()}>
-        <SliderField {...props} showValue={false} />
-      </Form>
-    )
-
-    expect(
-      await screen.queryByText('Current value is 50')
-    ).not.toBeInTheDocument()
   })
 
   //TODO: figure out how to pass aria-label properly so that there are no a11y issues

--- a/src/components/slider-field/SliderField.tsx
+++ b/src/components/slider-field/SliderField.tsx
@@ -22,8 +22,6 @@ export const SliderField: React.FC<SliderFieldProps> = ({
   name,
   defaultValue,
   outputLabel,
-  emptyData,
-  item,
   min = 0,
   max = 100,
   steps = [],
@@ -50,8 +48,6 @@ export const SliderField: React.FC<SliderFieldProps> = ({
             <Slider.Value
               value={value || defaultValue}
               outputLabel={outputLabel}
-              emptyData={emptyData}
-              item={item}
             />
           </Slider>
         )}

--- a/src/components/slider-field/SliderField.tsx
+++ b/src/components/slider-field/SliderField.tsx
@@ -3,20 +3,27 @@ import { Controller, useFormContext } from 'react-hook-form'
 
 import { FieldWrapper } from '~/components/field-wrapper'
 import { Slider, SliderProps } from '~/components/slider'
+import { SliderValueType } from '../slider/SliderValue'
 import type { CSS } from '~/stitches'
 
-type SliderFieldProps = SliderProps & {
-  css?: CSS
-  label: string
-  name: string
-  defaultValue: number[]
-}
+type SliderFieldProps = SliderProps &
+  SliderValueType & {
+    css?: CSS
+    label: string
+    name: string
+    defaultValue: number[]
+    showValue?: boolean
+  }
 
 export const SliderField: React.FC<SliderFieldProps> = ({
   css,
   label,
   name,
   defaultValue,
+  outputLabel,
+  emptyData,
+  item,
+  showValue = true,
   ...remainingProps
 }) => {
   const { control } = useFormContext()
@@ -28,13 +35,23 @@ export const SliderField: React.FC<SliderFieldProps> = ({
         name={name}
         defaultValue={defaultValue}
         render={({ onChange, value }) => (
-          <Slider
-            name={name}
-            defaultValue={defaultValue}
-            onValueChange={onChange}
-            value={value}
-            {...remainingProps}
-          />
+          <>
+            <Slider
+              name={name}
+              defaultValue={defaultValue}
+              onValueChange={onChange}
+              value={value}
+              {...remainingProps}
+            />
+            {showValue && (
+              <Slider.Value
+                value={value || defaultValue}
+                outputLabel={outputLabel}
+                emptyData={emptyData}
+                item={item}
+              />
+            )}
+          </>
         )}
       />
     </FieldWrapper>

--- a/src/components/slider-field/SliderField.tsx
+++ b/src/components/slider-field/SliderField.tsx
@@ -3,16 +3,17 @@ import { Controller, useFormContext } from 'react-hook-form'
 
 import { FieldWrapper } from '~/components/field-wrapper'
 import { Slider, SliderProps } from '~/components/slider'
+import { SliderStepsType } from '~/components/slider/SliderSteps'
 import { SliderValueType } from '../slider/SliderValue'
 import type { CSS } from '~/stitches'
 
 type SliderFieldProps = SliderProps &
+  SliderStepsType &
   SliderValueType & {
     css?: CSS
     label: string
     name: string
     defaultValue: number[]
-    showValue?: boolean
   }
 
 export const SliderField: React.FC<SliderFieldProps> = ({
@@ -23,7 +24,9 @@ export const SliderField: React.FC<SliderFieldProps> = ({
   outputLabel,
   emptyData,
   item,
-  showValue = true,
+  min = 0,
+  max = 100,
+  steps = [],
   ...remainingProps
 }) => {
   const { control } = useFormContext()
@@ -35,23 +38,22 @@ export const SliderField: React.FC<SliderFieldProps> = ({
         name={name}
         defaultValue={defaultValue}
         render={({ onChange, value }) => (
-          <>
-            <Slider
-              name={name}
-              defaultValue={defaultValue}
-              onValueChange={onChange}
-              value={value}
-              {...remainingProps}
+          <Slider
+            name={name}
+            defaultValue={defaultValue}
+            onValueChange={onChange}
+            value={value}
+            {...remainingProps}
+          >
+            <Slider.Steps min={min} max={max} steps={steps} />
+
+            <Slider.Value
+              value={value || defaultValue}
+              outputLabel={outputLabel}
+              emptyData={emptyData}
+              item={item}
             />
-            {showValue && (
-              <Slider.Value
-                value={value || defaultValue}
-                outputLabel={outputLabel}
-                emptyData={emptyData}
-                item={item}
-              />
-            )}
-          </>
+          </Slider>
         )}
       />
     </FieldWrapper>

--- a/src/components/slider-field/__snapshots__/SliderField.test.tsx.snap
+++ b/src/components/slider-field/__snapshots__/SliderField.test.tsx.snap
@@ -83,6 +83,13 @@ exports[`SliderField component renders 1`] = `
     background: var(--colors-tonal200);
     cursor: not-allowed;
   }
+
+  .c-dbleUi {
+    color: var(--colors-tonal600);
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
 }
 
 @media  {
@@ -111,6 +118,23 @@ exports[`SliderField component renders 1`] = `
   .c-eqsMSy-dOexvR-theme-tonal .c-nJgcq {
     background: var(--colors-tonal200);
   }
+
+  .c-dbleUi-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-dbleUi-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-dbleUi-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
 }
 
 @media  {
@@ -118,6 +142,12 @@ exports[`SliderField component renders 1`] = `
     justify-content: space-between;
     align-items: center;
     margin-bottom: var(--space-3);
+  }
+
+  .c-dbleUi-iQwDky-css {
+    margin-top: var(--space-4);
+    color: var(--colors-tonal300);
+    width: 100%;
   }
 }
 
@@ -177,6 +207,11 @@ exports[`SliderField component renders 1`] = `
         style="display: none;"
         value="50"
       />
+      <p
+        class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-iQwDky-css"
+      >
+        Current value is 50
+      </p>
     </div>
   </form>
 </div>

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -72,7 +72,7 @@ NOTE: this will only work if there is only one value selected. In order to not o
 
 By default this simply outputs the value, however this can be customised in a number of ways. `outputLabel` can be passed, which is a string that must contain the `$VALUE`. This will be replaced with the value when it renders. A string is used so that the value can be placed wherever it needs to be in the output sentence, such as in the example below.
 
-The `outputLabel` also will turn the string `$S` into conditional plurals, i.e. 's' will be output if the value is greater than 1. This is also shown in the example review.
+You can also put the string `$ITEM` in `outputLabel`, which will be replaced with either a single or plural depending on the current value. This relies on the prop `item` being passed, which should be an object with two keys, `single` and `plural`. These strings allow the handling of non standard plurals. This is shown in the example below.
 
 Another prop, `emptyData`, accepts a `label` and `value` object, and tells the output at what value the label should be replaced. This typically would be an empty state, such as in the example below.
 
@@ -80,8 +80,9 @@ Another prop, `emptyData`, accepts a `label` and `value` object, and tells the o
 <Slider
   defaultValue={[50]}
   showValue
-  outputLabel="You have selected $VALUE apple$S"
-  emptyData={{ label: 'No apples selected', value: 0 }}
+  outputLabel="You have selected $VALUE $ITEM"
+  item={{ single: 'goose', plural: 'geese' }}
+  emptyData={{ label: 'No geese selected', value: 0 }}
 />
 ```
 

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -7,7 +7,7 @@ category: Form primitives
 
 The `Slider` is a simple component that renders a form slider.
 
-The `Slider` component should be rendered with a label for accesibility reasons. Rather than using the `Slider` component directly, it is best to use the `SliderField` component, which provides a label and easily integrates with the `Form` component. It also adds the `Slider.Value` by default (with options to remove) in order to create a unified experience without bloating the individual component.
+The `Slider` component should be rendered with a label for accesibility reasons. Rather than using the `Slider` component directly, it is best to use the `SliderField` component, which provides a field label, a value label, and easily integrates with the `Form` component.
 
 Should you wish to create a more complex UI with `Field` components, you should use this base component.
 
@@ -51,7 +51,7 @@ The component requires min and max values, these should be the same as the optio
 
 `Slider.Steps` work well with the built in `step` property, which defaults to 1 and changes the size of each movement. For example, this would limit the slider to three values only.
 
-```tsx preview
+```tsx
 <Slider defaultValue={[50]} min={10} max={20} step={5}>
   <Slider.Steps
     min={10}
@@ -69,20 +69,11 @@ The component requires min and max values, these should be the same as the optio
 
 A separate component exists to output the value from a slider. This is most commonly used within the `SliderField`, but is here in case you need to compose your own complex component.
 
-NOTE: this will only work if there is only one value selected. In order to not overly complicate the output, it is recommended to indicate multiple values using `steps` (see above). If more than one value is passed in, the component will not render.
-
 ```tsx preview
 <Slider.Value value={[50]} />
 ```
 
-By default this simply outputs the value, however this can be customised in a number of ways. The property `outputLabel` accepts a callback function that takes a value and returns that in a string.
-
-```tsx preview
-<Slider.Value
-  value={[50]}
-  outputLabel={(value) => `Current number of geese is ${value}`)}
-/>
-```
+By default this simply outputs the value, however, this can be customised in a number of ways. The property `outputLabel` accepts a function that passes the value selected in the slider and expects a string returned for the label.
 
 You can also use this is in more complex ways, for example to set empty states and pluralisation, like below.
 
@@ -94,6 +85,15 @@ You can also use this is in more complex ways, for example to set empty states a
       ? 'You have no geese'
       : `You have ${value} ${value === 1 ? 'goose' : 'geese'}`
   }
+/>
+```
+
+Should you wish to use the label with multiple values, you can use `Array.join()` like below.
+
+```tsx
+<Slider.Value
+  value={[25, 75]}
+  outputLabel={(value) => `You have between ${value.join(' and ')} geese`}
 />
 ```
 

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -60,6 +60,31 @@ The steps work well with the built in `step` property, which defaults to 1 and c
 />
 ```
 
+## Value output
+
+The slider can be set to display a label below the track displaying the current value selected. To do this, pass in the prop `showValue`.
+
+NOTE: this will only work if there is only one value selected. In order to not overly complicate the output, it is recommended to indicate multiple values using `steps` (see above). Should you pass in this prop with multiple values, the value output will not be rendered.
+
+```tsx preview
+<Slider defaultValue={[50]} showValue />
+```
+
+By default this simply outputs the value, however this can be customised in a number of ways. `outputLabel` can be passed, which is a string that must contain the `$VALUE`. This will be replaced with the value when it renders. A string is used so that the value can be placed wherever it needs to be in the output sentence, such as in the example below.
+
+The `outputLabel` also will turn the string `$S` into conditional plurals, i.e. 's' will be output if the value is greater than 1. This is also shown in the example review.
+
+Another prop, `emptyData`, accepts a `label` and `value` object, and tells the output at what value the label should be replaced. This typically would be an empty state, such as in the example below.
+
+```tsx preview
+<Slider
+  defaultValue={[50]}
+  showValue
+  outputLabel="You have selected $VALUE apple$S"
+  emptyData={{ label: 'No apples selected', position: 0 }}
+/>
+```
+
 ## Styling
 
 Depending on the background of your page, you can change the theme of the track to be either light or tonal using `theme="light"`. Default is `theme="tonal"`.

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -75,18 +75,25 @@ NOTE: this will only work if there is only one value selected. In order to not o
 <Slider.Value value={[50]} />
 ```
 
-By default this simply outputs the value, however this can be customised in a number of ways. `outputLabel` can be passed, which is a string that must contain the `$VALUE`. This will be replaced with the value when it renders. A string is used so that the value can be placed wherever it needs to be in the output sentence, such as in the example below.
-
-You can also put the string `$ITEM` in `outputLabel`, which will be replaced with either a single or plural depending on the current value. This relies on the prop `item` being passed, which should be an object with two keys, `single` and `plural`. These strings allow the handling of non standard plurals. This is shown in the example below.
-
-Another prop, `emptyData`, accepts a `label` and `value` object, and tells the output at what value the label should be replaced. This typically would be an empty state, such as in the example below.
+By default this simply outputs the value, however this can be customised in a number of ways. The property `outputLabel` accepts a callback function that takes a value and returns that in a string.
 
 ```tsx preview
 <Slider.Value
   value={[50]}
-  outputLabel="You have selected $VALUE $ITEM"
-  item={{ single: 'goose', plural: 'geese' }}
-  emptyData={{ label: 'No geese selected', value: 0 }}
+  outputLabel={(value) => `Current number of geese is ${value}`)}
+/>
+```
+
+You can also use this is in more complex ways, for example to set empty states and pluralisation, like below.
+
+```tsx preview
+<Slider.Value
+  value={[50]}
+  outputLabel={(value) =>
+    value === 0
+      ? 'You have no geese'
+      : `You have ${value} ${value === 1 ? 'goose' : 'geese'}`
+  }
 />
 ```
 

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -1,6 +1,6 @@
 ---
 title: Slider
-component: Slider, Slider.Value
+component: Slider, Slider.Value, Slider.Steps
 description: The slider component implements the Slider component from Radix, with default styling and the CSS prop.
 category: Form primitives
 ---
@@ -25,39 +25,44 @@ Should you wish to have more than one control on the slider, you can pass those 
 <Slider defaultValue={[25, 75]} />
 ```
 
-## Steps and Labels
+## Slider.Steps
 
-The slider can output an array of labels which appear at given value points along the slider. These are passed in to the `steps` property using an array objects that contain a label and a value.
+A separate component exists to output an array of labels which appear at given value points along the slider. These are passed in to the `steps` property using an array objects that contain a label and a value.
+
+This is most commonly used within the `SliderField`, but is here in case you need to compose your own complex component.
 
 Note: it is likely better to create steps as a constant and pass in with `steps={steps}` or similar, but this preview code cannot see values outside of JSX.
 
 ```tsx preview
-<Slider
-  steps={[
-    { value: 0, label: 'min' },
-    { value: 50, label: 'mid' },
-    { value: 100, label: 'max' }
-  ]}
-  defaultValue={[50]}
-/>
+<Slider defaultValue={[50]}>
+  <Slider.Steps
+    min={0}
+    max={100}
+    steps={[
+      { value: 0, label: 'min' },
+      { value: 50, label: 'mid' },
+      { value: 100, label: 'max' }
+    ]}
+  />
+</Slider>
 ```
 
-These values should be limited to the `min` and `max` values that can be passed in to the slider object, as it is not limited to a 0-100 range.
+The component requires min and max values, these should be the same as the optional values that are passed to the Slider component.
 
-The steps work well with the built in `step` property, which defaults to 1 and changes the size of each movement. For example, this would limit the slider to three values only.
+`Slider.Steps` work well with the built in `step` property, which defaults to 1 and changes the size of each movement. For example, this would limit the slider to three values only.
 
 ```tsx preview
-<Slider
-  steps={[
-    { value: 10, label: 'min' },
-    { value: 15, label: 'mid' },
-    { value: 20, label: 'max' }
-  ]}
-  step={5}
-  min={10}
-  max={20}
-  defaultValue={[15]}
-/>
+<Slider defaultValue={[50]} min={10} max={20} step={5}>
+  <Slider.Steps
+    min={10}
+    max={20}
+    steps={[
+      { value: 10, label: 'min' },
+      { value: 15, label: 'mid' },
+      { value: 20, label: 'max' }
+    ]}
+  />
+</Slider>
 ```
 
 ## Slider.Value

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -81,7 +81,7 @@ Another prop, `emptyData`, accepts a `label` and `value` object, and tells the o
   defaultValue={[50]}
   showValue
   outputLabel="You have selected $VALUE apple$S"
-  emptyData={{ label: 'No apples selected', position: 0 }}
+  emptyData={{ label: 'No apples selected', value: 0 }}
 />
 ```
 

--- a/src/components/slider/Slider.mdx
+++ b/src/components/slider/Slider.mdx
@@ -1,13 +1,13 @@
 ---
 title: Slider
-component: Slider
+component: Slider, Slider.Value
 description: The slider component implements the Slider component from Radix, with default styling and the CSS prop.
 category: Form primitives
 ---
 
 The `Slider` is a simple component that renders a form slider.
 
-The `Slider` component should be rendered with a label for accesibility reasons. Rather than using the `Slider` component directly, it is best to use the `SliderField` component, which provides a label and easily integrates with the `Form` component.
+The `Slider` component should be rendered with a label for accesibility reasons. Rather than using the `Slider` component directly, it is best to use the `SliderField` component, which provides a label and easily integrates with the `Form` component. It also adds the `Slider.Value` by default (with options to remove) in order to create a unified experience without bloating the individual component.
 
 Should you wish to create a more complex UI with `Field` components, you should use this base component.
 
@@ -60,14 +60,14 @@ The steps work well with the built in `step` property, which defaults to 1 and c
 />
 ```
 
-## Value output
+## Slider.Value
 
-The slider can be set to display a label below the track displaying the current value selected. To do this, pass in the prop `showValue`.
+A separate component exists to output the value from a slider. This is most commonly used within the `SliderField`, but is here in case you need to compose your own complex component.
 
-NOTE: this will only work if there is only one value selected. In order to not overly complicate the output, it is recommended to indicate multiple values using `steps` (see above). Should you pass in this prop with multiple values, the value output will not be rendered.
+NOTE: this will only work if there is only one value selected. In order to not overly complicate the output, it is recommended to indicate multiple values using `steps` (see above). If more than one value is passed in, the component will not render.
 
 ```tsx preview
-<Slider defaultValue={[50]} showValue />
+<Slider.Value value={[50]} />
 ```
 
 By default this simply outputs the value, however this can be customised in a number of ways. `outputLabel` can be passed, which is a string that must contain the `$VALUE`. This will be replaced with the value when it renders. A string is used so that the value can be placed wherever it needs to be in the output sentence, such as in the example below.
@@ -77,9 +77,8 @@ You can also put the string `$ITEM` in `outputLabel`, which will be replaced wit
 Another prop, `emptyData`, accepts a `label` and `value` object, and tells the output at what value the label should be replaced. This typically would be an empty state, such as in the example below.
 
 ```tsx preview
-<Slider
-  defaultValue={[50]}
-  showValue
+<Slider.Value
+  value={[50]}
   outputLabel="You have selected $VALUE $ITEM"
   item={{ single: 'goose', plural: 'geese' }}
   emptyData={{ label: 'No geese selected', value: 0 }}

--- a/src/components/slider/Slider.test.tsx
+++ b/src/components/slider/Slider.test.tsx
@@ -54,7 +54,7 @@ describe('Slider.Value component', () => {
   it('renders with a custom empty value label', async () => {
     render(<Slider.Value value={[0]} emptyData={emptyData} />)
 
-    expect(await screen.findByText('No test items')).toBeVisible()
+    expect(await screen.findByText(emptyData.label)).toBeVisible()
   })
 
   it('does not render with a value label given multiple values', async () => {

--- a/src/components/slider/Slider.test.tsx
+++ b/src/components/slider/Slider.test.tsx
@@ -10,9 +10,8 @@ const steps = [
   { value: 100, label: 'max' }
 ]
 
-const outputLabel = '$VALUE test items'
-
-const emptyData = { value: 0, label: 'No test items' }
+const outputLabel = (value) =>
+  value === 0 ? 'No test items' : `${value} test items`
 
 describe('Slider component', () => {
   it('renders', async () => {
@@ -52,9 +51,9 @@ describe('Slider.Value component', () => {
   })
 
   it('renders with a custom empty value label', async () => {
-    render(<Slider.Value value={[0]} emptyData={emptyData} />)
+    render(<Slider.Value value={[0]} outputLabel={outputLabel} />)
 
-    expect(await screen.findByText(emptyData.label)).toBeVisible()
+    expect(await screen.findByText('No test items')).toBeVisible()
   })
 
   it('does not render with a value label given multiple values', async () => {

--- a/src/components/slider/Slider.test.tsx
+++ b/src/components/slider/Slider.test.tsx
@@ -27,39 +27,6 @@ describe('Slider component', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('renders with a value label', async () => {
-    render(<Slider defaultValue={[50]} showValue />)
-
-    expect(await screen.findByText('Current value is 50')).toBeVisible()
-  })
-
-  it('renders with a custom value label', async () => {
-    render(<Slider defaultValue={[50]} showValue outputLabel={outputLabel} />)
-
-    expect(await screen.findByText('50 test items')).toBeVisible()
-  })
-
-  it('renders with a custom empty value label', async () => {
-    render(
-      <Slider
-        defaultValue={[0]}
-        showValue
-        outputLabel={outputLabel}
-        emptyData={emptyData}
-      />
-    )
-
-    expect(await screen.findByText('No test items')).toBeVisible()
-  })
-
-  it('does not render with a value label given multiple values', async () => {
-    render(<Slider defaultValue={[50, 75]} showValue />)
-
-    expect(
-      await screen.queryByText('Current value is 50')
-    ).not.toBeInTheDocument()
-  })
-
   //TODO: figure out how to pass aria-label properly so that there are no a11y issues
   //NOTE: this is here because the slider seems to want an aria-label on the slider
   //thumb, which would require a lot of drilling, and doesn't seem the right solution.
@@ -68,5 +35,33 @@ describe('Slider component', () => {
     const { container } = render(<Slider defaultValue={[50]} />)
 
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('Slider.Value component', () => {
+  it('renders', async () => {
+    const { container } = render(<Slider.Value value={[50]} />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders with a custom value label', async () => {
+    render(<Slider.Value value={[50]} outputLabel={outputLabel} />)
+
+    expect(await screen.findByText('50 test items')).toBeVisible()
+  })
+
+  it('renders with a custom empty value label', async () => {
+    render(<Slider.Value value={[0]} emptyData={emptyData} />)
+
+    expect(await screen.findByText('No test items')).toBeVisible()
+  })
+
+  it('does not render with a value label given multiple values', async () => {
+    render(<Slider.Value value={[50, 75]} />)
+
+    expect(
+      await screen.queryByText('Current value is 50')
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/slider/Slider.test.tsx
+++ b/src/components/slider/Slider.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import * as React from 'react'
 import { axe } from 'jest-axe'
 
@@ -9,6 +9,10 @@ const steps = [
   { value: 50, label: 'mid' },
   { value: 100, label: 'max' }
 ]
+
+const outputLabel = '$VALUE test items'
+
+const emptyData = { value: 0, label: 'No test items' }
 
 describe('Slider component', () => {
   it('renders', async () => {
@@ -21,6 +25,39 @@ describe('Slider component', () => {
     const { container } = render(<Slider steps={steps} defaultValue={[50]} />)
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders with a value label', async () => {
+    render(<Slider defaultValue={[50]} showValue />)
+
+    expect(await screen.findByText('Current value is 50')).toBeVisible()
+  })
+
+  it('renders with a custom value label', async () => {
+    render(<Slider defaultValue={[50]} showValue outputLabel={outputLabel} />)
+
+    expect(await screen.findByText('50 test items')).toBeVisible()
+  })
+
+  it('renders with a custom empty value label', async () => {
+    render(
+      <Slider
+        defaultValue={[0]}
+        showValue
+        outputLabel={outputLabel}
+        emptyData={emptyData}
+      />
+    )
+
+    expect(await screen.findByText('No test items')).toBeVisible()
+  })
+
+  it('does not render with a value label given multiple values', async () => {
+    render(<Slider defaultValue={[50, 75]} showValue />)
+
+    expect(
+      await screen.queryByText('Current value is 50')
+    ).not.toBeInTheDocument()
   })
 
   //TODO: figure out how to pass aria-label properly so that there are no a11y issues

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -5,6 +5,7 @@ import { styled } from '~/stitches'
 import { CSSWrapper } from '~/utilities'
 
 import { SliderSteps, SliderStepsType } from './SliderSteps'
+import { SliderValue, SliderValueType } from './SliderValue'
 
 const StyledTrack = styled(Track, {
   borderRadius: '$round',
@@ -64,8 +65,11 @@ const StyledThumb = styled(Thumb, {
   '&[data-disabled]': { bg: '$tonal200', cursor: 'not-allowed' }
 })
 
+export type SliderPointType = { label: string; value: number }
+
 export type SliderProps = React.ComponentProps<typeof StyledSlider> &
-  SliderStepsType
+  SliderStepsType &
+  SliderValueType & { showValue?: boolean }
 
 export const Slider: React.FC<SliderProps> = ({
   steps = [],
@@ -75,9 +79,12 @@ export const Slider: React.FC<SliderProps> = ({
   max = 100,
   theme = 'tonal',
   css,
+  showValue = false,
+  outputLabel,
+  emptyData,
   ...remainingProps
 }) => {
-  const thumbs = value || defaultValue
+  const values = value || defaultValue
   return (
     <CSSWrapper css={css}>
       <StyledSlider
@@ -91,10 +98,18 @@ export const Slider: React.FC<SliderProps> = ({
         <StyledTrack>
           <StyledRange />
         </StyledTrack>
-        {thumbs?.length && thumbs.map((_, i) => <StyledThumb key={i} />)}
+        {values?.length && values.map((_, i) => <StyledThumb key={i} />)}
       </StyledSlider>
 
       <SliderSteps min={min} max={max} steps={steps} />
+
+      {showValue && (
+        <SliderValue
+          value={values}
+          outputLabel={outputLabel}
+          emptyData={emptyData}
+        />
+      )}
     </CSSWrapper>
   )
 }

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -65,8 +65,6 @@ const StyledThumb = styled(Thumb, {
   '&[data-disabled]': { bg: '$tonal200', cursor: 'not-allowed' }
 })
 
-export type SliderPointType = { label: string; value: number }
-
 export type SliderProps = React.ComponentProps<typeof StyledSlider>
 
 export const Slider: React.FC<SliderProps> & {

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -5,7 +5,7 @@ import { styled } from '~/stitches'
 import { CSSWrapper } from '~/utilities'
 
 import { SliderSteps, SliderStepsType } from './SliderSteps'
-import { SliderValue, SliderValueType } from './SliderValue'
+import { SliderValue } from './SliderValue'
 
 const StyledTrack = styled(Track, {
   borderRadius: '$round',
@@ -68,10 +68,9 @@ const StyledThumb = styled(Thumb, {
 export type SliderPointType = { label: string; value: number }
 
 export type SliderProps = React.ComponentProps<typeof StyledSlider> &
-  SliderStepsType &
-  SliderValueType & { showValue?: boolean }
+  SliderStepsType
 
-export const Slider: React.FC<SliderProps> = ({
+export const Slider: React.FC<SliderProps> & { Value: typeof SliderValue } = ({
   steps = [],
   value,
   defaultValue,
@@ -79,10 +78,6 @@ export const Slider: React.FC<SliderProps> = ({
   max = 100,
   theme = 'tonal',
   css,
-  showValue = false,
-  outputLabel,
-  emptyData,
-  item,
   ...remainingProps
 }) => {
   const values = value || defaultValue
@@ -103,17 +98,10 @@ export const Slider: React.FC<SliderProps> = ({
       </StyledSlider>
 
       <SliderSteps min={min} max={max} steps={steps} />
-
-      {showValue && (
-        <SliderValue
-          value={values}
-          outputLabel={outputLabel}
-          emptyData={emptyData}
-          item={item}
-        />
-      )}
     </CSSWrapper>
   )
 }
+
+Slider.Value = SliderValue
 
 Slider.displayName = 'Slider'

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -94,7 +94,8 @@ export const Slider: React.FC<SliderProps> & { Value: typeof SliderValue } = ({
         <StyledTrack>
           <StyledRange />
         </StyledTrack>
-        {values?.length && values.map((_, i) => <StyledThumb key={i} />)}
+        {values?.length &&
+          values.map((_, i) => <StyledThumb key={`thumb${i}`} />)}
       </StyledSlider>
 
       <SliderSteps min={min} max={max} steps={steps} />

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -82,6 +82,7 @@ export const Slider: React.FC<SliderProps> = ({
   showValue = false,
   outputLabel,
   emptyData,
+  item,
   ...remainingProps
 }) => {
   const values = value || defaultValue
@@ -108,6 +109,7 @@ export const Slider: React.FC<SliderProps> = ({
           value={values}
           outputLabel={outputLabel}
           emptyData={emptyData}
+          item={item}
         />
       )}
     </CSSWrapper>

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 import { CSSWrapper } from '~/utilities'
 
-import { SliderSteps, SliderStepsType } from './SliderSteps'
+import { SliderSteps } from './SliderSteps'
 import { SliderValue } from './SliderValue'
 
 const StyledTrack = styled(Track, {
@@ -67,17 +67,19 @@ const StyledThumb = styled(Thumb, {
 
 export type SliderPointType = { label: string; value: number }
 
-export type SliderProps = React.ComponentProps<typeof StyledSlider> &
-  SliderStepsType
+export type SliderProps = React.ComponentProps<typeof StyledSlider>
 
-export const Slider: React.FC<SliderProps> & { Value: typeof SliderValue } = ({
-  steps = [],
+export const Slider: React.FC<SliderProps> & {
+  Value: typeof SliderValue
+  Steps: typeof SliderSteps
+} = ({
   value,
   defaultValue,
   min = 0,
   max = 100,
   theme = 'tonal',
   css,
+  children,
   ...remainingProps
 }) => {
   const values = value || defaultValue
@@ -97,12 +99,12 @@ export const Slider: React.FC<SliderProps> & { Value: typeof SliderValue } = ({
         {values?.length &&
           values.map((_, i) => <StyledThumb key={`thumb${i}`} />)}
       </StyledSlider>
-
-      <SliderSteps min={min} max={max} steps={steps} />
+      {children}
     </CSSWrapper>
   )
 }
 
 Slider.Value = SliderValue
+Slider.Steps = SliderSteps
 
 Slider.displayName = 'Slider'

--- a/src/components/slider/SliderSteps.tsx
+++ b/src/components/slider/SliderSteps.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
 
 import { styled } from '~/stitches'
-import { SliderPointType } from '.'
 
 import { Text } from '../text'
 
 export type SliderStepsType = {
-  steps: SliderPointType[]
+  steps: { label: string; value: number }[]
 }
 
 type SliderStepsProps = {

--- a/src/components/slider/SliderSteps.tsx
+++ b/src/components/slider/SliderSteps.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
 import { styled } from '~/stitches'
+import { SliderPointType } from '.'
 
 import { Text } from '../text'
 
 export type SliderStepsType = {
-  steps: { value: number; label: string }[]
+  steps: SliderPointType[]
 }
 
 type SliderStepsProps = {

--- a/src/components/slider/SliderSteps.tsx
+++ b/src/components/slider/SliderSteps.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { styled } from '~/stitches'
 import { SliderPointType } from '.'

--- a/src/components/slider/SliderValue.tsx
+++ b/src/components/slider/SliderValue.tsx
@@ -19,9 +19,9 @@ export const SliderValue: React.FC<SliderValueProps> = ({
   emptyData,
   item = { single: '', plural: '' }
 }) => {
-  if (value.length > 1) return null
+  if (value.length !== 1) return null
 
-  const outputValue = value.length > 0 ? value[0] : ''
+  const outputValue = value[0]
 
   const outputString = outputLabel
     .replace('$VALUE', outputValue.toString())

--- a/src/components/slider/SliderValue.tsx
+++ b/src/components/slider/SliderValue.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Text } from '../text'
 
 export type SliderValueType = {
-  outputLabel?: (value) => string
+  outputLabel?: (value: number | number[]) => string
 }
 
 type SliderValueProps = SliderValueType & {
@@ -14,11 +14,9 @@ export const SliderValue: React.FC<SliderValueProps> = ({
   value = [],
   outputLabel = (value) => `Current value is ${value}`
 }) => {
-  if (value.length !== 1) return null
-
   return (
     <Text css={{ mt: '$4', color: '$tonal300', width: '100%' }}>
-      {outputLabel(value[0])}
+      {outputLabel(value.length === 1 ? value[0] : value)}
     </Text>
   )
 }

--- a/src/components/slider/SliderValue.tsx
+++ b/src/components/slider/SliderValue.tsx
@@ -4,7 +4,7 @@ import { SliderPointType } from '.'
 import { Text } from '../text'
 
 export type SliderValueType = {
-  outputLabel: string
+  outputLabel?: string
   emptyData?: SliderPointType
   item?: { single: string; plural: string }
 }

--- a/src/components/slider/SliderValue.tsx
+++ b/src/components/slider/SliderValue.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { SliderPointType } from '.'
+
+import { Text } from '../text'
+
+export type SliderValueType = {
+  outputLabel: string
+  emptyData?: SliderPointType
+}
+
+type SliderValueProps = SliderValueType & {
+  value?: number[]
+}
+
+export const SliderValue: React.FC<SliderValueProps> = ({
+  value = [],
+  outputLabel = 'Current value is $VALUE',
+  emptyData
+}) => {
+  if (value.length > 1) return null
+
+  const outputValue = value.length > 0 ? value[0] : ''
+
+  const outputString = outputLabel
+    .replace('$VALUE', outputValue.toString())
+    .replace('$S', outputValue > 1 ? 's' : '')
+
+  return (
+    <Text css={{ mt: '$4', color: '$tonal300', width: '100%' }}>
+      {outputValue === emptyData?.value ? emptyData?.label : outputString}
+    </Text>
+  )
+}

--- a/src/components/slider/SliderValue.tsx
+++ b/src/components/slider/SliderValue.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { SliderPointType } from '.'
 
 import { Text } from '../text'
@@ -6,6 +6,7 @@ import { Text } from '../text'
 export type SliderValueType = {
   outputLabel: string
   emptyData?: SliderPointType
+  item?: { single: string; plural: string }
 }
 
 type SliderValueProps = SliderValueType & {
@@ -15,7 +16,8 @@ type SliderValueProps = SliderValueType & {
 export const SliderValue: React.FC<SliderValueProps> = ({
   value = [],
   outputLabel = 'Current value is $VALUE',
-  emptyData
+  emptyData,
+  item = { single: '', plural: '' }
 }) => {
   if (value.length > 1) return null
 
@@ -23,7 +25,7 @@ export const SliderValue: React.FC<SliderValueProps> = ({
 
   const outputString = outputLabel
     .replace('$VALUE', outputValue.toString())
-    .replace('$S', outputValue > 1 ? 's' : '')
+    .replace('$ITEM', outputValue === 1 ? item?.single : item?.plural)
 
   return (
     <Text css={{ mt: '$4', color: '$tonal300', width: '100%' }}>

--- a/src/components/slider/SliderValue.tsx
+++ b/src/components/slider/SliderValue.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react'
-import { SliderPointType } from '.'
 
 import { Text } from '../text'
 
 export type SliderValueType = {
-  outputLabel?: string
-  emptyData?: SliderPointType
-  item?: { single: string; plural: string }
+  outputLabel?: (value) => string
 }
 
 type SliderValueProps = SliderValueType & {
@@ -15,21 +12,13 @@ type SliderValueProps = SliderValueType & {
 
 export const SliderValue: React.FC<SliderValueProps> = ({
   value = [],
-  outputLabel = 'Current value is $VALUE',
-  emptyData,
-  item = { single: '', plural: '' }
+  outputLabel = (value) => `Current value is ${value}`
 }) => {
   if (value.length !== 1) return null
 
-  const outputValue = value[0]
-
-  const outputString = outputLabel
-    .replace('$VALUE', outputValue.toString())
-    .replace('$ITEM', outputValue === 1 ? item?.single : item?.plural)
-
   return (
     <Text css={{ mt: '$4', color: '$tonal300', width: '100%' }}>
-      {outputValue === emptyData?.value ? emptyData?.label : outputString}
+      {outputLabel(value[0])}
     </Text>
   )
 }

--- a/src/components/slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/slider/__snapshots__/Slider.test.tsx.snap
@@ -295,3 +295,137 @@ exports[`Slider component renders with a steps list 1`] = `
   </div>
 </div>
 `;
+
+exports[`Slider.Value component renders 1`] = `
+@media  {
+  .c-eqsMSy {
+    align-items: center;
+    display: flex;
+    position: relative;
+    touch-action: none;
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: pointer;
+  }
+
+  .c-eqsMSy[data-orientation="horizontal"] {
+    height: var(--sizes-1);
+  }
+
+  .c-eqsMSy[data-orientation="vertical"] {
+    flex-direction: column;
+    width: var(--sizes-1);
+  }
+
+  .c-eqsMSy[data-disabled] {
+    cursor: not-allowed;
+    background: var(--colors-tonal100);
+  }
+
+  .c-nJgcq {
+    border-radius: var(--radii-round);
+    flex-grow: 1;
+    position: relative;
+  }
+
+  .c-nJgcq[data-orientation="horizontal"] {
+    height: var(--space-1);
+  }
+
+  .c-nJgcq[data-orientation="vertical"] {
+    width: var(--space-1);
+  }
+
+  .c-bOJGDH {
+    background: var(--colors-primary);
+    border-radius: var(--radii-round);
+    height: 100%;
+    position: absolute;
+  }
+
+  .c-bOJGDH[data-disabled] {
+    background: var(--colors-tonal200);
+    cursor: not-allowed;
+  }
+
+  .c-gCMpHY {
+    background: var(--colors-primaryMid);
+    border-radius: var(--radii-round);
+    display: block;
+    height: var(--sizes-1);
+    width: var(--sizes-1);
+  }
+
+  .c-gCMpHY:hover {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-gCMpHY:focus {
+    outline: 2px solid var(--colors-primaryMid);
+    outline-offset: 2px;
+  }
+
+  .c-gCMpHY[data-disabled] {
+    background: var(--colors-tonal200);
+    cursor: not-allowed;
+  }
+
+  .c-gyNHgU {
+    height: var(--space-3);
+    margin-top: var(--space-3);
+    position: relative;
+    width: 100%;
+  }
+
+  .c-dbleUi {
+    color: var(--colors-tonal600);
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
+}
+
+@media  {
+  .c-eqsMSy-dOexvR-theme-tonal .c-nJgcq {
+    background: var(--colors-tonal200);
+  }
+
+  .c-dbleUi-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-dbleUi-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-dbleUi-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+}
+
+@media  {
+  .c-dbleUi-ibmknkB-css {
+    position: absolute;
+    color: var(--colors-tonal300);
+  }
+
+  .c-dbleUi-iQwDky-css {
+    margin-top: var(--space-4);
+    color: var(--colors-tonal300);
+    width: 100%;
+  }
+}
+
+<div>
+  <p
+    class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-iQwDky-css"
+  >
+    Current value is 50
+  </p>
+</div>
+`;

--- a/src/components/slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/slider/__snapshots__/Slider.test.tsx.snap
@@ -191,49 +191,11 @@ exports[`Slider component renders with a steps list 1`] = `
     background: var(--colors-tonal200);
     cursor: not-allowed;
   }
-
-  .c-gyNHgU {
-    height: var(--space-3);
-    margin-top: var(--space-3);
-    position: relative;
-    width: 100%;
-  }
-
-  .c-dbleUi {
-    color: var(--colors-tonal600);
-    font-family: var(--fonts-body);
-    font-weight: 400;
-    margin: 0;
-  }
 }
 
 @media  {
   .c-eqsMSy-dOexvR-theme-tonal .c-nJgcq {
     background: var(--colors-tonal200);
-  }
-
-  .c-dbleUi-gvmVBy-size-md {
-    font-size: var(--fontSizes-md);
-    line-height: 1.5;
-  }
-
-  .c-dbleUi-gvmVBy-size-md::before {
-    content: '';
-    margin-bottom: -0.3864em;
-    display: table;
-  }
-
-  .c-dbleUi-gvmVBy-size-md::after {
-    content: '';
-    margin-top: -0.3864em;
-    display: table;
-  }
-}
-
-@media  {
-  .c-dbleUi-ibmknkB-css {
-    position: absolute;
-    color: var(--colors-tonal300);
   }
 }
 
@@ -242,6 +204,7 @@ exports[`Slider component renders with a steps list 1`] = `
     aria-disabled="false"
     class="c-eqsMSy c-eqsMSy-dOexvR-theme-tonal"
     data-orientation="horizontal"
+    steps="[object Object],[object Object],[object Object]"
     style="--radix-slider-thumb-transform: translateX(-50%);"
   >
     <span
@@ -271,28 +234,6 @@ exports[`Slider component renders with a steps list 1`] = `
       />
     </span>
   </span>
-  <div
-    class="c-gyNHgU"
-  >
-    <span
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibmknkB-css"
-      style="left: 0%; transform: translateX(-0%);"
-    >
-      min
-    </span>
-    <span
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibmknkB-css"
-      style="left: 50%; transform: translateX(-50%);"
-    >
-      mid
-    </span>
-    <span
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibmknkB-css"
-      style="left: 100%; transform: translateX(-100%);"
-    >
-      max
-    </span>
-  </div>
 </div>
 `;
 
@@ -370,13 +311,6 @@ exports[`Slider.Value component renders 1`] = `
     cursor: not-allowed;
   }
 
-  .c-gyNHgU {
-    height: var(--space-3);
-    margin-top: var(--space-3);
-    position: relative;
-    width: 100%;
-  }
-
   .c-dbleUi {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
@@ -409,11 +343,6 @@ exports[`Slider.Value component renders 1`] = `
 }
 
 @media  {
-  .c-dbleUi-ibmknkB-css {
-    position: absolute;
-    color: var(--colors-tonal300);
-  }
-
   .c-dbleUi-iQwDky-css {
     margin-top: var(--space-4);
     color: var(--colors-tonal300);


### PR DESCRIPTION
I needed a slider value label for work on the main site and realised that a slider is the only form component that doesn't explicitly state what its value is. I believe this isn't great as all inputs should probably inform the user of what input they're making. So I played around a bit and made this.

![image](https://user-images.githubusercontent.com/66493855/145784225-7c27b176-6219-4b92-a066-dcc257699841.png)
![image](https://user-images.githubusercontent.com/66493855/145784301-26b6255c-12d8-4a5e-9d7c-75a9b89ad1d4.png)
![image](https://user-images.githubusercontent.com/66493855/145784261-57a17692-0037-4a9a-aeeb-1e6428bcb39d.png)
![image](https://user-images.githubusercontent.com/66493855/145784394-2fa7e322-200a-4c2b-8e5d-ec2de73742aa.png)

Works with the slider steps, has custom empty state, supports custom value placement and pluralisation. There's also simple use case as well with default values so you can simply pass `showValue` to the slider and it will work.
