### PR TITLE
fix: search input clear

### DIFF
--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -62,21 +62,13 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
   )
 
-  const searchBoxRef = React.useRef<HTMLInputElement>(null)
-
   const handleClear = () => {
     setInputValue('')
     setActiveIcon(INPUT_ICON.SEARCH)
-
-    const nativeInputValueSetter = (
-      Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        'value'
-      ) || { set: (value) => null }
-    ).set
-    nativeInputValueSetter?.call(searchBoxRef?.current, '')
-    const event = new Event('input', { bubbles: true })
-    searchBoxRef?.current?.dispatchEvent(event)
+    onChange?.({
+      currentTarget: { value: '' },
+      target: { value: '' }
+    } as React.ChangeEvent<HTMLInputElement>)
   }
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -111,7 +103,6 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   return (
     <Box css={{ position: 'relative', ...css }}>
       <StyledSearchInput
-        ref={searchBoxRef}
         size={size}
         type="search"
         {...remainingProps}

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -41,9 +41,10 @@ const StyledIcon = styled(Icon, {
 })
 
 const StyledSearchInput = styled(Input, {
-  '&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, & input[type="search"]::-webkit-search-results-decoration': {
-    display: 'none'
-  }
+  '&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, & input[type="search"]::-webkit-search-results-decoration':
+    {
+      display: 'none'
+    }
 })
 
 export const SearchInput: React.FC<SearchInputProps> = ({
@@ -61,9 +62,21 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
   )
 
+  const searchBoxRef = React.useRef<HTMLInputElement>(null)
+
   const handleClear = () => {
     setInputValue('')
     setActiveIcon(INPUT_ICON.SEARCH)
+
+    const nativeInputValueSetter = (
+      Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+      ) || { set: (value) => null }
+    ).set
+    nativeInputValueSetter?.call(searchBoxRef?.current, '')
+    const event = new Event('input', { bubbles: true })
+    searchBoxRef?.current?.dispatchEvent(event)
   }
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -98,6 +111,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   return (
     <Box css={{ position: 'relative', ...css }}>
       <StyledSearchInput
+        ref={searchBoxRef}
         size={size}
         type="search"
         {...remainingProps}


### PR DESCRIPTION
Issue raised on DS jira board https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-90

The SearchInput wasn't properly clearing when functioning in a controlled manner. For example, if you did
`<SearchInput value={value} onChange={(e) => setValue(e.currentTarget.value)} />`
that wouldn't trigger when you press the internal clear button of the SearchInput.

Because in a controlled manner the SearchInput doesn't internally have access to the setState function for the value it is displaying, the state would not update when the internal value is cleared. We use `onChange` to send those changes up to the setState, but clearing using the button isn't the same as changing and it doesn't call the native change events.

To solve this, we access the native event from the object prototype and call that in the function we call when we press the clear button. This sends the change event up to the setState and the value is correctly changed.

With this change, because it will correctly result in state changes, we should see SearchInput clears properly retrigger things like API calls and/or filters.

Videos here show the controlled state value in the text above the SearchInput element. Not how in the second one, clearing the input doesn't affect the state.

Fixed:

https://user-images.githubusercontent.com/66493855/177315911-f9707f5d-7415-4d82-b82f-9bb3e11d8676.mov

Broken:

https://user-images.githubusercontent.com/66493855/177315845-368f1f05-3df3-44e1-8852-adc35924224d.mov