### PR TITLE
fix: update stitches version to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@radix-ui/react-tooltip": "0.1.1",
     "@radix-ui/react-visually-hidden": "0.1.1",
     "@reach/combobox": "^0.16.1",
-    "@stitches/react": "^1.2.5",
+    "@stitches/react": "^1.2.8",
     "@types/react": "^17.0.30",
     "color2k": "^2.0.0",
     "dayjs": "^1.10.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,9 +2566,9 @@
     "@size-limit/file" "7.0.5"
 
 "@stitches/react@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.2.5.tgz#2353343c220f0c59ba388a26fdd9ff7962cb6031"
-  integrity sha512-95Wwjp5cvoYQjg616OBiHZM1PnIF51pnFQIgSPxPzS/xXBrer9sNO1tfpVfLYfOifvuotse2IFNbypJ92BXzvg==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.2.8.tgz#954f8008be8d9c65c4e58efa0937f32388ce3a38"
+  integrity sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==
 
 "@testing-library/dom@^7.28.1":
   version "7.29.4"


### PR DESCRIPTION
We had a weird bug where TS would complain that our styling objects didn't have a `length` property (see image below). Updating to the latest stiches seems to fix it.


![image](https://user-images.githubusercontent.com/21319237/167808302-497766cd-ff1b-47d7-9190-a24cf6eb293b.png)
