### PR TITLE
fix: onSelect prop name clashing with the built-in React onSelect event

### DIFF
--- a/src/components/file-input/FileInput.test.tsx
+++ b/src/components/file-input/FileInput.test.tsx
@@ -7,7 +7,7 @@ import { FileInputProps } from './FileInput'
 
 describe('FileInput component', () => {
   const props: FileInputProps = {
-    onSelect: jest.fn()
+    onFileSelect: jest.fn()
   }
 
   it('renders', async () => {

--- a/src/components/file-input/FileInput.tsx
+++ b/src/components/file-input/FileInput.tsx
@@ -5,7 +5,7 @@ import { Button } from '../button'
 import { Icon } from '../icon'
 
 export type FileInputProps = React.ComponentProps<typeof Button> & {
-  onSelect: (selection: FileList | null) => void
+  onFileSelect: (selection: FileList | null) => void
   accept?: string
   multiple?: boolean
 }
@@ -14,13 +14,13 @@ export const FileInput: React.FC<FileInputProps> = ({
   accept,
   children,
   multiple = false,
-  onSelect,
+  onFileSelect,
   ...rest
 }) => {
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event.target
 
-    onSelect(files)
+    onFileSelect(files)
   }
 
   return (


### PR DESCRIPTION
Description:

The onSelect prop that the FileInput accepts conflicts with the React onSelect event, so when trying to pass a typed function, TS throws an error.