### PR TITLE
fix: allow external change handler on date input

### DIFF
--- a/src/components/date-field/DateField.tsx
+++ b/src/components/date-field/DateField.tsx
@@ -13,7 +13,6 @@ type DateFieldProps = DateInputProps & {
   name: string
   prompt?: { link: string; label: string }
   validation?: ValidationOptions
-  handleChange?: (value: Date) => void
 }
 
 export const DateField: React.FC<DateFieldProps> = ({

--- a/src/components/date-field/DateField.tsx
+++ b/src/components/date-field/DateField.tsx
@@ -13,6 +13,7 @@ type DateFieldProps = DateInputProps & {
   name: string
   prompt?: { link: string; label: string }
   validation?: ValidationOptions
+  handleChange?: (value: Date) => void
 }
 
 export const DateField: React.FC<DateFieldProps> = ({

--- a/src/components/date-input/DateInput.mdx
+++ b/src/components/date-input/DateInput.mdx
@@ -79,3 +79,9 @@ You can also translate the internal labels for accessibility purposes. The `labe
   }}
 />
 ```
+
+If you need even finer control over what happens with the selected date, you can pass `onChange`, which takes a `Date` type as input.
+
+```tsx
+<DateInput onChange={(date) => doSomethingWith(date)} />
+```

--- a/src/components/date-input/DateInput.test.tsx
+++ b/src/components/date-input/DateInput.test.tsx
@@ -33,7 +33,7 @@ describe('DateInput component', () => {
 
   it('allows external behaviour to be passed down to the "onDateSelected" callback', async () => {
     const changeSpy = jest.fn()
-    render(<DateInput aria-label="test" handleChange={changeSpy} />)
+    render(<DateInput aria-label="test" onChange={changeSpy} />)
 
     const button = await screen.findByRole('button')
     fireEvent.click(button)

--- a/src/components/date-input/DateInput.test.tsx
+++ b/src/components/date-input/DateInput.test.tsx
@@ -1,5 +1,5 @@
 import { IdProvider } from '@radix-ui/react-id'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
@@ -9,7 +9,7 @@ describe('DateInput component', () => {
   it('renders', async () => {
     const { container } = render(
       <IdProvider>
-        <DateInput onDateSelected={() => null} aria-label="test" />
+        <DateInput aria-label="test" />
       </IdProvider>
     )
 
@@ -17,19 +17,29 @@ describe('DateInput component', () => {
   })
 
   it('has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <DateInput onDateSelected={() => null} aria-label="test" />
-    )
+    const { container } = render(<DateInput aria-label="test" />)
 
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('opens date picker when clicked', async () => {
-    render(<DateInput onDateSelected={() => null} aria-label="test" />)
+    render(<DateInput aria-label="test" />)
 
     const button = await screen.findByRole('button')
     fireEvent.click(button)
 
     expect(await screen.findByRole('dialog')).toBeVisible()
+  })
+
+  it('allows external behaviour to be passed down to the "onDateSelected" callback', async () => {
+    const changeSpy = jest.fn()
+    render(<DateInput aria-label="test" handleChange={changeSpy} />)
+
+    const button = await screen.findByRole('button')
+    fireEvent.click(button)
+
+    expect(await screen.findByRole('dialog')).toBeVisible()
+    fireEvent.click(screen.getByText('15'))
+    await waitFor(() => expect(changeSpy).toHaveBeenCalled())
   })
 })

--- a/src/components/date-input/DateInput.test.tsx
+++ b/src/components/date-input/DateInput.test.tsx
@@ -31,7 +31,7 @@ describe('DateInput component', () => {
     expect(await screen.findByRole('dialog')).toBeVisible()
   })
 
-  it('allows external behaviour to be passed down to the "onDateSelected" callback', async () => {
+  it('allows an external change handler to be passed to the component', async () => {
     const changeSpy = jest.fn()
     render(<DateInput aria-label="test" onChange={changeSpy} />)
 

--- a/src/components/date-input/DateInput.tsx
+++ b/src/components/date-input/DateInput.tsx
@@ -18,7 +18,7 @@ export type DateInputProps = Omit<DayzedInterface, 'onDateSelected'> &
     disabled?: boolean
     size?: 'sm' | 'md'
     revalidate?: () => Promise<boolean>
-    handleChange?: (value: Date) => void
+    onChange?: (value?: Date) => void
   }
 
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
@@ -37,7 +37,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         previous: 'Previous month'
       },
       revalidate,
-      handleChange,
+      onChange,
       ...remainingProps
     },
     ref
@@ -48,6 +48,18 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
     const refDateToday = React.useRef<HTMLButtonElement>(null)
     const refDateSelected = React.useRef<HTMLButtonElement>(null)
+
+    React.useEffect(() => {
+      let isMounted = true
+
+      if (isMounted) {
+        onChange?.(date)
+      }
+
+      return () => {
+        isMounted = false
+      }
+    }, [date, onChange])
 
     return (
       <Box css={{ position: 'relative' }}>
@@ -93,7 +105,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                 setCalendarOpen(false)
                 await setDate(date.date, false)
                 if (revalidate) revalidate()
-                handleChange?.(date.date)
               }}
               refDateToday={refDateToday}
               refDateSelected={refDateSelected}

--- a/src/components/date-input/DateInput.tsx
+++ b/src/components/date-input/DateInput.tsx
@@ -18,6 +18,7 @@ export type DateInputProps = Omit<DayzedInterface, 'onDateSelected'> &
     disabled?: boolean
     size?: 'sm' | 'md'
     revalidate?: () => Promise<boolean>
+    handleChange?: (value: Date) => void
   }
 
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
@@ -36,6 +37,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         previous: 'Previous month'
       },
       revalidate,
+      handleChange,
       ...remainingProps
     },
     ref
@@ -91,6 +93,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                 setCalendarOpen(false)
                 await setDate(date.date, false)
                 if (revalidate) revalidate()
+                handleChange?.(date.date)
               }}
               refDateToday={refDateToday}
               refDateSelected={refDateSelected}

--- a/src/components/date-input/DateInput.tsx
+++ b/src/components/date-input/DateInput.tsx
@@ -50,15 +50,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const refDateSelected = React.useRef<HTMLButtonElement>(null)
 
     React.useEffect(() => {
-      let isMounted = true
-
-      if (isMounted) {
-        onChange?.(date)
-      }
-
-      return () => {
-        isMounted = false
-      }
+      onChange?.(date)
     }, [date, onChange])
 
     return (


### PR DESCRIPTION
Description

The `DateInput` wasn't taking any external change handlers, so if you needed to do something with the set value, there was no reliable way. This adds an optional `handleChange` prop to the component, which gets called inside the `onDateSelected` callback.