### PR TITLE
fix: tab triggerlist uppercase

### DIFF
--- a/src/components/tabs/TabsTriggerList.tsx
+++ b/src/components/tabs/TabsTriggerList.tsx
@@ -11,6 +11,7 @@ import { styled, theme } from '~/stitches'
 
 import { TabTrigger } from './TabTrigger'
 import { passPropsToChildren } from './utils'
+
 interface ListProps extends React.ComponentProps<typeof StyledTriggerList> {
   enableTabScrolling?: boolean
   scrollPercentage?: number
@@ -66,7 +67,7 @@ const StyledTriggerList = styled(List, {
     },
     appearance: {
       uppercase: {
-        textTransform: 'uppercase'
+        '& button': { textTransform: 'uppercase' }
       }
     }
   }


### PR DESCRIPTION
### Description

I noticed that `Tabs.TriggerList` wasn't doing anything when `appearance="uppercase"` was passed in.

### Implementation

In order to stop the textTransform property being overridden, I set the CSS from the uppercase variant to apply to descendant buttons instead of on the object itself.