### PR TITLE
fix: allow on change handler in radio button field

### DIFF
--- a/src/components/radio-button-field/RadioButtonField.mdx
+++ b/src/components/radio-button-field/RadioButtonField.mdx
@@ -21,5 +21,5 @@ category: Form fields
 If you need to know when the radio group value changes, you can pass `onValueChange`, which takes a `string` type as input.
 
 ```tsx
-<RadioButtonField onValueChange={(value) => doSomethingWith(value)} />
+<RadioButtonField onValueChange={onChangeHandler} />
 ```

--- a/src/components/radio-button-field/RadioButtonField.mdx
+++ b/src/components/radio-button-field/RadioButtonField.mdx
@@ -17,3 +17,9 @@ category: Form fields
   </RadioButtonField>
 </Form>
 ```
+
+If you need to know when the radio group value changes, you can pass `onValueChange`, which takes a `string` type as input.
+
+```tsx
+<RadioButtonField onValueChange={(value) => doSomethingWith(value)} />
+```

--- a/src/components/radio-button-field/RadioButtonField.test.tsx
+++ b/src/components/radio-button-field/RadioButtonField.test.tsx
@@ -1,5 +1,6 @@
 import { IdProvider } from '@radix-ui/react-id'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
@@ -46,8 +47,7 @@ describe('RadioButtonField component', () => {
     const onValueChangeSpy = jest.fn()
     render(<ExampleRadioButtonField onValueChange={onValueChangeSpy} />)
 
-    const button = await screen.findByLabelText('2')
-    fireEvent.click(button)
+    userEvent.click(screen.getByLabelText('2'))
     await waitFor(() => {
       expect(onValueChangeSpy).toHaveBeenCalledTimes(1)
       expect(onValueChangeSpy).toHaveBeenCalledWith('2')

--- a/src/components/radio-button-field/RadioButtonField.test.tsx
+++ b/src/components/radio-button-field/RadioButtonField.test.tsx
@@ -1,15 +1,25 @@
 import { IdProvider } from '@radix-ui/react-id'
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
 import { Form } from '../'
 import { RadioButtonField } from '.'
 
-const ExampleRadioButtonField = () => (
+type ExampleRadioFieldProps = Omit<
+  React.ComponentProps<typeof RadioButtonField>,
+  'name' | 'label'
+>
+
+const ExampleRadioButtonField = (props: ExampleRadioFieldProps) => (
   <IdProvider>
     <Form>
-      <RadioButtonField name="example" defaultValue="1" label="Example options">
+      <RadioButtonField
+        name="example"
+        defaultValue="1"
+        label="Example options"
+        {...props}
+      >
         <RadioButtonField.Item label="1" value="1" />
         <RadioButtonField.Item label="2" value="2" />
       </RadioButtonField>
@@ -30,5 +40,17 @@ describe('RadioButtonField component', () => {
     const { container } = render(<ExampleRadioButtonField />)
 
     expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('allows an external on value change handler to be passed to the component', async () => {
+    const onValueChangeSpy = jest.fn()
+    render(<ExampleRadioButtonField onValueChange={onValueChangeSpy} />)
+
+    const button = await screen.findByLabelText('2')
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(onValueChangeSpy).toHaveBeenCalledTimes(1)
+      expect(onValueChangeSpy).toHaveBeenCalledWith('2')
+    })
   })
 })

--- a/src/components/radio-button-field/RadioButtonField.tsx
+++ b/src/components/radio-button-field/RadioButtonField.tsx
@@ -22,6 +22,7 @@ type RadioButtonFieldProps = {
   direction?: 'row' | 'column'
   description?: string
   validation?: ValidationOptions
+  onValueChange?: (value: string) => void
 }
 
 export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
@@ -34,7 +35,8 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
   description,
   label,
   name,
-  validation
+  validation,
+  onValueChange
 }) => {
   const { control } = useFormContext()
   const { error } = useFieldError(name)
@@ -60,7 +62,10 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
           <RadioButtonGroup
             direction={direction}
             defaultValue={defaultValue}
-            onValueChange={onChange}
+            onValueChange={(value) => {
+              onChange(value)
+              onValueChange?.(value)
+            }}
             value={value}
           >
             {children}


### PR DESCRIPTION
### Description

`RadioButtonField` does not expose a way of knowing when the value changes, it thus requires `watching` the form field to know when the value changes and then doing something. This PR adds an optional `onValueChange(value: string)` prop that will get called when a value in the radio group gets changed, allowing the caller to do something with that value.