### PR TITLE
fix: slider min max bug

### DIFF
--- a/src/components/slider-field/SliderField.tsx
+++ b/src/components/slider-field/SliderField.tsx
@@ -41,6 +41,8 @@ export const SliderField: React.FC<SliderFieldProps> = ({
             defaultValue={defaultValue}
             onValueChange={onChange}
             value={value}
+            min={min}
+            max={max}
             {...remainingProps}
           >
             <Slider.Steps min={min} max={max} steps={steps} />

--- a/src/components/slider/SliderSteps.tsx
+++ b/src/components/slider/SliderSteps.tsx
@@ -5,7 +5,7 @@ import { styled } from '~/stitches'
 import { Text } from '../text'
 
 export type SliderStepsType = {
-  steps: { label: string; value: number }[]
+  steps?: { label: string; value: number }[]
 }
 
 type SliderStepsProps = {
@@ -35,7 +35,7 @@ const getTransformValue = (value: number, min: number, max: number): number => {
 export const SliderSteps: React.FC<SliderStepsProps> = ({
   min,
   max,
-  steps
+  steps = []
 }) => {
   if (steps.length === 0) return null
 


### PR DESCRIPTION
### Description

The recent change to Slider that added the Slider.Steps component accidentally composed the SliderField in such a way that `min` and `max` values weren't being passed to the Slider. These have now been explicitly passed down.

Also changing steps property to properly be optional in order to remove typescript errors.