### PR TITLE
Fix: DialogContent - handle case where child can be null

### DIFF
--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -91,7 +91,8 @@ export const DialogContent: React.FC<DialogContentProps> = ({
     <StyledDialogOverlay id={modalOverlayId}>
       {React.Children.map(
         children,
-        (child: React.ReactElement) => child?.type === DialogBackground && child
+        (child?: React.ReactElement) =>
+          child?.type === DialogBackground && child
       )}
       <StyledDialogContent
         size={size}
@@ -117,7 +118,7 @@ export const DialogContent: React.FC<DialogContentProps> = ({
         )}
         {React.Children.map(
           children,
-          (child: React.ReactElement) =>
+          (child?: React.ReactElement) =>
             child?.type !== DialogBackground && child
         )}
       </StyledDialogContent>

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -91,7 +91,7 @@ export const DialogContent: React.FC<DialogContentProps> = ({
     <StyledDialogOverlay id={modalOverlayId}>
       {React.Children.map(
         children,
-        (child: React.ReactElement) => child.type === DialogBackground && child
+        (child: React.ReactElement) => child?.type === DialogBackground && child
       )}
       <StyledDialogContent
         size={size}
@@ -118,7 +118,7 @@ export const DialogContent: React.FC<DialogContentProps> = ({
         {React.Children.map(
           children,
           (child: React.ReactElement) =>
-            child.type !== DialogBackground && child
+            child?.type !== DialogBackground && child
         )}
       </StyledDialogContent>
     </StyledDialogOverlay>


### PR DESCRIPTION
## Description
We have started seeing some failing tests which have been traced to the changes introduced in `v1.17.0`

```
TypeError: Cannot read property 'type' of null
        at /Users/avinah/workspace/atom-core/.yarn/__virtual__/@atom-learning-components-virtual-a3a313397e/0/cache/@atom-learning-components-npm-1.17.0-c6922d29f2-c0ffecf250.zip/node_modules/@atom-learning/components/dist/index.cjs.js:1:30825
```

Adding a null check in attempt to fix it