### PR TITLE
feat: table theme light

### DIFF
--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -129,10 +129,18 @@ The `Table` component by default renders with a slight border radius. If you wan
 <Table corners="square">...</Table>
 ```
 
-`Table.Header` accepts a theme prop, the current available options are `primary` and `primaryDark`. The default is `primaryDark`.
+`Table.Header` accepts a theme prop, the current available options are `primary`, `primaryDark`, and `neutral`. The default is `primaryDark`.
 
 ```tsx
 <Table>
-  <Table.Header theme="primary">...</Table.Header>
+  <Table.Header theme="neutral">...</Table.Header>
+</Table>
+```
+
+`Table.Body` accepts an appearance prop, which determines whether the rows will be alternate coloured or not. The current options are `alternating` and `simple`, and the default is `alternating`.
+
+```tsx
+<Table>
+  <Table.Body appearance="simple">...</Table.Body>
 </Table>
 ```

--- a/src/components/table/Table.mdx
+++ b/src/components/table/Table.mdx
@@ -129,15 +129,15 @@ The `Table` component by default renders with a slight border radius. If you wan
 <Table corners="square">...</Table>
 ```
 
-`Table.Header` accepts a theme prop, the current available options are `primary`, `primaryDark`, and `neutral`. The default is `primaryDark`.
+`Table.Header` accepts a theme prop, the current available options are `primary`, `primaryDark`, and `light`. The default is `primaryDark`.
 
 ```tsx
 <Table>
-  <Table.Header theme="neutral">...</Table.Header>
+  <Table.Header theme="light">...</Table.Header>
 </Table>
 ```
 
