### PR TITLE
fix: dateinput type error

### DIFF
--- a/src/components/date-input/DateInput.tsx
+++ b/src/components/date-input/DateInput.tsx
@@ -11,7 +11,7 @@ import { Popover } from '../popover/Popover'
 import { DEFAULT_DATE_FORMAT } from './constants'
 import { useDate } from './use-date'
 
-export type DateInputProps = DayzedInterface &
+export type DateInputProps = Omit<DayzedInterface, 'onDateSelected'> &
   CalendarTranslationProps & {
     initialDate?: Date
     dateFormat?: string


### PR DESCRIPTION
### Description

Noticed a tiny bug on the DateInput (that for some reason doesn't show up in the sandbox) - `onDateSelected` was being set as a required prop on DateInput even though it's not used as a prop and is set explicitly within DateInput on the Calendar component. So I have used `Omit` to remove that key from `DayzedInterface` when it is used to construct DateInput's prop types.