### PR TITLE
Fix stepper types

### DIFF
--- a/src/components/stepper/StepperStepBack.tsx
+++ b/src/components/stepper/StepperStepBack.tsx
@@ -5,7 +5,7 @@ import { useStepper } from './stepper-context/StepperContext'
 import { IStepperNavigateProps } from './types'
 
 export const StepperStepBack: React.FC<
-  IStepperNavigateProps & Partial<React.ComponentProps<typeof Button>>
+  IStepperNavigateProps & Omit<React.ComponentProps<typeof Button>, 'children'>
 > = ({ label, children, ...rest }) => {
   const { activeStep, goToPreviousStep } = useStepper()
   return (

--- a/src/components/stepper/StepperStepBack.tsx
+++ b/src/components/stepper/StepperStepBack.tsx
@@ -5,7 +5,7 @@ import { useStepper } from './stepper-context/StepperContext'
 import { IStepperNavigateProps } from './types'
 
 export const StepperStepBack: React.FC<
-  IStepperNavigateProps & React.ComponentProps<typeof Button>
+  IStepperNavigateProps & Partial<React.ComponentProps<typeof Button>>
 > = ({ label, children, ...rest }) => {
   const { activeStep, goToPreviousStep } = useStepper()
   return (
@@ -16,7 +16,7 @@ export const StepperStepBack: React.FC<
       disabled={activeStep === 0}
       onClick={goToPreviousStep}
     >
-      {children || label(activeStep)}
+      {children || label?.(activeStep)}
     </Button>
   )
 }

--- a/src/components/stepper/StepperStepForward.tsx
+++ b/src/components/stepper/StepperStepForward.tsx
@@ -5,13 +5,13 @@ import { useStepper } from './stepper-context/StepperContext'
 import { IStepperNavigateProps } from './types'
 
 export const StepperStepForward: React.FC<
-  IStepperNavigateProps & React.ComponentProps<typeof Button>
+  IStepperNavigateProps & Partial<React.ComponentProps<typeof Button>>
 > = ({ label, children, ...rest }) => {
   const { goToNextStep, activeStep } = useStepper()
 
   return (
     <Button size="sm" {...rest} onClick={goToNextStep} css={{ ml: 'auto' }}>
-      {children || label(activeStep)}
+      {children || label?.(activeStep)}
     </Button>
   )
 }

--- a/src/components/stepper/StepperStepForward.tsx
+++ b/src/components/stepper/StepperStepForward.tsx
@@ -5,7 +5,7 @@ import { useStepper } from './stepper-context/StepperContext'
 import { IStepperNavigateProps } from './types'
 
 export const StepperStepForward: React.FC<
-  IStepperNavigateProps & Partial<React.ComponentProps<typeof Button>>
+  IStepperNavigateProps & Omit<React.ComponentProps<typeof Button>, 'children'>
 > = ({ label, children, ...rest }) => {
   const { goToNextStep, activeStep } = useStepper()
 

--- a/src/components/stepper/types.ts
+++ b/src/components/stepper/types.ts
@@ -23,5 +23,5 @@ export interface IStepperProps {
 }
 
 export interface IStepperNavigateProps {
-  label: (currentStep?: number) => string
+  label?: (currentStep?: number) => string
 }


### PR DESCRIPTION
With the initial release, the Stepper component's types had the `StepNext` and `StepForward` require a `label` prop, which is actually optional. Also, because we pull in the `Button` component's props, `children` was also required, when in fact it's optional.

