### PR TITLE
feat: remove :before and :after for nested Text components

### DIFF
--- a/src/components/calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/src/components/calendar/__snapshots__/Calendar.test.tsx.snap
@@ -43,11 +43,16 @@ exports[`Calendar component renders 1`] = `
     grid-gap: var(--space-1) var(--space-2);
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 
   .c-epywoc {
@@ -109,18 +114,18 @@ exports[`Calendar component renders 1`] = `
     display: table;
   }
 
-  .c-dbleUi-bndJoy-size-sm {
+  .c-fIXJvv-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-dbleUi-bndJoy-size-sm::before {
+  .c-fIXJvv-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-dbleUi-bndJoy-size-sm::after {
+  .c-fIXJvv-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -184,7 +189,7 @@ exports[`Calendar component renders 1`] = `
     margin-bottom: var(--space-3);
   }
 
-  .c-dbleUi-idQvJRf-css {
+  .c-fIXJvv-idQvJRf-css {
     font-weight: 600;
     text-align: center;
   }
@@ -248,37 +253,37 @@ exports[`Calendar component renders 1`] = `
         class="c-fPxPMR c-fPxPMR-ihbtntv-css"
       >
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Sun
         </span>
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Mon
         </span>
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Tue
         </span>
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Wed
         </span>
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Thu
         </span>
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Fri
         </span>
         <span
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-idQvJRf-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-idQvJRf-css"
         >
           Sat
         </span>

--- a/src/components/date-field/__snapshots__/DateField.test.tsx.snap
+++ b/src/components/date-field/__snapshots__/DateField.test.tsx.snap
@@ -117,11 +117,16 @@ exports[`DateField component renders a field in error state 1`] = `
     font-weight: 400;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 }
 
@@ -172,18 +177,18 @@ exports[`DateField component renders a field in error state 1`] = `
     border: 1px solid var(--colors-danger);
   }
 
-  .c-dbleUi-bndJoy-size-sm {
+  .c-fIXJvv-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-dbleUi-bndJoy-size-sm::before {
+  .c-fIXJvv-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-dbleUi-bndJoy-size-sm::after {
+  .c-fIXJvv-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -248,7 +253,7 @@ exports[`DateField component renders a field in error state 1`] = `
     flex-shrink: 0;
   }
 
-  .c-dbleUi-ikkBjHS-css {
+  .c-fIXJvv-ikkBjHS-css {
     color: inherit;
     transform: translateY(var(--space-1));
   }
@@ -340,7 +345,7 @@ exports[`DateField component renders a field in error state 1`] = `
           />
         </svg>
         <p
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-ikkBjHS-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-ikkBjHS-css"
         >
           This field is required
         </p>

--- a/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FieldWrapper component renders 1`] = `
     margin: 0;
   }
 
-  .c-gEFkc {
+  .c-kgcOue {
     background: unset;
     border: unset;
     padding: unset;
@@ -22,29 +22,29 @@ exports[`FieldWrapper component renders 1`] = `
     text-decoration: none;
   }
 
-  .c-gEFkc:focus,
-  .c-gEFkc:hover {
+  .c-kgcOue:focus,
+  .c-kgcOue:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-gEFkc:active {
+  .c-kgcOue:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dbleUi > .c-gEFkc,
-  .c-iSnHBU > .c-gEFkc,
-  .c-PJLV > .c-gEFkc {
+  .c-fIXJvv > .c-kgcOue,
+  .c-iSnHBU > .c-kgcOue,
+  .c-PJLV > .c-kgcOue {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dbleUi > .c-gEFkc::before,
-  .c-dbleUi > .c-gEFkc::after,
-  .c-iSnHBU > .c-gEFkc::before,
-  .c-iSnHBU > .c-gEFkc::after,
-  .c-PJLV > .c-gEFkc::before,
-  .c-PJLV > .c-gEFkc::after {
+  .c-fIXJvv > .c-kgcOue::before,
+  .c-fIXJvv > .c-kgcOue::after,
+  .c-iSnHBU > .c-kgcOue::before,
+  .c-iSnHBU > .c-kgcOue::after,
+  .c-PJLV > .c-kgcOue::before,
+  .c-PJLV > .c-kgcOue::after {
     content: none;
   }
 
@@ -90,11 +90,16 @@ exports[`FieldWrapper component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 }
 
@@ -121,18 +126,18 @@ exports[`FieldWrapper component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-gEFkc-bndJoy-size-sm {
+  .c-kgcOue-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-gEFkc-bndJoy-size-sm::before {
+  .c-kgcOue-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-gEFkc-bndJoy-size-sm::after {
+  .c-kgcOue-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -149,18 +154,18 @@ exports[`FieldWrapper component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-dbleUi-bndJoy-size-sm {
+  .c-fIXJvv-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-dbleUi-bndJoy-size-sm::before {
+  .c-fIXJvv-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-dbleUi-bndJoy-size-sm::after {
+  .c-fIXJvv-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -185,7 +190,7 @@ exports[`FieldWrapper component renders 1`] = `
     flex-shrink: 0;
   }
 
-  .c-dbleUi-ikkBjHS-css {
+  .c-fIXJvv-ikkBjHS-css {
     color: inherit;
     transform: translateY(var(--space-1));
   }
@@ -205,7 +210,7 @@ exports[`FieldWrapper component renders 1`] = `
         Example Field
       </label>
       <a
-        class="c-gEFkc c-gEFkc-bndJoy-size-sm"
+        class="c-kgcOue c-kgcOue-bndJoy-size-sm"
         href="https://example.com"
       >
         Example prompt
@@ -242,7 +247,7 @@ exports[`FieldWrapper component renders 1`] = `
         />
       </svg>
       <p
-        class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-ikkBjHS-css"
+        class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-ikkBjHS-css"
       >
         Example error
       </p>

--- a/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -60,11 +60,16 @@ exports[`InputField component renders a field in error state 1`] = `
     vertical-align: middle;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 }
 
@@ -106,18 +111,18 @@ exports[`InputField component renders a field in error state 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-dbleUi-bndJoy-size-sm {
+  .c-fIXJvv-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-dbleUi-bndJoy-size-sm::before {
+  .c-fIXJvv-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-dbleUi-bndJoy-size-sm::after {
+  .c-fIXJvv-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -148,7 +153,7 @@ exports[`InputField component renders a field in error state 1`] = `
     flex-shrink: 0;
   }
 
-  .c-dbleUi-ikkBjHS-css {
+  .c-fIXJvv-ikkBjHS-css {
     color: inherit;
     transform: translateY(var(--space-1));
   }
@@ -209,7 +214,7 @@ exports[`InputField component renders a field in error state 1`] = `
           />
         </svg>
         <p
-          class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-ikkBjHS-css"
+          class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-ikkBjHS-css"
         >
           This field is required
         </p>

--- a/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Link component can be nested within Text and Heading 1`] = `
 @media  {
-  .c-gEFkc {
+  .c-kgcOue {
     background: unset;
     border: unset;
     padding: unset;
@@ -12,37 +12,42 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     text-decoration: none;
   }
 
-  .c-gEFkc:focus,
-  .c-gEFkc:hover {
+  .c-kgcOue:focus,
+  .c-kgcOue:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-gEFkc:active {
+  .c-kgcOue:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dbleUi > .c-gEFkc,
-  .c-iSnHBU > .c-gEFkc,
-  .c-PJLV > .c-gEFkc {
+  .c-fIXJvv > .c-kgcOue,
+  .c-iSnHBU > .c-kgcOue,
+  .c-PJLV > .c-kgcOue {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dbleUi > .c-gEFkc::before,
-  .c-dbleUi > .c-gEFkc::after,
-  .c-iSnHBU > .c-gEFkc::before,
-  .c-iSnHBU > .c-gEFkc::after,
-  .c-PJLV > .c-gEFkc::before,
-  .c-PJLV > .c-gEFkc::after {
+  .c-fIXJvv > .c-kgcOue::before,
+  .c-fIXJvv > .c-kgcOue::after,
+  .c-iSnHBU > .c-kgcOue::before,
+  .c-iSnHBU > .c-kgcOue::after,
+  .c-PJLV > .c-kgcOue::before,
+  .c-PJLV > .c-kgcOue::after {
     content: none;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 
   .c-iSnHBU {
@@ -54,52 +59,52 @@ exports[`Link component can be nested within Text and Heading 1`] = `
 }
 
 @media  {
-  .c-gEFkc-gvmVBy-size-md {
+  .c-kgcOue-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-gEFkc-gvmVBy-size-md::before {
+  .c-kgcOue-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-gEFkc-gvmVBy-size-md::after {
+  .c-kgcOue-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
   }
 
-  .c-gEFkc-jvTRJO-size-lg {
+  .c-kgcOue-jvTRJO-size-lg {
     font-size: var(--fontSizes-lg);
     line-height: 1.52;
   }
 
-  .c-gEFkc-jvTRJO-size-lg::before {
+  .c-kgcOue-jvTRJO-size-lg::before {
     content: '';
     margin-bottom: -0.3983em;
     display: table;
   }
 
-  .c-gEFkc-jvTRJO-size-lg::after {
+  .c-kgcOue-jvTRJO-size-lg::after {
     content: '';
     margin-top: -0.3983em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md {
+  .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dbleUi-gvmVBy-size-md::before {
+  .c-fIXJvv-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md::after {
+  .c-fIXJvv-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -125,10 +130,10 @@ exports[`Link component can be nested within Text and Heading 1`] = `
 
 <div>
   <p
-    class="c-dbleUi c-dbleUi-gvmVBy-size-md"
+    class="c-fIXJvv c-fIXJvv-gvmVBy-size-md"
   >
     <button
-      class="c-gEFkc c-gEFkc-gvmVBy-size-md"
+      class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     >
       TEXT LINK
     </button>
@@ -137,7 +142,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     class="c-iSnHBU c-iSnHBU-fOoUdm-size-md"
   >
     <button
-      class="c-gEFkc c-gEFkc-gvmVBy-size-md"
+      class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     >
       HEADING LINK
     </button>
@@ -147,7 +152,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
 
 exports[`Link component renders an anchor 1`] = `
 @media  {
-  .c-gEFkc {
+  .c-kgcOue {
     background: unset;
     border: unset;
     padding: unset;
@@ -157,46 +162,46 @@ exports[`Link component renders an anchor 1`] = `
     text-decoration: none;
   }
 
-  .c-gEFkc:focus,
-  .c-gEFkc:hover {
+  .c-kgcOue:focus,
+  .c-kgcOue:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-gEFkc:active {
+  .c-kgcOue:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dbleUi > .c-gEFkc,
-  .c-iSnHBU > .c-gEFkc,
-  .c-PJLV > .c-gEFkc {
+  .c-fIXJvv > .c-kgcOue,
+  .c-iSnHBU > .c-kgcOue,
+  .c-PJLV > .c-kgcOue {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dbleUi > .c-gEFkc::before,
-  .c-dbleUi > .c-gEFkc::after,
-  .c-iSnHBU > .c-gEFkc::before,
-  .c-iSnHBU > .c-gEFkc::after,
-  .c-PJLV > .c-gEFkc::before,
-  .c-PJLV > .c-gEFkc::after {
+  .c-fIXJvv > .c-kgcOue::before,
+  .c-fIXJvv > .c-kgcOue::after,
+  .c-iSnHBU > .c-kgcOue::before,
+  .c-iSnHBU > .c-kgcOue::after,
+  .c-PJLV > .c-kgcOue::before,
+  .c-PJLV > .c-kgcOue::after {
     content: none;
   }
 }
 
 @media  {
-  .c-gEFkc-gvmVBy-size-md {
+  .c-kgcOue-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-gEFkc-gvmVBy-size-md::before {
+  .c-kgcOue-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-gEFkc-gvmVBy-size-md::after {
+  .c-kgcOue-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -205,7 +210,7 @@ exports[`Link component renders an anchor 1`] = `
 
 <div>
   <a
-    class="c-gEFkc c-gEFkc-gvmVBy-size-md"
+    class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     href="https://google.com/"
   >
     GOOGLE
@@ -215,7 +220,7 @@ exports[`Link component renders an anchor 1`] = `
 
 exports[`Link component renders an large anchor 1`] = `
 @media  {
-  .c-gEFkc {
+  .c-kgcOue {
     background: unset;
     border: unset;
     padding: unset;
@@ -225,63 +230,63 @@ exports[`Link component renders an large anchor 1`] = `
     text-decoration: none;
   }
 
-  .c-gEFkc:focus,
-  .c-gEFkc:hover {
+  .c-kgcOue:focus,
+  .c-kgcOue:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-gEFkc:active {
+  .c-kgcOue:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dbleUi > .c-gEFkc,
-  .c-iSnHBU > .c-gEFkc,
-  .c-PJLV > .c-gEFkc {
+  .c-fIXJvv > .c-kgcOue,
+  .c-iSnHBU > .c-kgcOue,
+  .c-PJLV > .c-kgcOue {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dbleUi > .c-gEFkc::before,
-  .c-dbleUi > .c-gEFkc::after,
-  .c-iSnHBU > .c-gEFkc::before,
-  .c-iSnHBU > .c-gEFkc::after,
-  .c-PJLV > .c-gEFkc::before,
-  .c-PJLV > .c-gEFkc::after {
+  .c-fIXJvv > .c-kgcOue::before,
+  .c-fIXJvv > .c-kgcOue::after,
+  .c-iSnHBU > .c-kgcOue::before,
+  .c-iSnHBU > .c-kgcOue::after,
+  .c-PJLV > .c-kgcOue::before,
+  .c-PJLV > .c-kgcOue::after {
     content: none;
   }
 }
 
 @media  {
-  .c-gEFkc-gvmVBy-size-md {
+  .c-kgcOue-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-gEFkc-gvmVBy-size-md::before {
+  .c-kgcOue-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-gEFkc-gvmVBy-size-md::after {
+  .c-kgcOue-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
   }
 
-  .c-gEFkc-jvTRJO-size-lg {
+  .c-kgcOue-jvTRJO-size-lg {
     font-size: var(--fontSizes-lg);
     line-height: 1.52;
   }
 
-  .c-gEFkc-jvTRJO-size-lg::before {
+  .c-kgcOue-jvTRJO-size-lg::before {
     content: '';
     margin-bottom: -0.3983em;
     display: table;
   }
 
-  .c-gEFkc-jvTRJO-size-lg::after {
+  .c-kgcOue-jvTRJO-size-lg::after {
     content: '';
     margin-top: -0.3983em;
     display: table;
@@ -290,7 +295,7 @@ exports[`Link component renders an large anchor 1`] = `
 
 <div>
   <a
-    class="c-gEFkc c-gEFkc-jvTRJO-size-lg"
+    class="c-kgcOue c-kgcOue-jvTRJO-size-lg"
     href="https://google.com/"
   >
     GOOGLE

--- a/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -14,11 +14,16 @@ exports[`MarkdownContent component renders 1`] = `
     margin: 0;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 
   .c-ecBjWS {
@@ -65,7 +70,7 @@ exports[`MarkdownContent component renders 1`] = `
     padding: var(--space-3);
   }
 
-  .c-gEFkc {
+  .c-kgcOue {
     background: unset;
     border: unset;
     padding: unset;
@@ -75,29 +80,29 @@ exports[`MarkdownContent component renders 1`] = `
     text-decoration: none;
   }
 
-  .c-gEFkc:focus,
-  .c-gEFkc:hover {
+  .c-kgcOue:focus,
+  .c-kgcOue:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-gEFkc:active {
+  .c-kgcOue:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dbleUi > .c-gEFkc,
-  .c-iSnHBU > .c-gEFkc,
-  .c-PJLV > .c-gEFkc {
+  .c-fIXJvv > .c-kgcOue,
+  .c-iSnHBU > .c-kgcOue,
+  .c-PJLV > .c-kgcOue {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dbleUi > .c-gEFkc::before,
-  .c-dbleUi > .c-gEFkc::after,
-  .c-iSnHBU > .c-gEFkc::before,
-  .c-iSnHBU > .c-gEFkc::after,
-  .c-PJLV > .c-gEFkc::before,
-  .c-PJLV > .c-gEFkc::after {
+  .c-fIXJvv > .c-kgcOue::before,
+  .c-fIXJvv > .c-kgcOue::after,
+  .c-iSnHBU > .c-kgcOue::before,
+  .c-iSnHBU > .c-kgcOue::after,
+  .c-PJLV > .c-kgcOue::before,
+  .c-PJLV > .c-kgcOue::after {
     content: none;
   }
 
@@ -214,18 +219,18 @@ exports[`MarkdownContent component renders 1`] = `
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md {
+  .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dbleUi-gvmVBy-size-md::before {
+  .c-fIXJvv-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md::after {
+  .c-fIXJvv-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -263,18 +268,18 @@ exports[`MarkdownContent component renders 1`] = `
     font-weight: bold;
   }
 
-  .c-gEFkc-gvmVBy-size-md {
+  .c-kgcOue-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-gEFkc-gvmVBy-size-md::before {
+  .c-kgcOue-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-gEFkc-gvmVBy-size-md::after {
+  .c-kgcOue-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -301,12 +306,12 @@ exports[`MarkdownContent component renders 1`] = `
     margin-bottom: var(--space-5);
   }
 
-  .c-dbleUi-ijBQtuh-css {
+  .c-fIXJvv-ijBQtuh-css {
     color: inherit;
     max-width: 75ch;
   }
 
-  .c-dbleUi-ijBQtuh-css:not(:last-child) {
+  .c-fIXJvv-ijBQtuh-css:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
@@ -323,7 +328,7 @@ exports[`MarkdownContent component renders 1`] = `
     margin-bottom: var(--space-5);
   }
 
-  .c-dbleUi-ibHwuwj-css {
+  .c-fIXJvv-ibHwuwj-css {
     color: inherit;
   }
 
@@ -390,7 +395,7 @@ exports[`MarkdownContent component renders 1`] = `
       class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-icGzAje-css"
     />
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <strong
         class="c-ecBjWS"
@@ -399,7 +404,7 @@ exports[`MarkdownContent component renders 1`] = `
       </strong>
     </p>
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <strong
         class="c-ecBjWS"
@@ -408,7 +413,7 @@ exports[`MarkdownContent component renders 1`] = `
       </strong>
     </p>
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <em
         class="c-bYNGXt"
@@ -417,7 +422,7 @@ exports[`MarkdownContent component renders 1`] = `
       </em>
     </p>
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <em
         class="c-bYNGXt"
@@ -459,7 +464,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           Create a list by starting a line with 
           <code
@@ -485,7 +490,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           Sub-lists are made by indenting 2 spaces:
         </p>
@@ -496,7 +501,7 @@ exports[`MarkdownContent component renders 1`] = `
             class="c-PJLV"
           >
             <p
-              class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+              class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
             >
               Marker character change forces new list start:
             </p>
@@ -507,7 +512,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="c-PJLV"
               >
                 <p
-                  class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+                  class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
                 >
                   Ac tristique libero volutpat at
                 </p>
@@ -520,7 +525,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="c-PJLV"
               >
                 <p
-                  class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+                  class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
                 >
                   Facilisis in pretium nisl aliquet
                 </p>
@@ -533,7 +538,7 @@ exports[`MarkdownContent component renders 1`] = `
                 class="c-PJLV"
               >
                 <p
-                  class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+                  class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
                 >
                   Nulla volutpat aliquam velit
                 </p>
@@ -546,7 +551,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           Very easy!
         </p>
@@ -564,7 +569,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           Lorem ipsum dolor sit amet
         </p>
@@ -573,7 +578,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           Consectetur adipiscing elit
         </p>
@@ -582,7 +587,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           Integer molestie lorem at massa
         </p>
@@ -591,7 +596,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           You can use sequential numbers...
         </p>
@@ -600,7 +605,7 @@ exports[`MarkdownContent component renders 1`] = `
         class="c-PJLV"
       >
         <p
-          class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ibHwuwj-css"
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
         >
           ...or keep all the numbers as 
           <code
@@ -628,7 +633,7 @@ exports[`MarkdownContent component renders 1`] = `
       Inline code
     </h3>
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       This is inline 
       <code
@@ -672,20 +677,20 @@ line 3 of code
       class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-icGzAje-css"
     />
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <a
-        class="c-gEFkc c-gEFkc-gvmVBy-size-md"
+        class="c-kgcOue c-kgcOue-gvmVBy-size-md"
         href="http://dev.nodeca.com"
       >
         link text
       </a>
     </p>
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <a
-        class="c-gEFkc c-gEFkc-gvmVBy-size-md"
+        class="c-kgcOue c-kgcOue-gvmVBy-size-md"
         href="http://nodeca.github.io/pica/demo/"
         title="title text!"
       >
@@ -704,7 +709,7 @@ line 3 of code
       class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-icGzAje-css"
     />
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ijBQtuh-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ijBQtuh-css"
     >
       <img
         alt="Minion"

--- a/src/components/slider-field/__snapshots__/SliderField.test.tsx.snap
+++ b/src/components/slider-field/__snapshots__/SliderField.test.tsx.snap
@@ -84,11 +84,16 @@ exports[`SliderField component renders 1`] = `
     cursor: not-allowed;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 }
 
@@ -119,18 +124,18 @@ exports[`SliderField component renders 1`] = `
     background: var(--colors-tonal200);
   }
 
-  .c-dbleUi-gvmVBy-size-md {
+  .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dbleUi-gvmVBy-size-md::before {
+  .c-fIXJvv-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md::after {
+  .c-fIXJvv-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -144,7 +149,7 @@ exports[`SliderField component renders 1`] = `
     margin-bottom: var(--space-3);
   }
 
-  .c-dbleUi-iQwDky-css {
+  .c-fIXJvv-iQwDky-css {
     margin-top: var(--space-4);
     color: var(--colors-tonal300);
     width: 100%;
@@ -208,7 +213,7 @@ exports[`SliderField component renders 1`] = `
         value="50"
       />
       <p
-        class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-iQwDky-css"
+        class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-iQwDky-css"
       >
         Current value is 50
       </p>

--- a/src/components/slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/slider/__snapshots__/Slider.test.tsx.snap
@@ -311,11 +311,16 @@ exports[`Slider.Value component renders 1`] = `
     cursor: not-allowed;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 }
 
@@ -324,18 +329,18 @@ exports[`Slider.Value component renders 1`] = `
     background: var(--colors-tonal200);
   }
 
-  .c-dbleUi-gvmVBy-size-md {
+  .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dbleUi-gvmVBy-size-md::before {
+  .c-fIXJvv-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md::after {
+  .c-fIXJvv-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -343,7 +348,7 @@ exports[`Slider.Value component renders 1`] = `
 }
 
 @media  {
-  .c-dbleUi-iQwDky-css {
+  .c-fIXJvv-iQwDky-css {
     margin-top: var(--space-4);
     color: var(--colors-tonal300);
     width: 100%;
@@ -352,7 +357,7 @@ exports[`Slider.Value component renders 1`] = `
 
 <div>
   <p
-    class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-iQwDky-css"
+    class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-iQwDky-css"
   >
     Current value is 50
   </p>

--- a/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
+++ b/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
@@ -9,11 +9,16 @@ exports[`StackContent component renders a stack content 1`] = `
     margin: 0;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 
   .c-jpqjUq {
@@ -73,18 +78,18 @@ exports[`StackContent component renders a stack content 1`] = `
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md {
+  .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dbleUi-gvmVBy-size-md::before {
+  .c-fIXJvv-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md::after {
+  .c-fIXJvv-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -127,11 +132,11 @@ exports[`StackContent component renders a stack content 1`] = `
     margin-bottom: var(--space-5);
   }
 
-  .c-dbleUi-ielbxsX-css {
+  .c-fIXJvv-ielbxsX-css {
     max-width: 75ch;
   }
 
-  .c-dbleUi-ielbxsX-css:not(:last-child) {
+  .c-fIXJvv-ielbxsX-css:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
@@ -172,7 +177,7 @@ exports[`StackContent component renders a stack content 1`] = `
       HEADING
     </h2>
     <p
-      class="c-dbleUi c-dbleUi-gvmVBy-size-md c-dbleUi-ielbxsX-css"
+      class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ielbxsX-css"
     >
       TEXT
     </p>

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -42,6 +42,10 @@ export const StyledParagraph = styled('p', {
   fontFamily: '$body',
   fontWeight: 400,
   margin: 0,
+  /** Allow nesting `<Text />` inside `<Text />` without forcing a new line and spacing. */
+  '& > &': {
+    '&:before, &:after': { display: 'none' }
+  },
   variants: {
     size: textVariantSize()
   }

--- a/src/components/text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/text/__snapshots__/Text.test.tsx.snap
@@ -2,27 +2,32 @@
 
 exports[`Text component renders some text 1`] = `
 @media  {
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
   }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
+  }
 }
 
 @media  {
-  .c-dbleUi-gvmVBy-size-md {
+  .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dbleUi-gvmVBy-size-md::before {
+  .c-fIXJvv-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dbleUi-gvmVBy-size-md::after {
+  .c-fIXJvv-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -31,7 +36,7 @@ exports[`Text component renders some text 1`] = `
 
 <div>
   <p
-    class="c-dbleUi c-dbleUi-gvmVBy-size-md"
+    class="c-fIXJvv c-fIXJvv-gvmVBy-size-md"
   >
     TEXT
   </p>

--- a/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
+++ b/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
@@ -15,11 +15,16 @@ exports[`ValidationError component renders a validation error 1`] = `
     vertical-align: middle;
   }
 
-  .c-dbleUi {
+  .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
     font-weight: 400;
     margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
   }
 }
 
@@ -30,18 +35,18 @@ exports[`ValidationError component renders a validation error 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-dbleUi-bndJoy-size-sm {
+  .c-fIXJvv-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-dbleUi-bndJoy-size-sm::before {
+  .c-fIXJvv-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-dbleUi-bndJoy-size-sm::after {
+  .c-fIXJvv-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -59,7 +64,7 @@ exports[`ValidationError component renders a validation error 1`] = `
     flex-shrink: 0;
   }
 
-  .c-dbleUi-ikkBjHS-css {
+  .c-fIXJvv-ikkBjHS-css {
     color: inherit;
     transform: translateY(var(--space-1));
   }
@@ -91,7 +96,7 @@ exports[`ValidationError component renders a validation error 1`] = `
       />
     </svg>
     <p
-      class="c-dbleUi c-dbleUi-bndJoy-size-sm c-dbleUi-ikkBjHS-css"
+      class="c-fIXJvv c-fIXJvv-bndJoy-size-sm c-fIXJvv-ikkBjHS-css"
     >
       VALIDATION ERROR
     </p>


### PR DESCRIPTION
## Issue
When nesting `<Text />` elements, it would always render the nested component on a new line, including spacing set on the `<Text />` element. This is usually not what you want when you nest `<Text />` elements, as the most common cases are with using inline HTML elements such as `span`, `strong`, `em`, etc.

## Example
### For code
```tsx
<Text>This is text, <Text as="strong">and more text</Text></Text>
```

### Before
![image](https://user-images.githubusercontent.com/2501587/148947857-1cab5fda-9a18-4e6a-b365-47755e93c605.png)

### After
![image](https://user-images.githubusercontent.com/2501587/148947921-034b43ed-2606-4f7c-8b21-9823486915b8.png)
