### PR TITLE
feat: grid max item size

### DIFF
--- a/src/components/grid/Grid.mdx
+++ b/src/components/grid/Grid.mdx
@@ -16,3 +16,13 @@ The `gap` prop specifies the distance between items in the grid using the theme'
   ))}
 </Grid>
 ```
+
+Should you need further control of the size of grid items, you can pass `maxItemSize`, which accepts the same value types as `minItemSize`. This is useful when you wish to control the width of items that may or may not fill the container width based on content, so they do not stretch to fill the width.
+
+```tsx
+<Grid minItemSize="10em" maxItemSize="10em" gap="3" css={{ width: '100%' }}>
+  {Array.from(Array(3)).map((_, i) => (
+    <Box key={i} css={{ bg: '$primary', height: '10em' }} />
+  ))}
+</Grid>
+```

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -30,18 +30,20 @@ const GridContainer = styled('div', {
 
 type GridProps = React.ComponentProps<typeof GridContainer> & {
   minItemSize: string
+  maxItemSize?: string
 }
 
 export const Grid: React.FC<GridProps> = ({
   css,
   gap = 2,
   minItemSize,
+  maxItemSize = '1fr',
   ...remainingProps
 }) => (
   <GridContainer
     css={{
       ...(css as any),
-      gridTemplateColumns: `repeat(auto-fit, minmax(${minItemSize}, 1fr))`
+      gridTemplateColumns: `repeat(auto-fit, minmax(${minItemSize}, ${maxItemSize}))`
     }}
     gap={gap}
     {...remainingProps}


### PR DESCRIPTION
### Description

When using the grid earlier I noticed that you can't set a max item size. Because of the way the component is composed setting css `gridTemplateColumns` manually is impossible, and we hardcode the max size of the `minmax` function. I know. a lot of use cases want it to be `1fr`, but I needed the option earlier and didn't have it, so have added `maxItemSize` as an optional prop. 

### Screenshots

With maxItemSize:
![image](https://user-images.githubusercontent.com/66493855/155568824-20635dcc-588d-4944-b0b0-00936fb40e8c.png)

Without maxItemSize:
![image](https://user-images.githubusercontent.com/66493855/155568903-4e5b3d47-8f6b-4c13-bd64-04a8bcef7ab0.png)