### PR TITLE
Feat: Dialog - Custom Background

### DIFF
--- a/src/components/dialog/Dialog.mdx
+++ b/src/components/dialog/Dialog.mdx
@@ -46,4 +46,23 @@ Read more about the underlying UI component on the [Radix UI documentation site]
 </Dialog>
 ```
 
+`Dialog` can also be rendered with a custom background. Important to note that `Dialog.Background` needs to be a child of `Dialog.Content`
+
+```tsx
+<Dialog>
+  <Dialog.Trigger>Open Dialog</Dialog.Trigger>
+  <Dialog.Content>
+    <Dialog.Background>
+      <Text>
+        Custom Background Content
+      </Text>
+    </Dialog.Background>
+    <Text>
+      Dialog.Background will appear above the Overlay, but below the DialogContent
+    </Text>
+    <Button as={Dialog.Close}>Close</Button>
+  </Dialog.Content>
+</Dialog>
+```
+
 For any modifications of the default `Dialog` visuals, for example bypassing the panel design entirely, we recommend utilising the Radix UI Dialog component directly. You will need to wrap each exported component within a `styled()` function to enable `css` and `as`, and compose together `Dialog.Overlay` and `Dialog.Close` within `Dialog.Content` to mimic the behaviour of this modal.

--- a/src/components/dialog/Dialog.test.tsx
+++ b/src/components/dialog/Dialog.test.tsx
@@ -77,3 +77,27 @@ describe('Dialog component without close button', () => {
     expect(dialog).toMatchSnapshot()
   })
 })
+
+describe('Dialog component with custom background', () => {
+  it('renders', async () => {
+    await render(
+      <IdProvider>
+        <Dialog>
+          <Dialog.Trigger>TRIGGER</Dialog.Trigger>
+          <Dialog.Content>
+            <Dialog.Background>CUSTOM BACKGROUND</Dialog.Background>
+            CONTENT
+          </Dialog.Content>
+        </Dialog>
+      </IdProvider>
+    )
+
+    const trigger = await screen.getByText('TRIGGER')
+    userEvent.click(trigger)
+
+    const dialog = await screen.getByRole('dialog')
+
+    // Since background is a sibling to content
+    expect(dialog.parentElement).toMatchSnapshot()
+  })
+})

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -5,12 +5,14 @@ import { styled } from '~/stitches'
 
 import { DialogClose } from './DialogClose'
 import { DialogContent } from './DialogContent'
+import { DialogBackground } from './DialogBackground'
 
 const StyledDialog = styled(Root, {})
 
 type DialogProps = React.ComponentProps<typeof StyledDialog>
 
 export const Dialog: React.FC<DialogProps> & {
+  Background: typeof DialogBackground
   Close: typeof DialogClose
   Content: typeof DialogContent
   Description: typeof Description
@@ -18,6 +20,7 @@ export const Dialog: React.FC<DialogProps> & {
   Trigger: typeof Trigger
 } = (props) => <StyledDialog {...props} />
 
+Dialog.Background = DialogBackground
 Dialog.Close = DialogClose
 Dialog.Content = DialogContent
 Dialog.Description = Description

--- a/src/components/dialog/DialogBackground.tsx
+++ b/src/components/dialog/DialogBackground.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react'
+import { styled } from '~/stitches'
+
+import { Box } from '../box'
+
+export const DialogBackground = styled(Box, { width: '100vw', height: '100vh' })

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -8,6 +8,7 @@ import { fadeIn, fadeOut } from '~/utilities'
 
 import { ActionIcon } from '../action-icon/ActionIcon'
 import { Icon } from '../icon/Icon'
+import { DialogBackground } from './DialogBackground'
 
 const contentOnScreen = 'translate3d(-50%, -50%, 0)'
 const contentOffScreen = 'translate3d(-50%, 50vh, 0)'
@@ -88,6 +89,10 @@ export const DialogContent: React.FC<DialogContentProps> = ({
 }) => (
   <Portal>
     <StyledDialogOverlay id={modalOverlayId}>
+      {React.Children.map(
+        children,
+        (child: React.ReactElement) => child.type === DialogBackground && child
+      )}
       <StyledDialogContent
         size={size}
         aria-label="Dialog"
@@ -110,7 +115,11 @@ export const DialogContent: React.FC<DialogContentProps> = ({
             <Icon is={CloseIcon} />
           </ActionIcon>
         )}
-        {children}
+        {React.Children.map(
+          children,
+          (child: React.ReactElement) =>
+            child.type !== DialogBackground && child
+        )}
       </StyledDialogContent>
     </StyledDialogOverlay>
   </Portal>

--- a/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -178,6 +178,189 @@ exports[`Dialog component renders the trigger with the popover hidden by default
 </div>
 `;
 
+exports[`Dialog component with custom background renders 1`] = `
+@media  {
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-ixewiD {
+    background: white;
+    border-radius: var(--radii-1);
+    box-shadow: var(--shadows-3);
+    box-sizing: border-box;
+    left: 50%;
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: var(--space-5);
+    position: fixed;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    z-index: 2147483646;
+  }
+
+  .c-ixewiD:focus {
+    outline: none;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-ixewiD[data-state="open"] {
+      animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-ixewiD[data-state="closed"] {
+      animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+  .c-gJNIBC {
+    background-color: var(--colors-alpha600);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    overflow-y: auto;
+    z-index: 2147483646;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-gJNIBC[data-state="open"] {
+      animation: k-eyOShd 250ms ease-out;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-gJNIBC[data-state="closed"] {
+      animation: k-bHbNKp 550ms ease-out;
+    }
+}
+
+  .c-kNieLL {
+    width: 100vw;
+    height: 100vh;
+  }
+}
+
+@media  {
+  .c-fDzwZw-PrXKS-size-lg {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-hemXWm-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 2;
+  }
+
+  .c-ixewiD-lgqbzh-size-sm {
+    width: 480px;
+  }
+}
+
+@media  {
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-fDzwZw-ikHqHwu-css {
+    position: absolute;
+    right: var(--space-4);
+    top: var(--space-4);
+  }
+
+  .c-dbrbZt-ihFPSGE-css {
+    height: 20px;
+    width: 20px;
+  }
+}
+
+<div
+  class="c-gJNIBC"
+  data-state="open"
+  id="modal_overlay"
+  style="pointer-events: auto;"
+>
+  <div
+    aria-hidden="true"
+    class="c-PJLV c-kNieLL"
+    data-aria-hidden="true"
+  >
+    CUSTOM BACKGROUND
+  </div>
+  <div
+    aria-describedby="radix-20"
+    aria-label="Dialog"
+    aria-labelledby="radix-19"
+    class="c-ixewiD c-ixewiD-lgqbzh-size-sm"
+    data-state="open"
+    id="radix-18"
+    role="dialog"
+    style="pointer-events: auto;"
+    tabindex="-1"
+  >
+    <button
+      aria-label="Close dialog"
+      class="c-fDzwZw c-fDzwZw-PrXKS-size-lg c-fDzwZw-otpKd-cv c-fDzwZw-ikHqHwu-css"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.343 6.343l11.314 11.314m-11.314 0L17.657 6.343"
+        />
+      </svg>
+    </button>
+    CONTENT
+  </div>
+</div>
+`;
+
 exports[`Dialog component without close button renders 1`] = `
 @media  {
   .c-fDzwZw {


### PR DESCRIPTION
## Description
The `Dialog` component has a predefined background / overlay, as of now. This PR will allow us to set custom background (components / images), which will be placed above `Overlay` and under `DialogContent`

[Slack Thread](https://atom-learning.slack.com/archives/G01G926F9DM/p1656334232053669?thread_ts=1656330160.946999&cid=G01G926F9DM)

## Usage

```tsx
    <Dialog>
      <Dialog.Trigger asChild>
        <Button>Open Dialog</Button>
      </Dialog.Trigger>
      <Dialog.Content>
        <Dialog.Background css={{ backgroundImage: 'url(https://img.freepik.com/free-vector/hand-painted-watercolor-abstract-watercolor-background_23-2149005675.jpg?t=st=1656407416~exp=1656408016~hmac=1016624970b6b9e73d8245819f3657f0d7948d053eb886fe5c1355b8882d7e74&w=1800)' }}>
          Hello
        </Dialog.Background>
        <Heading size="sm" css={{ mb: '$3' }}>
          Dialog
        </Heading>
        <Text size="sm" css={{ mb: '$3' }}>
          The `Dialog` can display any type of element as a trigger and has the
          content hidden by default
        </Text>
        <Button appearance="outline" size="sm" as={Dialog.Close}>
          Close Dialog
        </Button>
      </Dialog.Content>
    </Dialog>
```

## Screenshot
<img width="1440" alt="Screenshot 2022-06-28 at 11 15 00" src="https://user-images.githubusercontent.com/1936119/176154931-ba24e26b-d789-4e46-a173-7418f7138499.png">

