### PR TITLE
fix: add compound variant for outline secondary buttons

### DIFF
--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -18,6 +18,7 @@ These are the available `themes` for the `Button` component: `primary` (default)
 ```tsx preview
 <>
   <Button>Primary</Button>
+  <Button theme="secondary'>Secondary</Button>
   <Button theme="success">Success</Button>
   <Button theme="warning">Warning</Button>
   <Button theme="danger">Danger</Button>

--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -13,7 +13,7 @@ It adds default styling and the `css` prop. By default `primary` theme is displa
 
 ## Themes
 
-These are the available `themes` for the `Button` component: `primary` (default), `success`, `warning`, `danger`, and `neutral`.
+These are the available `themes` for the `Button` component: `primary` (default), `secondary`, `success`, `warning`, `danger`, and `neutral`.
 
 ```tsx preview
 <>

--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -28,7 +28,7 @@ These are the available `themes` for the `Button` component: `primary` (default)
 
 ## Appearance
 
-There two options for the `appearance` property: `solid` and `outline`. There are the available `outline` variations for the `primary`, `secondary` and `neutral` themes.
+There are two options for the `appearance` property: `solid` and `outline`. There are the available `outline` variations for the `primary`, `secondary` and `neutral` themes.
 
 ```tsx preview
 <Button appearance="outline">Primary</Button>

--- a/src/components/button/Button.mdx
+++ b/src/components/button/Button.mdx
@@ -28,7 +28,7 @@ These are the available `themes` for the `Button` component: `primary` (default)
 
 ## Appearance
 
-There two options for the `appearance` property: `solid` and `outline`. There are the available `outline` variations for the `primary` and `neutral` themes.
+There two options for the `appearance` property: `solid` and `outline`. There are the available `outline` variations for the `primary`, `secondary` and `neutral` themes.
 
 ```tsx preview
 <Button appearance="outline">Primary</Button>

