### PR TITLE
fix: Stepper navigating outside of bullets range

### DIFF
--- a/src/components/stepper/Stepper.test.tsx
+++ b/src/components/stepper/Stepper.test.tsx
@@ -121,4 +121,31 @@ describe('Stepper', () => {
     fireEvent.click(screen.getByText('3'))
     expect(props.onStepChange).toHaveBeenCalledWith(2)
   })
+
+  it("doesn't allow navigating out of the bullets range when no onComplete is passed", () => {
+    render(
+      <Stepper allowSkip stepCount={3} onStepChange={jest.fn()}>
+        <Stepper.StepBack label={() => 'Back'} />
+        <Stepper.Steps />
+        <Stepper.StepForward label={() => 'Next'} />
+      </Stepper>
+    )
+    fireEvent.click(screen.getByText('Next'))
+    expect(screen.getByLabelText('step 2')).toHaveAttribute(
+      'aria-current',
+      'step'
+    )
+
+    fireEvent.click(screen.getByText('Next'))
+    expect(screen.getByLabelText('step 3')).toHaveAttribute(
+      'aria-current',
+      'step'
+    )
+
+    fireEvent.click(screen.getByText('Next'))
+    expect(screen.getByLabelText('step 3')).toHaveAttribute(
+      'aria-current',
+      'step'
+    )
+  })
 })

--- a/src/components/stepper/stepper-context/StepperContext.tsx
+++ b/src/components/stepper/stepper-context/StepperContext.tsx
@@ -34,7 +34,9 @@ export const StepperProvider: React.FC<StepperProviderProps> = ({
     if (onComplete && activeStep === stepCount - 1) {
       return onComplete()
     }
-    setActiveStep((current) => current + 1)
+    if (activeStep < stepCount - 1) {
+      return setActiveStep((current) => current + 1)
+    }
   }
 
   const goToPreviousStep = () => {


### PR DESCRIPTION
When `onComplete` isn't getting passed into the `Stepper` root component, the user is able to navigate outside the range of the bullets using the `StepForward` button.