### PR TITLE
fix: file input using wrong icon

### DIFF
--- a/src/components/file-input/FileInput.tsx
+++ b/src/components/file-input/FileInput.tsx
@@ -1,18 +1,16 @@
-import { Download } from '@atom-learning/icons'
+import { Upload } from '@atom-learning/icons'
 import * as React from 'react'
 
-import { Button, StyledButton } from '../button'
+import { Button } from '../button'
 import { Icon } from '../icon'
 
-export type FileInputProps = React.FC<
-  typeof StyledButton & {
-    accept?: string
-    multiple?: boolean
-    onSelect: (selection: FileList | null) => void
-  }
->
+export type FileInputProps = React.ComponentProps<typeof Button> & {
+  onSelect: (selection: FileList | null) => void
+  accept?: string
+  multiple?: boolean
+}
 
-export const FileInput: FileInputProps = ({
+export const FileInput: React.FC<FileInputProps> = ({
   accept,
   children,
   multiple = false,
@@ -27,6 +25,8 @@ export const FileInput: FileInputProps = ({
 
   return (
     <Button as="label" {...rest}>
+      <Icon is={Upload} />
+      {children}
       <input
         type="file"
         onChange={handleFileSelect}
@@ -34,8 +34,6 @@ export const FileInput: FileInputProps = ({
         multiple={multiple}
         hidden
       />
-      <Icon is={Download} />
-      {children}
     </Button>
   )
 }

--- a/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -69,8 +69,8 @@ exports[`FileInput component renders 1`] = `
 }
 
 @media  {
-  .c-dbrbZt-idQfaGE-css {
-    margin-left: var(--space-3);
+  .c-dbrbZt-idQgHjC-css {
+    margin-right: var(--space-3);
     height: 20px;
     width: 20px;
   }
@@ -81,27 +81,27 @@ exports[`FileInput component renders 1`] = `
     class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gsycxF-cv"
     type="button"
   >
-    <input
-      hidden=""
-      type="file"
-    />
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-idQfaGE-css"
+      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-idQgHjC-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M12 3v13"
+        d="M12 4v13"
       />
       <polyline
-        points="7 12 12 17 17 12"
+        points="7 8 12 3 17 8"
       />
       <path
         d="M20 21H4"
       />
     </svg>
     Upload
+    <input
+      hidden=""
+      type="file"
+    />
   </label>
 </div>
 `;


### PR DESCRIPTION
Description

The FileInput uses the wrong icon alongside the button label (Download instead of Upload). Also, because the actual `input type="file"` is  currently the first nested child of the wrapping `Button`, making the `icon` the second child, the margin applied to the `icon` is to the left, instead of right , as we need it to be.

Screenshots:

Before:

<img width="868" alt="Screenshot 2022-04-13 at 17 19 24" src="https://user-images.githubusercontent.com/9009155/163201548-2f589345-f513-4c65-a89c-ff988553bbc5.png">

After:

<img width="1288" alt="Screenshot 2022-04-13 at 17 18 06" src="https://user-images.githubusercontent.com/9009155/163201338-607e5e06-58af-45df-b46b-3f193a3a7f20.png">
