### PR TITLE
feat: tabs trigger list flex container

### DIFF
--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -5,7 +5,7 @@ description: Tabs is a component that provides different sections of content tha
 category: Layout
 ---
 
-The component provides a set of default styles, which can be overwritten by using the `css` prop. It is composed by combining smaller components, such as `Tabs.TriggerList`, `Tabs.Trigger`, and `Tabs.Content`.
+The component provides a set of default styles, which can be overwritten by using the `css` prop. It is composed by combining smaller components, such as `Tabs.TriggerList`, `Tabs.Trigger`, `Tabs.Content`, and the optional `Tabs.TriggerListFlexContainer`.
 
 ```tsx preview
 <Tabs defaultValue="tab1" css={{ height: '100px' }}>
@@ -98,3 +98,19 @@ In order to style the different states of a trigger, the following CSS selectors
 `&[data-state="active"]` to style an active trigger.
 
 If the content of the trigger is, say, a `<Text>` component instead of a string, you can append the `*` symbol or any other child/sibling selectors, to make sure that any nested content is styled accordingly. You can also simply style the nested child component directly via its own `css` prop.
+
+## Tabs.TriggerListFlexContainer
+
+For more complex designs, where tab triggers require a fixed element at the start or end separate to the scrollable tab trigger list, you can wrap `Tabs.TriggerList` and your other required element(s) in `Tabs.TriggerListFlexContainer`.
+
+```tsx
+<Tabs>
+  <Tabs.TriggerListFlexContainer>
+    <Tabs.TriggerList>...</Tabs.TriggerList>
+    <RequiredItemHere />
+  </Tabs.TriggerListFlexContainer>
+  ...
+</Tabs>
+```
+
+Note: for larger items you may need to apply `flex-shrink: 0` CSS to the required item.

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 
 import { TabTrigger } from './TabTrigger'
-import { TriggerListWrapper } from './TabsTriggerList'
+import { TriggerListWrapper, TriggerListFlexContainer } from './TabsTriggerList'
 import { passPropsToChildren } from './utils'
 
 type TabsProps = React.ComponentProps<typeof StyledRoot>
@@ -42,18 +42,21 @@ const StyledTabContent = styled(Content, {
 
 export const Tabs: React.FC<TabsProps> & {
   TriggerList: typeof TriggerListWrapper
+  TriggerListFlexContainer: typeof TriggerListFlexContainer
   Trigger: typeof TabTrigger
   Content: typeof StyledTabContent
 } = ({ theme = 'light', children, ...remainingProps }) => (
   <StyledRoot theme={theme} {...remainingProps}>
     {passPropsToChildren(children, { theme }, [
       TriggerListWrapper,
+      TriggerListFlexContainer,
       StyledTabContent
     ])}
   </StyledRoot>
 )
 
 Tabs.TriggerList = TriggerListWrapper
+Tabs.TriggerListFlexContainer = TriggerListFlexContainer
 Tabs.Trigger = TabTrigger
 Tabs.Content = StyledTabContent
 

--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -70,6 +70,15 @@ const StyledTriggerList = styled(List, {
   }
 })
 
+export const TriggerListFlexContainer: React.FC<ListProps> = ({
+  children,
+  theme
+}) => (
+  <Flex css={{ flexDirection: 'row' }}>
+    {passPropsToChildren(children, { theme }, [TriggerListWrapper])}
+  </Flex>
+)
+
 export const TriggerListWrapper: React.FC<ListProps> = ({
   children,
   theme,
@@ -150,7 +159,7 @@ export const TriggerListWrapper: React.FC<ListProps> = ({
 
   if (showScroller) {
     return (
-      <Flex css={{ position: 'relative' }}>
+      <Flex css={{ position: 'relative', minWidth: '0' }}>
         <StyledChevronIcon
           size="xl"
           label="Scroll Left"

--- a/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -304,8 +304,9 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-dhzjXW-icmpvrW-css {
+  .c-dhzjXW-ifaJnEw-css {
     position: relative;
+    min-width: 0;
   }
 
   .c-fDwKcF-icezigA-css {
@@ -328,7 +329,7 @@ exports[`Tabs component renders mobile view 1`] = `
     data-orientation="horizontal"
   >
     <div
-      class="c-dhzjXW c-dhzjXW-icmpvrW-css"
+      class="c-dhzjXW c-dhzjXW-ifaJnEw-css"
     >
       <button
         aria-label="Scroll Left"


### PR DESCRIPTION
### Description

I needed a way to make tab trigger lists work with flex, so that we could have items at the end of a tab trigger list (or start) that remain there, and do not affect the area for scrollable tabs. (i.e. the buttons aren't overlapping the item you've placed at the end).

This was almost entirely possible by adding CSS, but the wrapper you would need to add to allow it would mean theme properties weren't passed down properly to trigger lists or trigger items. So I made a simple wrapper component that handles the flex and passes the properties down to its children.

```tsx
<Tabs>
  <Tabs.TriggerListFlexContainer>
    <Tabs.TriggerList>
      <Tabs.Trigger></Tabs.Trigger>
      <Tabs.Trigger></Tabs.Trigger>
      <Tabs.Trigger></Tabs.Trigger>
    </Tabs.TriggerList>
      WHATEVER CONTENT YOU WANT HERE
  </Tabs.TriggerListFlexContainer>
...
</Tabs>
```

This wrapper is completely optional and the tabs function as normal without it. It just allows flex positioning for complex designs should you need them.

### Screenshots

![image](https://user-images.githubusercontent.com/66493855/149137229-8dd8d3cc-2c9a-4425-9f7e-18320890911f.png)
![image](https://user-images.githubusercontent.com/66493855/149137323-fa8f0da3-07a8-42b9-9500-e5cabcb28aaa.png)