--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -80,6 +80,16 @@ describe(`Button component`, () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders a outline button with secondary theme', async () => {
+    const { container } = render(
+      <Button appearance="outline" theme="secondary" {...props}>
+        BUTTON
+      </Button>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
   it('renders a disabled warning outline button - has no programmatically detectable a11y issues', async () => {
     const { container } = render(
       <Button disabled appearance="outline" theme="warning" {...props}>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -178,6 +178,15 @@ export const StyledButton = styled('button', {
         opacify(-0.2, 'white'),
         opacify(-0.35, 'white')
       )
+    },
+    {
+      theme: 'secondary',
+      appearance: 'outline',
+      css: getButtonOutlineVariant(
+        '$primaryDark',
+        darken(0.05, theme.colors.primaryDark.value),
+        darken(0.1, theme.colors.primaryDark.value)
+      )
     }
   ]
 })

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -184,8 +184,8 @@ export const StyledButton = styled('button', {
       appearance: 'outline',
       css: getButtonOutlineVariant(
         '$primaryDark',
-        darken(0.05, theme.colors.primaryDark.value),
-        darken(0.1, theme.colors.primaryDark.value)
+        darken(0.1, theme.colors.primaryDark.value),
+        darken(0.15, theme.colors.primaryDark.value)
       )
     }
   ]

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -132,26 +132,26 @@ exports[`Button component Loading state renders a loading button 1`] = `
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv {
+  .c-fkUJsw-gRlFrS-cv {
     border: 1px solid;
     border-color: currentColor;
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv[disabled] {
+  .c-fkUJsw-gRlFrS-cv[disabled] {
     border-color: var(--colors-tonal400);
     color: var(--colors-tonal400);
     cursor: not-allowed;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
-  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):hover,
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):focus {
     text-decoration: none;
-    color: #0e278b;
+    color: #0b2074;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
-    color: #0b2074;
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):active {
+    color: #091a5c;
   }
 }
 
@@ -360,26 +360,26 @@ exports[`Button component renders a button with an icon 1`] = `
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv {
+  .c-fkUJsw-gRlFrS-cv {
     border: 1px solid;
     border-color: currentColor;
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv[disabled] {
+  .c-fkUJsw-gRlFrS-cv[disabled] {
     border-color: var(--colors-tonal400);
     color: var(--colors-tonal400);
     cursor: not-allowed;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
-  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):hover,
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):focus {
     text-decoration: none;
-    color: #0e278b;
+    color: #0b2074;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
-    color: #0b2074;
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):active {
+    color: #091a5c;
   }
 }
 
@@ -742,32 +742,32 @@ exports[`Button component renders a outline button with secondary theme 1`] = `
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv {
+  .c-fkUJsw-gRlFrS-cv {
     border: 1px solid;
     border-color: currentColor;
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv[disabled] {
+  .c-fkUJsw-gRlFrS-cv[disabled] {
     border-color: var(--colors-tonal400);
     color: var(--colors-tonal400);
     cursor: not-allowed;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
-  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):hover,
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):focus {
     text-decoration: none;
-    color: #0e278b;
+    color: #0b2074;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
-    color: #0b2074;
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):active {
+    color: #091a5c;
   }
 }
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-dlmocn-cv"
+    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gRlFrS-cv"
     type="button"
   >
     BUTTON
@@ -868,26 +868,26 @@ exports[`Button component renders a rounded button  1`] = `
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv {
+  .c-fkUJsw-gRlFrS-cv {
     border: 1px solid;
     border-color: currentColor;
     color: var(--colors-primaryDark);
   }
 
-  .c-fkUJsw-dlmocn-cv[disabled] {
+  .c-fkUJsw-gRlFrS-cv[disabled] {
     border-color: var(--colors-tonal400);
     color: var(--colors-tonal400);
     cursor: not-allowed;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
-  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):hover,
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):focus {
     text-decoration: none;
-    color: #0e278b;
+    color: #0b2074;
   }
 
-  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
-    color: #0b2074;
+  .c-fkUJsw-gRlFrS-cv:not([disabled]):active {
+    color: #091a5c;
   }
 }
 

--- a/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -131,6 +131,28 @@ exports[`Button component Loading state renders a loading button 1`] = `
   .c-fkUJsw-fSssiS-cv:not([disabled]):active {
     color: var(--colors-primaryDark);
   }
+
+  .c-fkUJsw-dlmocn-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
+  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+    text-decoration: none;
+    color: #0e278b;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
+    color: #0b2074;
+  }
 }
 
 @media  {
@@ -336,6 +358,28 @@ exports[`Button component renders a button with an icon 1`] = `
 
   .c-fkUJsw-fSssiS-cv:not([disabled]):active {
     color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
+  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+    text-decoration: none;
+    color: #0e278b;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
+    color: #0b2074;
   }
 }
 
@@ -624,6 +668,113 @@ exports[`Button component renders a outline button 1`] = `
 </div>
 `;
 
+exports[`Button component renders a outline button with secondary theme 1`] = `
+@media  {
+  .c-fkUJsw {
+    align-items: center;
+    background: unset;
+    border: unset;
+    border-radius: var(--radii-0);
+    cursor: pointer;
+    display: flex;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    justify-content: center;
+    padding: unset;
+    text-decoration: none;
+    transition: all 100ms ease-out;
+    white-space: nowrap;
+    width: max-content;
+  }
+}
+
+@media  {
+  .c-fkUJsw-elrwsr-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+    height: var(--sizes-4);
+    padding-left: var(--space-5);
+    padding-right: var(--space-5);
+  }
+}
+
+@media  {
+  .c-fkUJsw-gsycxF-cv {
+    background: var(--colors-primary);
+    color: white;
+  }
+
+  .c-fkUJsw-gsycxF-cv[disabled] {
+    background: var(--colors-tonal100);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-gsycxF-cv:not([disabled]):hover,
+  .c-fkUJsw-gsycxF-cv:not([disabled]):focus {
+    background: var(--colors-primaryMid);
+    color: white;
+  }
+
+  .c-fkUJsw-gsycxF-cv:not([disabled]):active {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-fSssiS-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primary);
+  }
+
+  .c-fkUJsw-fSssiS-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-fSssiS-cv:not([disabled]):hover,
+  .c-fkUJsw-fSssiS-cv:not([disabled]):focus {
+    text-decoration: none;
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fkUJsw-fSssiS-cv:not([disabled]):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
+  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+    text-decoration: none;
+    color: #0e278b;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
+    color: #0b2074;
+  }
+}
+
+<div>
+  <button
+    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-dlmocn-cv"
+    type="button"
+  >
+    BUTTON
+  </button>
+</div>
+`;
+
 exports[`Button component renders a rounded button  1`] = `
 @media  {
   .c-fkUJsw {
@@ -715,6 +866,28 @@ exports[`Button component renders a rounded button  1`] = `
 
   .c-fkUJsw-fSssiS-cv:not([disabled]):active {
     color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fkUJsw-dlmocn-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):hover,
+  .c-fkUJsw-dlmocn-cv:not([disabled]):focus {
+    text-decoration: none;
+    color: #0e278b;
+  }
+
+  .c-fkUJsw-dlmocn-cv:not([disabled]):active {
+    color: #0b2074;
   }
 }
 


### PR DESCRIPTION
Problem: 
```tsx
<Button theme="secondary" appearance="outline">Button</Button>
```
The above rendered a button with `color: rgb(0,0,0)` when it should have rendered one with `color: $primaryDark`

Reason: 
Compound Variant for this combination was absent. Hence it was falling back to default color

Fix: 
Adds a compound variant to remedy that

Preview :

https://user-images.githubusercontent.com/1936119/160368094-fe8cedb3-9aa3-4416-a491-93dbd9f09048.mov

 