### PR TITLE
feat: made the minItemSize prop optional and allow gridTemplateColumns property to be overridden

### DIFF
--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -42,7 +42,7 @@ export const Grid: React.FC<GridProps> = ({
 }) => (
   <GridContainer
     css={{
-      ...(minItemSize !== undefined && {
+      ...(minItemSize && {
         gridTemplateColumns: `repeat(auto-fit, minmax(${minItemSize}, ${maxItemSize}))`
       }),
       ...(css as any)

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -29,7 +29,7 @@ const GridContainer = styled('div', {
 })
 
 type GridProps = React.ComponentProps<typeof GridContainer> & {
-  minItemSize: string
+  minItemSize?: string
   maxItemSize?: string
 }
 
@@ -42,8 +42,10 @@ export const Grid: React.FC<GridProps> = ({
 }) => (
   <GridContainer
     css={{
-      ...(css as any),
-      gridTemplateColumns: `repeat(auto-fit, minmax(${minItemSize}, ${maxItemSize}))`
+      ...(minItemSize !== undefined && {
+        gridTemplateColumns: `repeat(auto-fit, minmax(${minItemSize}, ${maxItemSize}))`
+      }),
+      ...(css as any)
     }}
     gap={gap}
     {...remainingProps}


### PR DESCRIPTION
## Problem
The `<Grid />` component outputs the following line of CSS by default:
```ts
gridTemplateColumns: `repeat(auto-fit, minmax(${minItemSize}, ${maxItemSize}))`
```

`maxItemSize` is optional and defaults to `1fr`, but `minItemSize` is required. `auto-fit` only works with fixed values, so this means that we cannot create a grid with flexible column widths at the moment.

Because we cannot override the `gridTemplateColumns` property either, we can't opt-out of using `repeat` and `auto-fit`.

## Changes
- Make `minItemSize` optional and only set `gridTemplateColumns` when it is defined.
- Move the `css` spread to the end of the object, so that the `gridTemplateColumns` property can always be overridden.

## Note
Checked the `core` codebase, and it doesn't conflict anywhere.