### PR TITLE
Gt 178 drag and drop design system changes

### DIFF
--- a/lib/src/components/toggle-group/ToggleGroup.mdx
+++ b/lib/src/components/toggle-group/ToggleGroup.mdx
@@ -38,12 +38,14 @@ Extends visually by allowing for different sizing, vertical/horizontal display a
 `size="sm | md | lg"`
 
 ```jsx preview
-<ToggleGroup.Root type="single" gap={3} size="sm">
-  <ToggleGroup.Button value="a">
+<ToggleGroup.Root type="single" gap={3}>
+  <ToggleGroup.Button value="a" size="sm">
     <Icon is={Upload} /> A
   </ToggleGroup.Button>
-  <ToggleGroup.Button value="b">B</ToggleGroup.Button>
-  <ToggleGroup.Button value="icon">
+  <ToggleGroup.Button value="b" size="sm">
+    B
+  </ToggleGroup.Button>
+  <ToggleGroup.Button value="icon" size="sm">
     <Icon is={Upload} />
   </ToggleGroup.Button>
 </ToggleGroup.Root>

--- a/lib/src/components/toggle-group/ToggleGroup.test.tsx
+++ b/lib/src/components/toggle-group/ToggleGroup.test.tsx
@@ -13,13 +13,12 @@ const ToggleGroupImplementation = () => (
     type="multiple"
     orientation="vertical"
     gap={2}
-    size="sm"
     defaultValue={['item_a', 'button_a']}
   >
     <ToggleGroup.Item disabled value="item_a">item</ToggleGroup.Item>
-    <ToggleGroup.Button disabled value="button_a"> button A </ToggleGroup.Button>
-    <ToggleGroup.Button value="button_b">button B</ToggleGroup.Button>
-    <ToggleGroup.Button value="button_icon">
+    <ToggleGroup.Button size="sm" disabled value="button_a"> button A </ToggleGroup.Button>
+    <ToggleGroup.Button size="sm" value="button_b">button B</ToggleGroup.Button>
+    <ToggleGroup.Button size="sm" value="button_icon">
       <Icon is={Upload} />
       Button with icon
     </ToggleGroup.Button>

--- a/lib/src/components/toggle-group/ToggleGroupButton.tsx
+++ b/lib/src/components/toggle-group/ToggleGroupButton.tsx
@@ -81,9 +81,9 @@ export const StyledButton = styled(StyledItem, {
   ]
 })
 
-export const ToggleGroupButton: React.FC<
+export const ToggleGroupButton: React.ForwardRefExoticComponent<
   React.ComponentProps<typeof StyledButton>
-> = ({ size, children, ...rest }) => {
+> = React.forwardRef(({ size = 'md', children, ...rest }, ref) => {
   const childrenArray = React.Children.toArray(children)
   const isSingleChild = childrenArray.length <= 1
   const isIconOnly =
@@ -92,7 +92,7 @@ export const ToggleGroupButton: React.FC<
     childrenArray[0]?.type === Icon
 
   return (
-    <StyledButton size={size} isIconOnly={isIconOnly} {...rest}>
+    <StyledButton ref={ref} size={size} isIconOnly={isIconOnly} {...rest}>
       {
         childrenArray.map((child) => {
           if (!isSingleChild && typeof child === 'string')
@@ -106,4 +106,4 @@ export const ToggleGroupButton: React.FC<
       }
     </StyledButton>
   )
-}
+})

--- a/lib/src/components/toggle-group/ToggleGroupRoot.tsx
+++ b/lib/src/components/toggle-group/ToggleGroupRoot.tsx
@@ -7,11 +7,10 @@ import { styled } from '~/stitches'
 import { StyledItem } from './ToggleGroupItem'
 
 type RootType = {
-  size: 'sm' | 'md' | 'lg'
   orientation?: 'horizontal' | 'vertical'
   gap?: number
   isFullWidth?: boolean
-  wrap: 'wrap' | 'no-wrap' | 'wrap-reverse'
+  wrap?: 'wrap' | 'no-wrap' | 'wrap-reverse'
 }
 
 export const StyledRoot = styled(ToggleGroup.Root, {
@@ -114,22 +113,21 @@ export const StyledRoot = styled(ToggleGroup.Root, {
 const orientationToDirection = (orientation) =>
   orientation === 'horizontal' ? 'row' : 'column'
 
-export const ToggleGroupRoot: React.FC<
+export const ToggleGroupRoot: React.ForwardRefExoticComponent<
   React.ComponentProps<typeof StyledRoot> & RootType
-> = ({
-  size = 'md',
+> = React.forwardRef(({
   orientation = 'horizontal',
   gap = false,
   isFullWidth,
   children,
   wrap = 'no-wrap',
   ...rest
-}) => {
+}, ref) => {
   const hasGap = typeof gap === 'number'
-  const childrenArray = React.Children.toArray(children)
   const direction = orientationToDirection(orientation)
   return (
     <StyledRoot
+      ref={ref}
       direction={direction}
       hasGap={hasGap}
       isFullWidth={isFullWidth}
@@ -142,13 +140,8 @@ export const ToggleGroupRoot: React.FC<
         align={false}
         wrap={wrap}
       >
-        {
-          childrenArray.map((child) => {
-            if (!React.isValidElement(child)) return child
-            return React.cloneElement(child, { ...child.props, size })
-          }) as React.ReactElement[]
-        }
+        {children}
       </Stack>
     </StyledRoot>
   )
-}
+})

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,3 +1,5 @@
 export * from './components'
 
 export * from './stitches'
+
+export { focusVisibleStyleBlock } from '~/utilities'


### PR DESCRIPTION
Some small-ish changes to the design system which arose while I was working on https://github.com/Atom-Learning/atom-core/pull/2129

[feat: focusVisibleStyleBlock export](https://github.com/Atom-Learning/components/pull/371/commits/fd50c4ca6576da0c6459fb765e6edfca5db2fc28)
^ I need this to do the focus style around a Sortable Button in core
 
[refactor: ToggleGroup simplify and forwardRef](https://github.com/Atom-Learning/components/pull/371/commits/16cd33cc20688e3dd750dafb1c84afbf4374e6f0)
^ I've done the same pattern in sortable when I use a size but I've done it per child (like this change suggests) rather than cloneElement.
 I honestly think it's much simpler and probs efficient to just pass the prop when needed rather than give to parent and clone so I want to change ToggleGroup to work the same way.