### PR TITLE
AP-186: Create a file input

### DIFF
--- a/src/components/file-input/FileInput.mdx
+++ b/src/components/file-input/FileInput.mdx
@@ -1,0 +1,51 @@
+---
+title: File Input
+component: FileInput
+description: FileInput is the lowest-level input component for text and number types
+category: Form primitives
+---
+
+`FileInput` is a specialised input that allows file uploads.
+
+The 3 most important props it takes are: `onSelect`, `id` and `label`.
+
+`onSelect` is a callback that accepts the actual file selection (as a FileList), which gets updated after the user interacts with the file browser interface. The file selection can then be used in order to build a payload for something like a `POST` API call.
+
+Note: The actual action of uploading the file to a backend is not this input's responsability.
+
+`id` is really important because under the hood, the actual file input is hidden, while the visible element is a `label` with an `htmlFor` attribute that pairs with the hidden input via the `id` attribute. So make sure the `id` is unique.
+
+`label` is used to add text to the visible button.
+
+```jsx preview
+<FileInput
+  onSelect={(fileSelection) => console.log(fileSelection)}
+  id="unique-identifier"
+  label="Select file"
+/>
+```
+
+The input can also accept multiple files at once, via the `multiple` prop. Another important feature is the `accept` prop. This makes the input filter out unwanted file types and prevent the user from selecting them.
+
+```jsx preview
+<FileInput
+  onSelect={(fileSelection) => console.log(fileSelection)}
+  id="unique-identifier"
+  label="Select file"
+  multiple
+  accept="application/pdf"
+/>
+```
+
+You can also use our icon pack to add an icon next to the button text.
+
+```jsx preview
+<FileInput
+  onSelect={(fileSelection) => console.log(fileSelection)}
+  id="unique-identifier"
+  label="Select file"
+  multiple
+  accept="application/pdf"
+  icon={Upload}
+/>
+```

--- a/src/components/file-input/FileInput.test.tsx
+++ b/src/components/file-input/FileInput.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import * as React from 'react'
+
+import { FileInput } from '.'
+import { FileInputProps } from './FileInput'
+
+describe('FileInput component', () => {
+  const props: FileInputProps = {
+    onSelect: jest.fn(),
+    id: 'file-input-id',
+    label: 'Select file'
+  }
+
+  it('renders', async () => {
+    const { container } = render(<FileInput {...props} />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<FileInput {...props} />)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('uploads a file', async () => {
+    const file = new File(['random content'], 'upload.txt')
+    render(<FileInput {...props} />)
+
+    const input = screen.getByTestId('file-upload') as HTMLInputElement
+
+    await waitFor(() =>
+      fireEvent.change(input, {
+        target: { files: [file] }
+      })
+    )
+
+    expect(input.files[0].name).toBe('upload.txt')
+    expect(input.files.length).toBe(1)
+  })
+})

--- a/src/components/file-input/FileInput.tsx
+++ b/src/components/file-input/FileInput.tsx
@@ -1,0 +1,57 @@
+import { CSS } from '@stitches/react'
+import * as React from 'react'
+
+import { Button } from '../button'
+import { Icon } from '../icon'
+
+export type FileInputProps = {
+  onSelect: (selection: FileList) => void
+  id: string
+  label: string
+  accept?: string
+  multiple?: boolean
+  appearance?: string
+  css?: CSS
+  icon?: SVGSVGElement
+}
+
+export const FileInput: React.FC<FileInputProps> = ({
+  onSelect,
+  label,
+  accept,
+  multiple,
+  id,
+  appearance = 'outline',
+  icon,
+  css
+}) => {
+  const [fileSelection, setFileSelection] = React.useState<FileList>()
+
+  React.useEffect(() => {
+    onSelect(fileSelection)
+  }, [fileSelection, onSelect])
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFileSelection(event.target.files)
+  }
+
+  return (
+    <>
+      <input
+        type="file"
+        onChange={handleFileSelect}
+        accept={accept}
+        multiple={multiple}
+        id={id}
+        data-testid="file-upload"
+        hidden
+      />
+      <Button as="label" htmlFor={id} appearance={appearance} css={css}>
+        {icon && <Icon is={icon} />}
+        {label}
+      </Button>
+    </>
+  )
+}
+
+FileInput.displayName = 'FileInput'

--- a/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileInput component renders 1`] = `
+@media  {
+  .c-fkUJsw {
+    align-items: center;
+    background: unset;
+    border: unset;
+    border-radius: var(--radii-0);
+    cursor: pointer;
+    display: flex;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    justify-content: center;
+    padding: unset;
+    text-decoration: none;
+    transition: all 100ms ease-out;
+    white-space: nowrap;
+    width: max-content;
+  }
+}
+
+@media  {
+  .c-fkUJsw-elrwsr-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+    height: var(--sizes-4);
+    padding-left: var(--space-5);
+    padding-right: var(--space-5);
+  }
+}
+
+@media  {
+  .c-fkUJsw-fSssiS-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primary);
+  }
+
+  .c-fkUJsw-fSssiS-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-fSssiS-cv:not([disabled]):hover,
+  .c-fkUJsw-fSssiS-cv:not([disabled]):focus {
+    text-decoration: none;
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fkUJsw-fSssiS-cv:not([disabled]):active {
+    color: var(--colors-primaryDark);
+  }
+}
+
+<div>
+  <input
+    data-testid="file-upload"
+    hidden=""
+    id="file-input-id"
+    type="file"
+  />
+  <label
+    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-fSssiS-cv"
+    for="file-input-id"
+    type="button"
+  >
+    Select file
+  </label>
+</div>
+`;

--- a/src/components/file-input/index.ts
+++ b/src/components/file-input/index.ts
@@ -1,0 +1,1 @@
+export { FileInput } from './FileInput'


### PR DESCRIPTION
JIRA: https://atomlearningltd.atlassian.net/browse/AP-186

Description: 
Introduces an `input type="file"`.

Note: For this initial version, no drag-and-drop functionality has been implemented. This will be added in a future V2.

Screen recording:

https://user-images.githubusercontent.com/9009155/162151068-e8d74a71-61c7-4d2c-be11-121f3da2c308.mov
