### PR TITLE
Fix: Add ESBuild targets

### DIFF
--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -31,7 +31,10 @@ export default {
     summary({ showMinifiedSize: false, showBrotliSize: false }),
     commonjs(),
     alias({ entries: hq.get('rollup', { format: 'array' }) }),
-    esbuild({ minify: isProduction }),
+    esbuild({
+      minify: isProduction,
+      target: ['chrome80', 'edge91', 'firefox78', 'ios12.2', 'safari12.1']
+    }),
     resolve({ extensions: ['.ts', '.tsx'] }),
     isDebug && visualizer()
   ]


### PR DESCRIPTION
An unintentional (I assume) upgrade to ESBuild as part of the docs site work changed how our output code was transformed.

Previously it had transformed optional chaining into a compatible equivalent for non-supporting browsers, however, this upgrade (`0.14.10` to `0.14.47`) changed that default behaviour so now we need to add in the specific target browsers we wish to compile to. The browsers added to our targets array match our supported browsers in `core`.