### PR TITLE
fix: setting modal content and overlay z-index so it appears correctly on top of other components

### DIFF
--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -1,5 +1,5 @@
 import { Close as CloseIcon } from '@atom-learning/icons'
-import { Close, Content, Overlay } from '@radix-ui/react-dialog'
+import { Close, Content, Overlay, Portal } from '@radix-ui/react-dialog'
 import * as React from 'react'
 
 import { keyframes, styled } from '~/stitches'
@@ -11,6 +11,7 @@ import { Icon } from '../icon/Icon'
 const contentOnScreen = 'translate3d(-50%, -50%, 0)'
 const contentOffScreen = 'translate3d(-50%, 50vh, 0)'
 const modalOverlayId = 'modal_overlay'
+const DIALOG_Z_INDEX = 2147483646
 
 const slideIn = keyframes({
   '0%': { transform: contentOffScreen },
@@ -25,6 +26,8 @@ const StyledDialogOverlay = styled(Overlay, {
   backgroundColor: '$alpha600',
   inset: 0,
   position: 'fixed',
+  overflowY: 'auto',
+  zIndex: DIALOG_Z_INDEX,
   '@allowMotion': {
     '&[data-state="open"]': {
       animation: `${fadeIn} 250ms ease-out`
@@ -46,6 +49,7 @@ const StyledDialogContent = styled(Content, {
   position: 'fixed',
   top: '50%',
   transform: contentOnScreen,
+  zIndex: DIALOG_Z_INDEX,
   '&:focus': {
     outline: 'none'
   },
@@ -80,31 +84,32 @@ export const DialogContent: React.FC<DialogContentProps> = ({
   showCloseButton = true,
   ...remainingProps
 }) => (
-  <>
-    <StyledDialogOverlay id={modalOverlayId} />
-    <StyledDialogContent
-      size={size}
-      aria-label="Dialog"
-      onPointerDownOutside={(event) => {
-        const element = event.target as HTMLElement
-        if (element?.id !== modalOverlayId) {
-          event.preventDefault()
-        }
-      }}
-      {...remainingProps}
-    >
-      {showCloseButton && (
-        <ActionIcon
-          as={Close}
-          css={{ position: 'absolute', right: '$4', top: '$4' }}
-          label={closeDialogText}
-          size="lg"
-          theme="neutral"
-        >
-          <Icon is={CloseIcon} />
-        </ActionIcon>
-      )}
-      {children}
-    </StyledDialogContent>
-  </>
+  <Portal>
+    <StyledDialogOverlay id={modalOverlayId}>
+      <StyledDialogContent
+        size={size}
+        aria-label="Dialog"
+        onPointerDownOutside={(event) => {
+          const element = event.target as HTMLElement
+          if (element?.id !== modalOverlayId) {
+            event.preventDefault()
+          }
+        }}
+        {...remainingProps}
+      >
+        {showCloseButton && (
+          <ActionIcon
+            as={Close}
+            css={{ position: 'absolute', right: '$4', top: '$4' }}
+            label={closeDialogText}
+            size="lg"
+            theme="neutral"
+          >
+            <Icon is={CloseIcon} />
+          </ActionIcon>
+        )}
+        {children}
+      </StyledDialogContent>
+    </StyledDialogOverlay>
+  </Portal>
 )

--- a/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -2,28 +2,30 @@
 
 exports[`Dialog component opens the popover once trigger is clicked 1`] = `
 @media  {
-  .c-hSCvKD {
+  .c-gJNIBC {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
     position: fixed;
+    overflow-y: auto;
+    z-index: 2147483646;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hSCvKD[data-state="open"] {
+    .c-gJNIBC[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hSCvKD[data-state="closed"] {
+    .c-gJNIBC[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
 
-  .c-iZiUtw {
+  .c-cEjFpV {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -34,20 +36,21 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
+    z-index: 2147483646;
   }
 
-  .c-iZiUtw:focus {
+  .c-cEjFpV:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-iZiUtw[data-state="open"] {
+    .c-cEjFpV[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-iZiUtw[data-state="closed"] {
+    .c-cEjFpV[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
@@ -78,7 +81,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
 }
 
 @media  {
-  .c-iZiUtw-lgqbzh-size-sm {
+  .c-cEjFpV-lgqbzh-size-sm {
     width: 480px;
   }
 
@@ -131,7 +134,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
 <div
   aria-describedby="radix-5"
   aria-label="Dialog"
-  class="c-iZiUtw c-iZiUtw-lgqbzh-size-sm"
+  class="c-cEjFpV c-cEjFpV-lgqbzh-size-sm"
   data-state="open"
   id="radix-3"
   role="dialog"
@@ -174,28 +177,30 @@ exports[`Dialog component renders the trigger with the popover hidden by default
 
 exports[`Dialog component without close button renders 1`] = `
 @media  {
-  .c-hSCvKD {
+  .c-gJNIBC {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
     position: fixed;
+    overflow-y: auto;
+    z-index: 2147483646;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hSCvKD[data-state="open"] {
+    .c-gJNIBC[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hSCvKD[data-state="closed"] {
+    .c-gJNIBC[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
 
-  .c-iZiUtw {
+  .c-cEjFpV {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -206,20 +211,21 @@ exports[`Dialog component without close button renders 1`] = `
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
+    z-index: 2147483646;
   }
 
-  .c-iZiUtw:focus {
+  .c-cEjFpV:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-iZiUtw[data-state="open"] {
+    .c-cEjFpV[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-iZiUtw[data-state="closed"] {
+    .c-cEjFpV[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
@@ -250,7 +256,7 @@ exports[`Dialog component without close button renders 1`] = `
 }
 
 @media  {
-  .c-iZiUtw-lgqbzh-size-sm {
+  .c-cEjFpV-lgqbzh-size-sm {
     width: 480px;
   }
 
@@ -269,7 +275,7 @@ exports[`Dialog component without close button renders 1`] = `
 <div
   aria-describedby="radix-17"
   aria-label="Dialog"
-  class="c-iZiUtw c-iZiUtw-lgqbzh-size-sm"
+  class="c-cEjFpV c-cEjFpV-lgqbzh-size-sm"
   data-state="open"
   id="radix-15"
   role="dialog"


### PR DESCRIPTION
### Description
After bumping Radix Dialog version to 0.1.2 the Dialog component was being rendered behind some components
Related PR: https://github.com/Atom-Learning/components/pull/322

### Implementation
- Wrapping dialog into a Portal
- Setting z-index to dialog overlay and content
- Wrapping the dialog content into the overlay to allow scrolling

### Screenshots
![image](https://user-images.githubusercontent.com/11462265/163370484-3c211e14-2166-4477-bed2-5a3fddc722af.png)

