### PR TITLE
feat(form): added optional onError callback to handleSubmit

### DIFF
--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -36,7 +36,7 @@ const InputField = ({ label, name, validation }) => {
 
 ## Form submission
 
-To handle form submission onSubmit and optional onError callback props can be passed to Form. If there are any validation errors present onError will be called, in case of no errors the onSubmit will be called instead.
+To handle form submission, `onSubmit` and optional `onError` callback props can be passed to Form. If there are any validation errors present `onError` will be called, in case of no errors the `onSubmit` will be called instead.
 
 ## ValidationOptions
 

--- a/src/components/form/Form.mdx
+++ b/src/components/form/Form.mdx
@@ -34,6 +34,10 @@ const InputField = ({ label, name, validation }) => {
 }
 ```
 
+## Form submission
+
+To handle form submission onSubmit and optional onError callback props can be passed to Form. If there are any validation errors present onError will be called, in case of no errors the onSubmit will be called instead.
+
 ## ValidationOptions
 
 The `ValidationOptions` type provides preset logic for common validation and processing patterns. You can also define your own custom logic.

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import * as React from 'react'
@@ -190,5 +190,42 @@ describe(`Form component`, () => {
     expect(screen.getByRole('form').getAttribute('data-index-number')).toEqual(
       '12345'
     )
+  })
+
+  it('should call onError if there are erros in the form and onSubmit when the errors are gone', async () => {
+    const onSubmit = jest.fn()
+    const onError = jest.fn()
+
+    render(
+      <div>
+        <Form onSubmit={onSubmit} onError={onError}>
+          <InputField
+            name="test"
+            label="Test"
+            validation={{
+              required: 'Test is required',
+              minLength: {
+                value: 5,
+                message: 'Test needs length 5'
+              }
+            }}
+          />
+          <Button type="submit">Submit</Button>
+        </Form>
+      </div>
+    )
+    await waitFor(() => screen.getByRole('button').click())
+
+    expect(onError).toBeCalledTimes(1)
+    expect(onSubmit).toBeCalledTimes(0)
+
+    const input = screen.getByRole('textbox')
+
+    userEvent.type(input, 'test5')
+
+    await waitFor(() => screen.getByRole('button').click())
+
+    expect(onError).toBeCalledTimes(1)
+    expect(onSubmit).toBeCalledTimes(1)
   })
 })

--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -192,7 +192,7 @@ describe(`Form component`, () => {
     )
   })
 
-  it('should call onError if there are erros in the form and onSubmit when the errors are gone', async () => {
+  it('should call onError if there are errors in the form and onSubmit when the errors are gone', async () => {
     const onSubmit = jest.fn()
     const onError = jest.fn()
 

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -62,6 +62,7 @@ const FormContent: React.FC<FormContentProps> = ({
   formMethods,
   handleSubmit,
   onSubmit,
+  onError,
   children,
   ...remainingProps
 }) => (
@@ -69,7 +70,7 @@ const FormContent: React.FC<FormContentProps> = ({
     <StyledForm
       aria-label="form"
       {...remainingProps}
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleSubmit(onSubmit, onError)}
     >
       {children}
     </StyledForm>
@@ -80,6 +81,7 @@ export const Form: React.FC<FormProps> = ({
   children,
   defaultValues = {},
   onSubmit,
+  onError,
   validationMode = 'onBlur',
   render,
   persist,
@@ -102,6 +104,7 @@ export const Form: React.FC<FormProps> = ({
     formMethods,
     handleSubmit,
     onSubmit,
+    onError,
     ...remainingProps
   }
 

--- a/src/components/form/Form.types.ts
+++ b/src/components/form/Form.types.ts
@@ -28,14 +28,19 @@ export type PersistFormWrapperValues = {
 
 export type FormContentValues = {
   formMethods
-  handleSubmit: (data: any) => void | any
+  handleSubmit: (
+    submitHandler: (data: any) => void | any,
+    submitErrorHandler?: (errors: any) => void
+  ) => (e: any) => Promise<void>
   onSubmit: (data: any) => void | any
+  onError?: (errors: any) => void
   children: React.ReactNode | any
 }
 
 export type FormValues = {
   defaultValues?: { [key: string]: string | number }
   onSubmit: (data: any) => void | any
+  onError?: (errors: any) => void
   validationMode?: Mode
   persist?: PersistOptions
 } & (


### PR DESCRIPTION
Added optional onError callback prop that can be passed to Form component. React hook form passes both onError and onSubmit callback to handleSubmit function and calls onSubmit if there are no errors and onError instead if any errors are present.