### PR TITLE
Fix: DateField accepting invalid date

### DIFF
--- a/lib/src/components/date-input/use-date.ts
+++ b/lib/src/components/date-input/use-date.ts
@@ -23,7 +23,7 @@ export const useDate = (
 
   const saveDate = (inputDate, isDateString = false) => {
     const parsedInputDate = isDateString
-      ? dayjs(inputDate, dateFormat)
+      ? dayjs(inputDate, dateFormat, true)
       : dayjs(inputDate)
 
     setDate(parsedInputDate.isValid() ? parsedInputDate.toDate() : undefined)


### PR DESCRIPTION
Previous behaviour:

>have date field set to dateFormat=DD/MM/YYYY
>we’re converting to YYYY-MM-DD
>if I go 25/10/2015 it outputs 2015-10-25
>if I go 10/25/2015 rather than saying invalid it outputs 2017-01-10

https://day.js.org/docs/en/parse/is-valid