### PR TITLE
fix: select controlled warning

### DIFF
--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -75,33 +75,23 @@ export type SelectProps = Override<
 >
 
 export const Select: React.FC<SelectProps> = React.forwardRef(
-  (
-    {
-      placeholder,
-      children,
-      size = 'md',
-      defaultValue,
-      value,
-      ...remainingProps
-    },
-    ref
-  ) => (
-    <StyledSelect
-      size={size}
-      {...(defaultValue && { defaultValue })}
-      {...(value && { value })}
-      {...(!defaultValue && !value && { defaultValue: '' })}
-      {...remainingProps}
-      ref={ref}
-    >
-      {placeholder && (
-        <option disabled hidden value="">
-          {placeholder}
-        </option>
-      )}
-      {children}
-    </StyledSelect>
-  )
+  ({ placeholder, children, size = 'md', ...remainingProps }, ref) => {
+    const props = { size, ref, ...remainingProps }
+
+    if (!remainingProps.value && !remainingProps.defaultValue)
+      props.defaultValue = ''
+
+    return (
+      <StyledSelect {...props}>
+        {placeholder && (
+          <option disabled hidden value="">
+            {placeholder}
+          </option>
+        )}
+        {children}
+      </StyledSelect>
+    )
+  }
 )
 
 Select.displayName = 'Select'

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -75,8 +75,25 @@ export type SelectProps = Override<
 >
 
 export const Select: React.FC<SelectProps> = React.forwardRef(
-  ({ placeholder, children, size = 'md', ...remainingProps }, ref) => (
-    <StyledSelect size={size} defaultValue="" {...remainingProps} ref={ref}>
+  (
+    {
+      placeholder,
+      children,
+      size = 'md',
+      defaultValue,
+      value,
+      ...remainingProps
+    },
+    ref
+  ) => (
+    <StyledSelect
+      size={size}
+      {...(defaultValue && { defaultValue })}
+      {...(value && { value })}
+      {...(!defaultValue && !value && { defaultValue: '' })}
+      {...remainingProps}
+      ref={ref}
+    >
       {placeholder && (
         <option disabled hidden value="">
           {placeholder}


### PR DESCRIPTION
From https://github.com/Atom-Learning/components/issues/306

### Description

Our select components were causing a console warning when they were controlled, due to the way they were composed. I have fixed this.

### Implementation

Conditionally pass in `value` and `defaultValue` in order to only have one on the object, so the component can be either controlled or uncontrolled.