-`Table.Body` accepts an appearance prop, which determines whether the rows will be alternate coloured or not. The current options are `alternating` and `simple`, and the default is `alternating`.
+`Table.Body` accepts an appearance prop, which determines whether the rows will be alternate coloured or not. The current options are `striped` and `simple`, and the default is `striped`.
 
 ```tsx
 <Table>

--- a/src/components/table/TableBody.tsx
+++ b/src/components/table/TableBody.tsx
@@ -4,14 +4,14 @@ import { TableRow } from './TableRow'
 
 const StyledTableBody = styled('tbody', {
   variants: {
-    appearance: {
-      striped: {
+    striped: {
+      true: {
         [`${TableRow}`]: {
           '&:nth-child(odd)': { bg: 'white' },
           '&:nth-child(even)': { bg: '$tonal50' }
         }
       },
-      simple: {
+      false: {
         bg: 'white'
       }
     }
@@ -21,8 +21,8 @@ const StyledTableBody = styled('tbody', {
 type TableBodyProps = React.ComponentProps<typeof StyledTableBody>
 
 export const TableBody: React.FC<TableBodyProps> = ({
-  appearance = 'striped',
+  striped = true,
   ...rest
-}) => <StyledTableBody appearance={appearance} {...rest} />
+}) => <StyledTableBody striped={striped} {...rest} />
 
 TableBody.displayName = 'TableBody'

--- a/src/components/table/TableBody.tsx
+++ b/src/components/table/TableBody.tsx
@@ -5,7 +5,7 @@ import { TableRow } from './TableRow'
 const StyledTableBody = styled('tbody', {
   variants: {
     appearance: {
-      alternating: {
+      striped: {
         [`${TableRow}`]: {
           '&:nth-child(odd)': { bg: 'white' },
           '&:nth-child(even)': { bg: '$tonal50' }
@@ -21,7 +21,7 @@ const StyledTableBody = styled('tbody', {
 type TableBodyProps = React.ComponentProps<typeof StyledTableBody>
 
 export const TableBody: React.FC<TableBodyProps> = ({
-  appearance = 'alternating',
+  appearance = 'striped',
   ...rest
 }) => <StyledTableBody appearance={appearance} {...rest} />
 

--- a/src/components/table/TableBody.tsx
+++ b/src/components/table/TableBody.tsx
@@ -1,5 +1,28 @@
 import { styled } from '~/stitches'
+import * as React from 'react'
+import { TableRow } from './TableRow'
 
-export const TableBody = styled('tbody', {})
+const StyledTableBody = styled('tbody', {
+  variants: {
+    appearance: {
+      alternating: {
+        [`${TableRow}`]: {
+          '&:nth-child(odd)': { bg: 'white' },
+          '&:nth-child(even)': { bg: '$tonal50' }
+        }
+      },
+      simple: {
+        bg: 'white'
+      }
+    }
+  }
+})
+
+type TableBodyProps = React.ComponentProps<typeof StyledTableBody>
+
+export const TableBody: React.FC<TableBodyProps> = ({
+  appearance = 'alternating',
+  ...rest
+}) => <StyledTableBody appearance={appearance} {...rest} />
 
 TableBody.displayName = 'TableBody'

--- a/src/components/table/TableCell.tsx
+++ b/src/components/table/TableCell.tsx
@@ -9,13 +9,7 @@ export const TableCell = styled('td', {
   p: '$2 $3',
   textAlign: 'left',
   verticalAlign: 'middle',
-  '&:first-child': { fontWeight: 'bold' },
-  'tr:nth-child(odd) &': {
-    bg: 'white'
-  },
-  'tr:nth-child(even) &': {
-    bg: '$tonal50'
-  }
+  '&:first-child': { fontWeight: 'bold' }
 })
 
 TableCell.displayName = 'TableCell'

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -17,7 +17,7 @@ const StyledTableHeader = styled('thead', {
           bg: '$primaryDark'
         }
       },
-      neutral: {
+      light: {
         [`${TableHeaderCell}`]: {
           bg: '$tonal50',
           color: '$tonal600'

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -16,6 +16,12 @@ const StyledTableHeader = styled('thead', {
         [`${TableHeaderCell}`]: {
           bg: '$primaryDark'
         }
+      },
+      neutral: {
+        [`${TableHeaderCell}`]: {
+          bg: '$tonal50',
+          color: '$tonal600'
+        }
       }
     }
   }

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -63,11 +63,11 @@ exports[`Table component renders 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 }
@@ -97,7 +97,7 @@ exports[`Table component renders 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
     >
       <tr
         class="c-PJLV"
@@ -189,11 +189,11 @@ exports[`Table component renders with a themed header 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 
@@ -233,7 +233,7 @@ exports[`Table component renders with a themed header 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
     >
       <tr
         class="c-PJLV"
@@ -325,11 +325,11 @@ exports[`Table component renders with size set to lg 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 
@@ -365,7 +365,7 @@ exports[`Table component renders with size set to lg 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
     >
       <tr
         class="c-PJLV"
@@ -457,11 +457,11 @@ exports[`Table component renders with square corners 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 
@@ -497,7 +497,7 @@ exports[`Table component renders with square corners 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
     >
       <tr
         class="c-PJLV"

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Table component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ {
+  .c-cCZzXk {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
@@ -31,44 +31,44 @@ exports[`Table component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ:first-child {
+  .c-cCZzXk:first-child {
     font-weight: bold;
-  }
-
-  tr:nth-child(odd) .c-dOcJjJ {
-    background: white;
-  }
-
-  tr:nth-child(even) .c-dOcJjJ {
-    background: var(--colors-tonal50);
   }
 }
 
 @media  {
-  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
-  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
+  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
+  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
+  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
   .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
     background: var(--colors-primaryDark);
+  }
+
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+    background: white;
+  }
+
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+    background: var(--colors-tonal50);
   }
 }
 
@@ -81,7 +81,7 @@ exports[`Table component renders 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bgSNGZ-size-md c-cwQMhQ-gCFJjl-corners-round c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-UpMKF-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
@@ -97,13 +97,13 @@ exports[`Table component renders 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
     >
       <tr
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           This is text
         </td>
@@ -116,7 +116,7 @@ exports[`Table component renders 1`] = `
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           Footer 1
         </td>
@@ -146,7 +146,7 @@ exports[`Table component renders with a themed header 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ {
+  .c-cCZzXk {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
@@ -157,39 +157,31 @@ exports[`Table component renders with a themed header 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ:first-child {
+  .c-cCZzXk:first-child {
     font-weight: bold;
-  }
-
-  tr:nth-child(odd) .c-dOcJjJ {
-    background: white;
-  }
-
-  tr:nth-child(even) .c-dOcJjJ {
-    background: var(--colors-tonal50);
   }
 }
 
 @media  {
-  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
-  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
+  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
+  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
+  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
@@ -197,9 +189,17 @@ exports[`Table component renders with a themed header 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-cwQMhQ-lhkyUQ-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-lhkyUQ-size-lg .c-GSaiK,
-  .c-cwQMhQ-lhkyUQ-size-lg .c-hYjVQ {
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+    background: white;
+  }
+
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+    background: var(--colors-tonal50);
+  }
+
+  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
+  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
+  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
     height: var(--sizes-5);
   }
 
@@ -217,7 +217,7 @@ exports[`Table component renders with a themed header 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bgSNGZ-size-md c-cwQMhQ-gCFJjl-corners-round c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-UpMKF-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-gmYsCp-theme-primary"
@@ -233,13 +233,13 @@ exports[`Table component renders with a themed header 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
     >
       <tr
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           This is text
         </td>
@@ -252,7 +252,7 @@ exports[`Table component renders with a themed header 1`] = `
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           Footer 1
         </td>
@@ -282,7 +282,7 @@ exports[`Table component renders with size set to lg 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ {
+  .c-cCZzXk {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
@@ -293,39 +293,31 @@ exports[`Table component renders with size set to lg 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ:first-child {
+  .c-cCZzXk:first-child {
     font-weight: bold;
-  }
-
-  tr:nth-child(odd) .c-dOcJjJ {
-    background: white;
-  }
-
-  tr:nth-child(even) .c-dOcJjJ {
-    background: var(--colors-tonal50);
   }
 }
 
 @media  {
-  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
-  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
+  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
+  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
+  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
@@ -333,9 +325,17 @@ exports[`Table component renders with size set to lg 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-cwQMhQ-lhkyUQ-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-lhkyUQ-size-lg .c-GSaiK,
-  .c-cwQMhQ-lhkyUQ-size-lg .c-hYjVQ {
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+    background: white;
+  }
+
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+    background: var(--colors-tonal50);
+  }
+
+  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
+  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
+  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
     height: var(--sizes-5);
   }
 }
@@ -349,7 +349,7 @@ exports[`Table component renders with size set to lg 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-lhkyUQ-size-lg c-cwQMhQ-gCFJjl-corners-round c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-goJwcl-size-lg c-cwQMhQ-UpMKF-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
@@ -365,13 +365,13 @@ exports[`Table component renders with size set to lg 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
     >
       <tr
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           This is text
         </td>
@@ -384,7 +384,7 @@ exports[`Table component renders with size set to lg 1`] = `
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           Footer 1
         </td>
@@ -414,7 +414,7 @@ exports[`Table component renders with square corners 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ {
+  .c-cCZzXk {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
@@ -425,39 +425,31 @@ exports[`Table component renders with square corners 1`] = `
     vertical-align: middle;
   }
 
-  .c-dOcJjJ:first-child {
+  .c-cCZzXk:first-child {
     font-weight: bold;
-  }
-
-  tr:nth-child(odd) .c-dOcJjJ {
-    background: white;
-  }
-
-  tr:nth-child(even) .c-dOcJjJ {
-    background: var(--colors-tonal50);
   }
 }
 
 @media  {
-  .c-cwQMhQ-bgSNGZ-size-md .c-dOcJjJ,
-  .c-cwQMhQ-bgSNGZ-size-md .c-GSaiK,
-  .c-cwQMhQ-bgSNGZ-size-md .c-hYjVQ {
+  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
+  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
+  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
     height: var(--sizes-4);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-UpMKF-corners-round .c-GSaiK:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:first-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-gCFJjl-corners-round .c-PJLV:last-child .c-dOcJjJ:last-child {
+  .c-cwQMhQ-UpMKF-corners-round .c-PJLV:last-child .c-cCZzXk:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
@@ -465,9 +457,17 @@ exports[`Table component renders with square corners 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-cwQMhQ-lhkyUQ-size-lg .c-dOcJjJ,
-  .c-cwQMhQ-lhkyUQ-size-lg .c-GSaiK,
-  .c-cwQMhQ-lhkyUQ-size-lg .c-hYjVQ {
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(odd) {
+    background: white;
+  }
+
+  .c-PJLV-gQAHHw-appearance-alternating .c-PJLV:nth-child(even) {
+    background: var(--colors-tonal50);
+  }
+
+  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
+  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
+  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
     height: var(--sizes-5);
   }
 }
@@ -481,7 +481,7 @@ exports[`Table component renders with square corners 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-bgSNGZ-size-md c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-icnGIKd-css"
   >
     <thead
       class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
@@ -497,13 +497,13 @@ exports[`Table component renders with square corners 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV"
+      class="c-PJLV c-PJLV-gQAHHw-appearance-alternating"
     >
       <tr
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           This is text
         </td>
@@ -516,7 +516,7 @@ exports[`Table component renders with square corners 1`] = `
         class="c-PJLV"
       >
         <td
-          class="c-dOcJjJ"
+          class="c-cCZzXk"
         >
           Footer 1
         </td>

--- a/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -63,11 +63,11 @@ exports[`Table component renders 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 }
@@ -97,7 +97,7 @@ exports[`Table component renders 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
+      class="c-PJLV c-PJLV-gQAHHw-striped-true"
     >
       <tr
         class="c-PJLV"
@@ -189,11 +189,11 @@ exports[`Table component renders with a themed header 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 
@@ -233,7 +233,7 @@ exports[`Table component renders with a themed header 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
+      class="c-PJLV c-PJLV-gQAHHw-striped-true"
     >
       <tr
         class="c-PJLV"
@@ -325,11 +325,11 @@ exports[`Table component renders with size set to lg 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 
@@ -365,7 +365,7 @@ exports[`Table component renders with size set to lg 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
+      class="c-PJLV c-PJLV-gQAHHw-striped-true"
     >
       <tr
         class="c-PJLV"
@@ -457,11 +457,11 @@ exports[`Table component renders with square corners 1`] = `
     background: var(--colors-primaryDark);
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(odd) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(odd) {
     background: white;
   }
 
-  .c-PJLV-gQAHHw-appearance-striped .c-PJLV:nth-child(even) {
+  .c-PJLV-gQAHHw-striped-true .c-PJLV:nth-child(even) {
     background: var(--colors-tonal50);
   }
 
@@ -497,7 +497,7 @@ exports[`Table component renders with square corners 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c-PJLV c-PJLV-gQAHHw-appearance-striped"
+      class="c-PJLV c-PJLV-gQAHHw-striped-true"
     >
       <tr
         class="c-PJLV"


### PR DESCRIPTION
### Description

I needed a light theme for the table component, where we have a grey header and no alternating row colours.

https://atomlearningltd.atlassian.net/jira/software/projects/PAR/boards/11?selectedIssue=PAR-126

### Implementation

- Added `light` theme to `Table.Header`
- Extended `Table.Body` to accept a striped prop, which is a boolean.
- Removed the alternating background colour from `Table.Cell` so it can be handled at a `Table.Body` level
- Updated snapshots and mdx

### Screenshots

![image](https://user-images.githubusercontent.com/66493855/172823972-5876183e-d7a9-4760-8003-a852067b7f7a.png)