### PR TITLE
feat: make it possible to show / hide close button in modal

### DIFF
--- a/src/components/dialog/Dialog.mdx
+++ b/src/components/dialog/Dialog.mdx
@@ -14,7 +14,7 @@ Read more about the underlying UI component on the [Radix UI documentation site]
 ```tsx preview
 <Dialog>
   <Dialog.Trigger asChild>
-    <Button>Click me</Button>
+    <Button>Open Dialog</Button>
   </Dialog.Trigger>
   <Dialog.Content>
     <Heading size="sm" css={{ mb: '$3' }}>
@@ -31,28 +31,19 @@ Read more about the underlying UI component on the [Radix UI documentation site]
 </Dialog>
 ```
 
-`Dialog` may be rendered without a close button. Example - 
+`Dialog` may be rendered without a close button. It's important to note that in case the default close button is hidden, one would need to provide an action button explicitly, to close the dialog.
 
-```tsx preview
+```tsx
 <Dialog>
-  <Dialog.Trigger asChild>
-    <Button>Click me</Button>
-  </Dialog.Trigger>
-  <Dialog.Content showCloseIcon={false}>
-    <Heading size="sm" css={{ mb: '$3' }}>
-      Dialog
-    </Heading>
-    <Text size="sm" css={{ mb: '$3' }}>
-      The `Dialog` can display any type of element as a trigger and has the
-      content hidden by default
+  <Dialog.Trigger>Open Dialog</Dialog.Trigger>
+  <Dialog.Content showCloseButton={false}>
+    <Text>
+      Dialog.Close is used below to retain the correct accessible roles and
+      related logic
     </Text>
-    <Button appearance="outline" size="sm" as={Dialog.Close}>
-      Close Dialog
-    </Button>
+    <Button as={Dialog.Close}>Close</Button>
   </Dialog.Content>
 </Dialog>
 ```
-
-It's important to note that in case the default close button is hidden, one would need to provide an action button explicitly, to close the dialog
 
 For any modifications of the default `Dialog` visuals, for example bypassing the panel design entirely, we recommend utilising the Radix UI Dialog component directly. You will need to wrap each exported component within a `styled()` function to enable `css` and `as`, and compose together `Dialog.Overlay` and `Dialog.Close` within `Dialog.Content` to mimic the behaviour of this modal.

--- a/src/components/dialog/Dialog.mdx
+++ b/src/components/dialog/Dialog.mdx
@@ -31,4 +31,28 @@ Read more about the underlying UI component on the [Radix UI documentation site]
 </Dialog>
 ```
 
+`Dialog` may be rendered without a close button. Example - 
+
+```tsx preview
+<Dialog>
+  <Dialog.Trigger asChild>
+    <Button>Click me</Button>
+  </Dialog.Trigger>
+  <Dialog.Content showCloseIcon={false}>
+    <Heading size="sm" css={{ mb: '$3' }}>
+      Dialog
+    </Heading>
+    <Text size="sm" css={{ mb: '$3' }}>
+      The `Dialog` can display any type of element as a trigger and has the
+      content hidden by default
+    </Text>
+    <Button appearance="outline" size="sm" as={Dialog.Close}>
+      Close Dialog
+    </Button>
+  </Dialog.Content>
+</Dialog>
+```
+
+It's important to note that in case the default close button is hidden, one would need to provide an action button explicitly, to close the dialog
+
 For any modifications of the default `Dialog` visuals, for example bypassing the panel design entirely, we recommend utilising the Radix UI Dialog component directly. You will need to wrap each exported component within a `styled()` function to enable `css` and `as`, and compose together `Dialog.Overlay` and `Dialog.Close` within `Dialog.Content` to mimic the behaviour of this modal.

--- a/src/components/dialog/Dialog.test.tsx
+++ b/src/components/dialog/Dialog.test.tsx
@@ -1,5 +1,6 @@
 import { IdProvider } from '@radix-ui/react-id'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, RenderResult, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
