### PR TITLE
Chore: add new action to lint and format on merge into main

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,35 @@
+name: auto-fix
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  auto-fix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup environment
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run ESLint
+        run: yarn lint
+
+      - name: Run Prettier
+        run: yarn format
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply auto-fix changes

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Apply auto-fix changes
+          commit_message: 'chore: apply auto-fix changes'


### PR DESCRIPTION
Added a new "Autofix" workflow to run ESLint and Prettier on merge into `main`, the commit will appear as "Apply auto-fix changes" co-authored by a Github actions user and the PR (or last commit) author

![Screenshot 2022-02-19 at 10 41 02](https://user-images.githubusercontent.com/3226804/154797500-11fe3068-6718-4266-bb59-7a6f7ccd7d58.png)
