### PR TITLE
fix: separator colours and skipping behaviour

### DIFF
--- a/src/components/stepper/Stepper.mdx
+++ b/src/components/stepper/Stepper.mdx
@@ -23,7 +23,7 @@ The root `Stepper` component must be passed `stepCount` as a number in order to 
 </Stepper>
 ```
 
-The root `Stepper` component can also take an `allowSkip` prop that allows the user to navigate by clicking the actual bullets.
+The root `Stepper` component can also take an `allowSkip` prop that allows the user to navigate by clicking the actual bullets. However, navigating by clicking a bullet is only possible if the user has already viewed it by using the `Next`/`Back` navigation buttons.
 
 Below is a more complex example that shows how to dynamically render the button labels, get the activeStep in order to potentially use it to determine what content to render based on the current position, and use an `onComplete` function to trigger custom behaviour when the user reaches the final step.
 

--- a/src/components/stepper/Stepper.mdx
+++ b/src/components/stepper/Stepper.mdx
@@ -23,7 +23,7 @@ The root `Stepper` component must be passed `stepCount` as a number in order to 
 </Stepper>
 ```
 
-The root `Stepper` component can also take an `allowSkip` prop that allows the user to navigate by clicking the actual bullets. However, navigating by clicking a bullet is only possible if the user has already viewed it by using the `Next`/`Back` navigation buttons.
+The root `Stepper` component can also take an `allowSkip` prop that allows the user to navigate by clicking the actual bullets. However, navigating by clicking a bullet is only possible if the user has already viewed it by using the `Next` button.
 
 Below is a more complex example that shows how to dynamically render the button labels, get the activeStep in order to potentially use it to determine what content to render based on the current position, and use an `onComplete` function to trigger custom behaviour when the user reaches the final step.
 

--- a/src/components/stepper/StepperSteps.tsx
+++ b/src/components/stepper/StepperSteps.tsx
@@ -37,12 +37,12 @@ const StyledBullet = styled(Flex, {
     separator: {
       normal: {
         '&:not(:last-child)::after': {
-          bg: '$tonal400'
+          bg: '$tonal50'
         }
       },
       highlight: {
         '&:not(:last-child)::after': {
-          bg: '$primary'
+          bg: '$primaryDark'
         }
       }
     }
@@ -58,6 +58,9 @@ export const StepperSteps: React.FC = () => {
     return 'normal'
   }
 
+  const getSeparatorState = (index: number) =>
+    index < Math.max(...viewedSteps) ? 'highlight' : 'normal'
+
   return (
     <Flex css={{ alignItems: 'center' }}>
       {steps.map((_, index) => {
@@ -65,12 +68,19 @@ export const StepperSteps: React.FC = () => {
           <StyledBullet
             key={`step_${index}`}
             as={allowSkip ? 'button' : 'div'}
-            onClick={() => (allowSkip ? goToStep(index) : undefined)}
+            onClick={() =>
+              allowSkip && viewedSteps.includes(index)
+                ? goToStep(index)
+                : undefined
+            }
             state={getBulletState(index)}
-            separator={index < activeStep ? 'highlight' : 'normal'}
+            separator={getSeparatorState(index)}
             aria-current={index === activeStep ? 'step' : undefined}
             aria-label={`step ${index + 1}`}
-            css={{ cursor: allowSkip ? 'pointer' : 'auto' }}
+            css={{
+              cursor:
+                allowSkip && viewedSteps.includes(index) ? 'pointer' : 'auto'
+            }}
           >
             {index + 1}
           </StyledBullet>

--- a/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
@@ -65,8 +65,8 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     color: white;
   }
 
-  .c-krQlAY-bUvtCt-separator-normal:not(:last-child)::after {
-    background: var(--colors-tonal400);
+  .c-krQlAY-iPHtVM-separator-normal:not(:last-child)::after {
+    background: var(--colors-tonal50);
   }
 
   .c-krQlAY-jdelko-state-normal {
@@ -162,19 +162,19 @@ exports[`Stepper renders the correct number of bullets 1`] = `
       <button
         aria-current="step"
         aria-label="step 1"
-        class="c-dhzjXW c-krQlAY c-krQlAY-lkRQpS-state-active c-krQlAY-bUvtCt-separator-normal c-dhzjXW-igsmDXe-css"
+        class="c-dhzjXW c-krQlAY c-krQlAY-lkRQpS-state-active c-krQlAY-iPHtVM-separator-normal c-dhzjXW-igsmDXe-css"
       >
         1
       </button>
       <button
         aria-label="step 2"
-        class="c-dhzjXW c-krQlAY c-krQlAY-jdelko-state-normal c-krQlAY-bUvtCt-separator-normal c-dhzjXW-igsmDXe-css"
+        class="c-dhzjXW c-krQlAY c-krQlAY-jdelko-state-normal c-krQlAY-iPHtVM-separator-normal c-dhzjXW-idGcKFW-css"
       >
         2
       </button>
       <button
         aria-label="step 3"
-        class="c-dhzjXW c-krQlAY c-krQlAY-jdelko-state-normal c-krQlAY-bUvtCt-separator-normal c-dhzjXW-igsmDXe-css"
+        class="c-dhzjXW c-krQlAY c-krQlAY-jdelko-state-normal c-krQlAY-iPHtVM-separator-normal c-dhzjXW-idGcKFW-css"
       >
         3
       </button>


### PR DESCRIPTION
Adjusted the colours of the separator lines and also the step skipping behaviour: 
* the user can only skip to a step if they previously viewed it
* the separator line will remain dark blue even if the user goes back to previous steps, as long as the bullet after it has been viewed

<img width="709" alt="Screenshot 2022-03-01 at 16 42 15" src="https://user-images.githubusercontent.com/9009155/156189557-4f73ecc1-c946-400a-a013-276b022ae1d4.png">
 
<img width="713" alt="Screenshot 2022-03-01 at 16 42 49" src="https://user-images.githubusercontent.com/9009155/156189664-d4d83c3e-be76-45a5-b77d-d85bee843cc2.png">

https://user-images.githubusercontent.com/9009155/156189838-a041d3a2-ee6b-4116-827b-65407351072d.mov