@@ -15,7 +16,7 @@ const DialogTest = (props) => (
 )
 
 describe(`Dialog component`, () => {
-  let rendered
+  let rendered: RenderResult
   let trigger
 
   beforeEach(() => {
@@ -35,9 +36,12 @@ describe(`Dialog component`, () => {
     expect(await screen.queryByText('CONTENT')).not.toBeInTheDocument()
 
     trigger.focus()
-    fireEvent.click(trigger)
+    userEvent.click(trigger)
 
     expect(await screen.queryByText('CONTENT')).toBeInTheDocument()
+
+    const dialog = await screen.getByRole('dialog')
+    expect(dialog).toMatchSnapshot()
   })
 
   it('has no programmatically detectable a11y issues', async () => {
@@ -46,11 +50,30 @@ describe(`Dialog component`, () => {
 
   describe(`when open`, () => {
     beforeEach(() => {
-      fireEvent.click(trigger)
+      userEvent.click(trigger)
     })
 
     it('has no programmatically detectable a11y issues', async () => {
       expect(await axe(rendered.container)).toHaveNoViolations()
     })
+  })
+})
+
+describe('Dialog component without close button', () => {
+  it('renders', async () => {
+    await render(
+      <IdProvider>
+        <Dialog>
+          <Dialog.Trigger>TRIGGER</Dialog.Trigger>
+          <Dialog.Content showCloseIcon={false}>CONTENT</Dialog.Content>
+        </Dialog>
+      </IdProvider>
+    )
+
+    const trigger = await screen.getByText('TRIGGER')
+    userEvent.click(trigger)
+
+    const dialog = await screen.getByRole('dialog')
+    expect(dialog).toMatchSnapshot()
   })
 })

--- a/src/components/dialog/Dialog.test.tsx
+++ b/src/components/dialog/Dialog.test.tsx
@@ -65,7 +65,7 @@ describe('Dialog component without close button', () => {
       <IdProvider>
         <Dialog>
           <Dialog.Trigger>TRIGGER</Dialog.Trigger>
-          <Dialog.Content showCloseIcon={false}>CONTENT</Dialog.Content>
+          <Dialog.Content showCloseButton={false}>CONTENT</Dialog.Content>
         </Dialog>
       </IdProvider>
     )

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -69,20 +69,20 @@ const StyledDialogContent = styled(Content, {
 
 type DialogContentProps = React.ComponentProps<typeof StyledDialogContent> & {
   closeDialogText?: string
-  showCloseIcon?: boolean
+  showCloseButton?: boolean
 }
 
 export const DialogContent: React.FC<DialogContentProps> = ({
   size = 'sm',
   children,
   closeDialogText = 'Close dialog',
-  showCloseIcon = true,
+  showCloseButton = true,
   ...remainingProps
 }) => (
   <>
     <StyledDialogOverlay />
     <StyledDialogContent size={size} {...remainingProps}>
-      {showCloseIcon && (
+      {showCloseButton && (
         <ActionIcon
           as={Close}
           css={{ position: 'absolute', right: '$4', top: '$4' }}

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -69,26 +69,30 @@ const StyledDialogContent = styled(Content, {
 
 type DialogContentProps = React.ComponentProps<typeof StyledDialogContent> & {
   closeDialogText?: string
+  showCloseIcon?: boolean
 }
 
 export const DialogContent: React.FC<DialogContentProps> = ({
   size = 'sm',
   children,
   closeDialogText = 'Close dialog',
+  showCloseIcon = true,
   ...remainingProps
 }) => (
   <>
     <StyledDialogOverlay />
     <StyledDialogContent size={size} {...remainingProps}>
-      <ActionIcon
-        as={Close}
-        css={{ position: 'absolute', right: '$4', top: '$4' }}
-        label={closeDialogText}
-        size="lg"
-        theme="neutral"
-      >
-        <Icon is={CloseIcon} />
-      </ActionIcon>
+      {showCloseIcon && (
+        <ActionIcon
+          as={Close}
+          css={{ position: 'absolute', right: '$4', top: '$4' }}
+          label={closeDialogText}
+          size="lg"
+          theme="neutral"
+        >
+          <Icon is={CloseIcon} />
+        </ActionIcon>
+      )}
       {children}
     </StyledDialogContent>
   </>

--- a/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -1,5 +1,163 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dialog component opens the popover once trigger is clicked 1`] = `
+@media  {
+  .c-hSCvKD {
+    background-color: var(--colors-alpha600);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    position: fixed;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hSCvKD[data-state="open"] {
+      animation: k-eyOShd 250ms ease-out;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hSCvKD[data-state="closed"] {
+      animation: k-bHbNKp 550ms ease-out;
+    }
+}
+
+  .c-iZiUtw {
+    background: white;
+    border-radius: var(--radii-1);
+    box-shadow: var(--shadows-3);
+    box-sizing: border-box;
+    left: 50%;
+    max-width: 90vw;
+    padding: var(--space-5);
+    position: fixed;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+  }
+
+  .c-iZiUtw:focus {
+    outline: none;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-iZiUtw[data-state="open"] {
+      animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-iZiUtw[data-state="closed"] {
+      animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+}
+
+@media  {
+  .c-iZiUtw-lgqbzh-size-sm {
+    width: 480px;
+  }
+
+  .c-fDzwZw-PrXKS-size-lg {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-hemXWm-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 2;
+  }
+}
+
+@media  {
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-fDzwZw-ikHqHwu-css {
+    position: absolute;
+    right: var(--space-4);
+    top: var(--space-4);
+  }
+
+  .c-dbrbZt-ihFPSGE-css {
+    height: 20px;
+    width: 20px;
+  }
+}
+
+<div
+  aria-describedby="radix-id-0-3"
+  aria-labelledby="radix-id-0-2"
+  class="c-iZiUtw c-iZiUtw-lgqbzh-size-sm"
+  data-state="open"
+  id="radix-id-0-1"
+  role="dialog"
+  style="pointer-events: auto;"
+  tabindex="-1"
+>
+  <button
+    aria-label="Close dialog"
+    class="c-fDzwZw c-fDzwZw-PrXKS-size-lg c-fDzwZw-otpKd-cv c-fDzwZw-ikHqHwu-css"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6.343 6.343l11.314 11.314m-11.314 0L17.657 6.343"
+      />
+    </svg>
+  </button>
+  CONTENT
+</div>
+`;
+
 exports[`Dialog component renders the trigger with the popover hidden by default 1`] = `
 <div>
   <button
@@ -11,5 +169,113 @@ exports[`Dialog component renders the trigger with the popover hidden by default
   >
     TRIGGER
   </button>
+</div>
+`;
+
+exports[`Dialog component without close button renders 1`] = `
+@media  {
+  .c-hSCvKD {
+    background-color: var(--colors-alpha600);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    position: fixed;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hSCvKD[data-state="open"] {
+      animation: k-eyOShd 250ms ease-out;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hSCvKD[data-state="closed"] {
+      animation: k-bHbNKp 550ms ease-out;
+    }
+}
+
+  .c-iZiUtw {
+    background: white;
+    border-radius: var(--radii-1);
+    box-shadow: var(--shadows-3);
+    box-sizing: border-box;
+    left: 50%;
+    max-width: 90vw;
+    padding: var(--space-5);
+    position: fixed;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+  }
+
+  .c-iZiUtw:focus {
+    outline: none;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-iZiUtw[data-state="open"] {
+      animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-iZiUtw[data-state="closed"] {
+      animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+}
+
+@media  {
+  .c-iZiUtw-lgqbzh-size-sm {
+    width: 480px;
+  }
+
+  .c-fDzwZw-PrXKS-size-lg {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-hemXWm-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 2;
+  }
+}
+
+<div
+  aria-describedby="radix-id-0-3"
+  aria-labelledby="radix-id-0-2"
+  class="c-iZiUtw c-iZiUtw-lgqbzh-size-sm"
+  data-state="open"
+  id="radix-id-0-1"
+  role="dialog"
+  style="pointer-events: auto;"
+  tabindex="-1"
+>
+  CONTENT
 </div>
 `;


### PR DESCRIPTION
Currently, it is not possible to manipulate the close button in the modal. Adding a prop to `DialogContent` to make it possible. Snapshots in PR for reference