### PR TITLE
Add ability to customize the StepperSteps container css

### DIFF
--- a/src/components/stepper/Stepper.mdx
+++ b/src/components/stepper/Stepper.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stepper
-component: Stepper, Stepper.StepBack, Stepper.StepForward
+component: Stepper, Stepper.StepBack, Stepper.StepForward, Stepper.Steps
 description: Stepper provides a bullet list of steps and forward/backwards navigation buttons.
 category: Navigation
 ---
@@ -11,7 +11,7 @@ category: Navigation
 
 `Stepper.StepForward` represents the forward navigation element. It can receive either a child text node or a `label` prop as a function that receives `activeStep` as an argument in order to possibly render different labels based on the current step the user is on.
 
-`Stepper.Steps` holds the actual bullet list.
+`Stepper.Steps` holds the actual bullet list. It can receive a `stepsWidth` prop as a string in order to customize the width of the container that holds all of the bullets.
 
 The root `Stepper` component must be passed `stepCount` as a number in order to display the desired number of bullet steps. It also takes `onStepChange` as a function that takes `activeStep` as an argument. This can be used to determine what content to display, based on the current step. It can also take `onComplete` as a function that gets called when the user clicks the `StepForward` button while on the last step.
 
@@ -37,7 +37,7 @@ Below is a more complex example that shows how to dynamically render the button 
   }
 >
   <Stepper.StepBack label={(activeStep) => 'Back'} />
-  <Stepper.Steps />
+  <Stepper.Steps width="200px" />
   <Stepper.StepForward
     label={(activeStep) => (activeStep === 2 ? 'Finish' : 'Next')}
   />

--- a/src/components/stepper/Stepper.mdx
+++ b/src/components/stepper/Stepper.mdx
@@ -11,7 +11,7 @@ category: Navigation
 
 `Stepper.StepForward` represents the forward navigation element. It can receive either a child text node or a `label` prop as a function that receives `activeStep` as an argument in order to possibly render different labels based on the current step the user is on.
 
-`Stepper.Steps` holds the actual bullet list. It can receive a `stepsWidth` prop as a string in order to customize the width of the container that holds all of the bullets.
+`Stepper.Steps` holds the actual bullet list. It can receive a `css` prop, allowing for full customization.
 
 The root `Stepper` component must be passed `stepCount` as a number in order to display the desired number of bullet steps. It also takes `onStepChange` as a function that takes `activeStep` as an argument. This can be used to determine what content to display, based on the current step. It can also take `onComplete` as a function that gets called when the user clicks the `StepForward` button while on the last step.
 
@@ -37,7 +37,7 @@ Below is a more complex example that shows how to dynamically render the button 
   }
 >
   <Stepper.StepBack label={(activeStep) => 'Back'} />
-  <Stepper.Steps width="200px" />
+  <Stepper.Steps css={{ width: '200px' }} />
   <Stepper.StepForward
     label={(activeStep) => (activeStep === 2 ? 'Finish' : 'Next')}
   />

--- a/src/components/stepper/StepperSteps.tsx
+++ b/src/components/stepper/StepperSteps.tsx
@@ -4,6 +4,7 @@ import { styled } from '~/stitches'
 
 import { Flex } from '../flex'
 import { useStepper } from './stepper-context/StepperContext'
