### PR TITLE
fix: bot token in correct workflow step

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
           ref: ${{ github.head_ref }}
 
       - name: Setup environment
@@ -32,5 +33,5 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+          
           commit_message: 'chore: apply auto-fix changes'


### PR DESCRIPTION
My previous attempt at setting up an automatic lint/formatting step tried to use the bot's access token in the wrong step: we have to use it at the checkout step!