### PR TITLE
fix: the ProgressBar now accepts absolute values and calculates the percentage based on them

### DIFF
--- a/src/components/progress-bar/ProgressBar.tsx
+++ b/src/components/progress-bar/ProgressBar.tsx
@@ -39,11 +39,17 @@ type ProgressBarProps = React.ComponentPropsWithoutRef<
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   value,
+  max = 100,
   theme = 'primary',
   ...remainingProps
 }) => (
-  <StyledProgressBar theme={theme} {...remainingProps}>
-    <StyledIndicator style={{ width: `${value}%` }} />
+  <StyledProgressBar value={value} max={max} theme={theme} {...remainingProps}>
+    <StyledIndicator
+      style={{
+        width: '100%',
+        transform: `translateX(-${100 - ((value || 0) / max) * 100}%)`
+      }}
+    />
   </StyledProgressBar>
 )
 

--- a/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/progress-bar/__snapshots__/ProgressBar.test.tsx.snap
@@ -32,16 +32,20 @@ exports[`ProgressBar component renders a progress bar using default props 1`] = 
     aria-label="label"
     aria-valuemax="100"
     aria-valuemin="0"
+    aria-valuenow="50"
+    aria-valuetext="50%"
     class="c-rTKYu c-rTKYu-ixnjYu-theme-primary"
     data-max="100"
-    data-state="indeterminate"
+    data-state="loading"
+    data-value="50"
     role="progressbar"
   >
     <div
       class="c-igejEK"
       data-max="100"
-      data-state="indeterminate"
-      style="width: 50%;"
+      data-state="loading"
+      data-value="50"
+      style="width: 100%; transform: translateX(-50%);"
     />
   </div>
 </div>
@@ -80,16 +84,20 @@ exports[`ProgressBar component renders a solid progress bar 1`] = `
     aria-label="label"
     aria-valuemax="100"
     aria-valuemin="0"
+    aria-valuenow="50"
+    aria-valuetext="50%"
     class="c-rTKYu c-rTKYu-ixnjYu-theme-primary"
     data-max="100"
-    data-state="indeterminate"
+    data-state="loading"
+    data-value="50"
     role="progressbar"
   >
     <div
       class="c-igejEK"
       data-max="100"
-      data-state="indeterminate"
-      style="width: 50%;"
+      data-state="loading"
+      data-value="50"
+      style="width: 100%; transform: translateX(-50%);"
     />
   </div>
 </div>


### PR DESCRIPTION
## Issue
- The progress bar only accepted a `value` from 1 to 100, because the `value` was directly used as a percentage for the indicator width.
- The `value` wasn't passed onto the `ProgressBar` component, which meant that the `aria-valuenow` attribute was never set. As a result, `data-state` was always `indeterminate`.

## Changes
- Passed `value` onto the `ProgressBar` component, so that the correct attributes are set.
- The indicator bar's size is now calculated based on `value` and `max`.
- Changed the transition from using `width` to `transition`. This should make it slightly smoother.