### PR TITLE
Fix: Button fullWidth false variant

### DIFF
--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -110,7 +110,7 @@ export const StyledButton = styled('button', {
     },
     fullWidth: {
       false: {
-        width: 'auto'
+        width: 'max-content'
       },
       true: {
         width: '100%'


### PR DESCRIPTION
`fullWidth = {false}` currently sets the `Button`'s `width` to `auto`, but we default it to `max-content` when no `fullWidth` prop is provided, so we should revert back to that when `fullWidth` is `false`. 

Since the `Button` has `display: flex`, `width: auto` forces it to take up all available horizontal space, so it might as well have `width: 100%`! 🤦🏻 