### PR TITLE
Setting false fullWidth value on Button

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -109,6 +109,9 @@ export const StyledButton = styled('button', {
       }
     },
     fullWidth: {
+      false: {
+        width: 'auto'
+      },
       true: {
         width: '100%'
       }


### PR DESCRIPTION
Currently the button component will be full width in both mobile view and non-mobile view when using `fullWidth={{ '@initial': true, '@sm': false }}` with this change it will only be full width in mobile view.

A little bit of context:
https://www.figma.com/file/j1Xz1sJfHoSFVcCCZXn4Tc/Comprehension-Uploader?node-id=1099%3A15584