### PR TITLE
feat(stepper): adding ability to override default forward behaviour

### DIFF
--- a/src/components/stepper/Stepper.mdx
+++ b/src/components/stepper/Stepper.mdx
@@ -9,7 +9,7 @@ category: Navigation
 
 `Stepper.StepBack` represents the backwards navigation element. It can receive either a child text node or a `label` prop as a function that receives `activeStep` as an argument in order to possibly render different labels based on the current step the user is on. It is automatically disabled while the user is viewing the first step.
 
-`Stepper.StepForward` represents the forward navigation element. It can receive either a child text node or a `label` prop as a function that receives `activeStep` as an argument in order to possibly render different labels based on the current step the user is on.
+`Stepper.StepForward` represents the forward navigation element. It can receive either a child text node or a `label` prop as a function that receives `activeStep` as an argument in order to possibly render different labels based on the current step the user is on. It can receive an onClick prop to override its default behaviour in case some logic or validation needs to be applied before going to the next step.
 
 `Stepper.Steps` holds the actual bullet list. It can receive a `css` prop, allowing for full customization.
 
@@ -41,5 +41,17 @@ Below is a more complex example that shows how to dynamically render the button 
   <Stepper.StepForward
     label={(activeStep) => (activeStep === 2 ? 'Finish' : 'Next')}
   />
+</Stepper>
+```
+
+Below is how to override the forward default behavior if some logic or validation need to be done before moving to the next step
+```tsx preview
+<Stepper stepCount={3}>
+  <Stepper.StepBack>Back</Stepper.StepBack>
+  <Stepper.Steps />
+  <Stepper.StepForward onClick={(goToNextStep) => {
+    // do something before
+    goToNextStep()
+  }}>Next</Stepper.StepForward>
 </Stepper>
 ```

--- a/src/components/stepper/Stepper.test.tsx
+++ b/src/components/stepper/Stepper.test.tsx
@@ -163,4 +163,20 @@ describe('Stepper', () => {
       'step'
     )
   })
+
+  it('allows overriding default forward event', () => {
+    const onClickFn = jest.fn()
+    render(
+      <Stepper {...props}>
+        <Stepper.StepBack label={() => 'Back'} />
+        <Stepper.Steps />
+        <Stepper.StepForward label={() => 'Next'} onClick={onClickFn} />
+      </Stepper>
+    )
+    // clear the onStepChange mock, because it's getting called with `0` when the component initializes
+    jest.clearAllMocks()
+    fireEvent.click(screen.getByText('Next'))
+    expect(props.onStepChange).not.toHaveBeenCalled()
+    expect(onClickFn).toHaveBeenCalled()
+  })
 })

--- a/src/components/stepper/StepperStepForward.tsx
+++ b/src/components/stepper/StepperStepForward.tsx
@@ -6,11 +6,18 @@ import { IStepperNavigateProps } from './types'
 
 export const StepperStepForward: React.FC<
   IStepperNavigateProps & Omit<React.ComponentProps<typeof Button>, 'children'>
-> = ({ label, children, ...rest }) => {
+> = ({ label, children, onClick, ...rest }) => {
   const { goToNextStep, activeStep } = useStepper()
 
+  const handleClick = () => {
+    if (onClick) {
+      return onClick(goToNextStep)
+    }
+    goToNextStep()
+  }
+
   return (
-    <Button size="sm" {...rest} onClick={goToNextStep} css={{ ml: 'auto' }}>
+    <Button size="sm" {...rest} onClick={handleClick} css={{ ml: 'auto' }}>
       {children || label?.(activeStep)}
     </Button>
   )

--- a/src/components/stepper/types.ts
+++ b/src/components/stepper/types.ts
@@ -26,6 +26,7 @@ export interface IStepperProps {
 
 export interface IStepperNavigateProps {
   label?: (currentStep?: number) => string
+  onClick?: (next: () => void) => void
 }
 
 export interface IStepperStepsProps {


### PR DESCRIPTION
JIRA: https://atomlearningltd.atlassian.net/browse/PP-160

Adding the ability to override the default `StepForward` click behaviour by passing a onClick function.
This will be useful when we need to add some logic or validation before moving to the next step or we want to prevent moving to the next step if something goes wrong.

