### PR TITLE
feat: button neutral theme

### DIFF
--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -13,7 +13,7 @@ It adds default styling and the `css` prop. By default `primary` theme is displa
 
 ## Themes
 
-These are the available `themes` for the `Button` component: `primary` (default), `success`, `warning`, `danger`
+These are the available `themes` for the `Button` component: `primary` (default), `success`, `warning`, `danger`, and `neutral`.
 
 ```tsx preview
 <>
@@ -21,12 +21,13 @@ These are the available `themes` for the `Button` component: `primary` (default)
   <Button theme="success">Success</Button>
   <Button theme="warning">Warning</Button>
   <Button theme="danger">Danger</Button>
+  <Button theme="neutral">Danger</Button>
 </>
 ```
 
 ## Appearance
 
-There two options for the `appearance` property: `solid` and `outline`. These are the available `outline` variations for the `primary` theme.
+There two options for the `appearance` property: `solid` and `outline`. There are the available `outline` variations for the `primary` and `neutral` themes.
 
 ```tsx preview
 <Button appearance="outline">Primary</Button>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,5 +1,5 @@
 import type * as Stitches from '@stitches/react'
-import { darken } from 'polished'
+import { darken, opacify } from 'polished'
 import * as React from 'react'
 
 import { Box } from '~/components/box'
@@ -74,7 +74,8 @@ export const StyledButton = styled('button', {
       secondary: {},
       success: {},
       warning: {},
-      danger: {}
+      danger: {},
+      neutral: {}
     },
     appearance: {
       solid: {},
@@ -153,6 +154,16 @@ export const StyledButton = styled('button', {
       theme: 'danger',
       appearance: 'solid',
       css: getButtonSolidVariant('$danger', '$dangerMid', '$dangerDark')
+    },
+    {
+      theme: 'neutral',
+      appearance: 'solid',
+      css: getButtonSolidVariant(
+        'white',
+        opacify(-0.1, 'white'),
+        opacify(-0.25, 'white'),
+        '$primary'
+      )
     },
     {
       theme: 'primary',

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -169,6 +169,15 @@ export const StyledButton = styled('button', {
       theme: 'primary',
       appearance: 'outline',
       css: getButtonOutlineVariant('$primary', '$primaryMid', '$primaryDark')
+    },
+    {
+      theme: 'neutral',
+      appearance: 'outline',
+      css: getButtonOutlineVariant(
+        'white',
+        opacify(-0.2, 'white'),
+        opacify(-0.35, 'white')
+      )
     }
   ]
 })


### PR DESCRIPTION
### Description

In the parent portal we have a lot of white buttons that are currently not handled by theme. As such, there is inconsistency between their active and hover states because different people have added them at different times. We would like to consolidate this use case into a new button theme, Neutral.

### Screenshots

![image](https://user-images.githubusercontent.com/66493855/154306826-35a6e6b2-e7a9-4059-9452-f1063351b359.png)

https://user-images.githubusercontent.com/66493855/154307177-23a43508-6a19-45b5-ad55-5e6230f1dab4.mov

Outline variant:
![image](https://user-images.githubusercontent.com/66493855/154317152-f2c61c0c-76c6-41fc-b7e5-c8b79b67fbe4.png)
