### PR TITLE
feat: tab scroll percentage

### DIFF
--- a/src/components/tabs/Tabs.mdx
+++ b/src/components/tabs/Tabs.mdx
@@ -45,6 +45,8 @@ It also takes a `theme` prop that should either be "light" or "dark".
 The `Tabs.TriggerList` component simply holds the individual `Tabs.Trigger` components. It can also get custom styling via the `css` prop.
 `Tabs.TriggerList` will automatically show `<` & `>` buttons in case the content is overshooting the available space.
 
+The default scroll amount for the scroll buttons on the `Tabs.TriggerList` is 10% of the content width. You can set this to any percentage by setting, for example, `scrollPercentage={25}`.
+
 ## Tabs.Trigger
 
 The `Tabs.Trigger` component holds the content that will be displayed inside the button that the user would click in order to switch tabs. In can hold either a string, or some other component. It needs to be passed a `value` prop, that would be identical to the `value` prop passed to its corresponding `Tabs.Content` component.


### PR DESCRIPTION
### Description

Adding optional `scrollPercentage` to `Tabs.TriggerList`, so that the amount each button scrolls by can be set manually. Otherwise it now defaults to 10% instead of 25%, as I believe this was causing issues.

I also looked at the scroll behaviour, I believe there was an error in the scroll logic which was causing issues in certain cases. Also added a failsafe for the hiding of buttons that allowed for small pixel precision errors that appeared to be happening with large lists of tabs, and potentially exacerbated by the 25% instead of 10% issue above.

Everything looks the same and no API is broken, this will hopefully just fix some issues and add an option for those who want it.