+import { IStepperStepsProps } from './types'
 
 const StyledBullet = styled(Flex, {
   position: 'relative',
@@ -23,7 +24,6 @@ const StyledBullet = styled(Flex, {
   },
   '&:not(:last-child)::after': {
     content: '',
-    width: '$1',
     height: '1px',
     position: 'absolute',
     left: '$sizes$2'
@@ -49,7 +49,7 @@ const StyledBullet = styled(Flex, {
   }
 })
 
-export const StepperSteps: React.FC = () => {
+export const StepperSteps: React.FC<IStepperStepsProps> = ({ stepsWidth }) => {
   const { steps, goToStep, activeStep, viewedSteps, allowSkip } = useStepper()
 
   const getBulletState = (index: number) => {
@@ -62,7 +62,13 @@ export const StepperSteps: React.FC = () => {
     index < Math.max(...viewedSteps) ? 'highlight' : 'normal'
 
   return (
-    <Flex css={{ alignItems: 'center' }}>
+    <Flex
+      css={{
+        alignItems: 'center',
+        width: stepsWidth || 'unset',
+        justifyContent: 'space-between'
+      }}
+    >
       {steps.map((_, index) => {
         return (
           <StyledBullet
@@ -79,7 +85,14 @@ export const StepperSteps: React.FC = () => {
             aria-label={`step ${index + 1}`}
             css={{
               cursor:
-                allowSkip && viewedSteps.includes(index) ? 'pointer' : 'auto'
+                allowSkip && viewedSteps.includes(index) ? 'pointer' : 'auto',
+              '&:not(:last-child)::after': {
+                width: stepsWidth
+                  ? `calc((${stepsWidth} - ($2 * ${steps.length})) / ${
+                      steps.length - 1
+                    })`
+                  : '$1'
+              }
             }}
           >
             {index + 1}

--- a/src/components/stepper/StepperSteps.tsx
+++ b/src/components/stepper/StepperSteps.tsx
@@ -50,7 +50,7 @@ const StyledBullet = styled(Flex, {
 })
 
 export const StepperSteps: React.FC<IStepperStepsProps> = ({
-  stepsWidth,
+  css,
   ...rest
 }) => {
   const { steps, goToStep, activeStep, viewedSteps, allowSkip } = useStepper()
@@ -68,8 +68,8 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({
     <Flex
       css={{
         alignItems: 'center',
-        width: stepsWidth || 'unset',
-        justifyContent: 'space-between'
+        justifyContent: 'space-between',
+        ...css
       }}
       {...rest}
     >
@@ -91,8 +91,8 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({
               cursor:
                 allowSkip && viewedSteps.includes(index) ? 'pointer' : 'auto',
               '&:not(:last-child)::after': {
-                width: stepsWidth
-                  ? `calc((${stepsWidth} - ($2 * ${steps.length})) / ${
+                width: css?.width
+                  ? `calc((${css.width} - ($2 * ${steps.length})) / ${
                       steps.length - 1
                     })`
                   : '$1'

--- a/src/components/stepper/StepperSteps.tsx
+++ b/src/components/stepper/StepperSteps.tsx
@@ -49,7 +49,10 @@ const StyledBullet = styled(Flex, {
   }
 })
 
-export const StepperSteps: React.FC<IStepperStepsProps> = ({ stepsWidth }) => {
+export const StepperSteps: React.FC<IStepperStepsProps> = ({
+  stepsWidth,
+  ...rest
+}) => {
   const { steps, goToStep, activeStep, viewedSteps, allowSkip } = useStepper()
 
   const getBulletState = (index: number) => {
@@ -68,6 +71,7 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({ stepsWidth }) => {
         width: stepsWidth || 'unset',
         justifyContent: 'space-between'
       }}
+      {...rest}
     >
       {steps.map((_, index) => {
         return (

--- a/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     display: flex;
   }
 
-  .c-krQlAY {
+  .c-dJecyp {
     position: relative;
     padding: var(--space-2);
     justify-content: center;
@@ -38,13 +38,12 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     font-size: var(--fontSizes-sm);
   }
 
-  .c-krQlAY:not(:first-child) {
+  .c-dJecyp:not(:first-child) {
     margin-left: var(--space-3);
   }
 
-  .c-krQlAY:not(:last-child)::after {
+  .c-dJecyp:not(:last-child)::after {
     content: "";
-    width: var(--sizes-1);
     height: 1px;
     position: absolute;
     left: var(--sizes-2);
@@ -60,16 +59,16 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     padding-right: var(--space-4);
   }
 
-  .c-krQlAY-lkRQpS-state-active {
+  .c-dJecyp-lkRQpS-state-active {
     background: var(--colors-primary);
     color: white;
   }
 
-  .c-krQlAY-iPHtVM-separator-normal:not(:last-child)::after {
+  .c-dJecyp-iPHtVM-separator-normal:not(:last-child)::after {
     background: var(--colors-tonal50);
   }
 
-  .c-krQlAY-jdelko-state-normal {
+  .c-dJecyp-jdelko-state-normal {
     background: var(--colors-tonal50);
     color: var(--colors-tonal400);
   }
@@ -127,20 +126,30 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     grid-template-columns: 1fr auto 1fr;
   }
 
-  .c-dhzjXW-ijroWjL-css {
+  .c-dhzjXW-igRvUEk-css {
     align-items: center;
+    width: unset;
+    justify-content: space-between;
   }
 
-  .c-dhzjXW-idGcKFW-css {
+  .c-dhzjXW-icnQKYw-css {
     cursor: auto;
+  }
+
+  .c-dhzjXW-icnQKYw-css:not(:last-child)::after {
+    width: var(--sizes-1);
   }
 
   .c-fkUJsw-icKSZB-css {
     margin-left: auto;
   }
 
-  .c-dhzjXW-igsmDXe-css {
+  .c-dhzjXW-ifdDoaQ-css {
     cursor: pointer;
+  }
+
+  .c-dhzjXW-ifdDoaQ-css:not(:last-child)::after {
+    width: var(--sizes-1);
   }
 }
 
@@ -157,24 +166,24 @@ exports[`Stepper renders the correct number of bullets 1`] = `
       Back
     </button>
     <div
-      class="c-dhzjXW c-dhzjXW-ijroWjL-css"
+      class="c-dhzjXW c-dhzjXW-igRvUEk-css"
     >
       <button
         aria-current="step"
         aria-label="step 1"
-        class="c-dhzjXW c-krQlAY c-krQlAY-lkRQpS-state-active c-krQlAY-iPHtVM-separator-normal c-dhzjXW-igsmDXe-css"
+        class="c-dhzjXW c-dJecyp c-dJecyp-lkRQpS-state-active c-dJecyp-iPHtVM-separator-normal c-dhzjXW-ifdDoaQ-css"
       >
         1
       </button>
       <button
         aria-label="step 2"
-        class="c-dhzjXW c-krQlAY c-krQlAY-jdelko-state-normal c-krQlAY-iPHtVM-separator-normal c-dhzjXW-idGcKFW-css"
+        class="c-dhzjXW c-dJecyp c-dJecyp-jdelko-state-normal c-dJecyp-iPHtVM-separator-normal c-dhzjXW-icnQKYw-css"
       >
         2
       </button>
       <button
         aria-label="step 3"
-        class="c-dhzjXW c-krQlAY c-krQlAY-jdelko-state-normal c-krQlAY-iPHtVM-separator-normal c-dhzjXW-idGcKFW-css"
+        class="c-dhzjXW c-dJecyp c-dJecyp-jdelko-state-normal c-dJecyp-iPHtVM-separator-normal c-dhzjXW-icnQKYw-css"
       >
         3
       </button>

--- a/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
@@ -126,9 +126,8 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     grid-template-columns: 1fr auto 1fr;
   }
 
-  .c-dhzjXW-igRvUEk-css {
+  .c-dhzjXW-ieSUmSB-css {
     align-items: center;
-    width: unset;
     justify-content: space-between;
   }
 
@@ -166,7 +165,7 @@ exports[`Stepper renders the correct number of bullets 1`] = `
       Back
     </button>
     <div
-      class="c-dhzjXW c-dhzjXW-igRvUEk-css"
+      class="c-dhzjXW c-dhzjXW-ieSUmSB-css"
     >
       <button
         aria-current="step"

--- a/src/components/stepper/types.ts
+++ b/src/components/stepper/types.ts
@@ -1,3 +1,5 @@
+import { CSS } from '~/stitches'
+
 export type Context = {
   steps: unknown[]
   goToPreviousStep: () => void
@@ -27,5 +29,6 @@ export interface IStepperNavigateProps {
 }
 
 export interface IStepperStepsProps {
+  css?: CSS
   stepsWidth?: string
 }

--- a/src/components/stepper/types.ts
+++ b/src/components/stepper/types.ts
@@ -25,3 +25,7 @@ export interface IStepperProps {
 export interface IStepperNavigateProps {
   label?: (currentStep?: number) => string
 }
+
+export interface IStepperStepsProps {
+  stepsWidth?: string
+}


### PR DESCRIPTION
By default, the Stepper.Steps component had all the spacing and dimensions hardcoded, meaning that if you had a small number of bullets on a large screen, these would gather to center of the screen, leaving a lot of empty space between them and the Back/Next buttons. 

We needed a way to make the container's width dynamic and also make sure the separator lines between bullets are spaced and sized accordingly.

Screenshots:
Before:
<img width="1430" alt="Screenshot 2022-03-07 at 15 58 03" src="https://user-images.githubusercontent.com/9009155/157048103-77a5e760-ec46-4ce9-8619-6e81e1185851.png">

After:
<img width="1432" alt="Screenshot 2022-03-07 at 15 59 27" src="https://user-images.githubusercontent.com/9009155/157048230-472146fb-344c-4188-ba5b-87241b400884.png">


