### PR TITLE
Fix: update stroke widths for icons

### DIFF
--- a/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -81,10 +81,10 @@ exports[`Accordion component renders an accordion 1`] = `
 }
 
 @media  {
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-gErdmT-irYuKu-theme-primaryDark {
@@ -128,7 +128,7 @@ exports[`Accordion component renders an accordion 1`] = `
         TRIGGER1
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-iRFrve"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-iRFrve"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -164,7 +164,7 @@ exports[`Accordion component renders an accordion 1`] = `
         TRIGGER2
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-iRFrve"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-iRFrve"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
+++ b/lib/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
@@ -33,10 +33,10 @@ exports[`ActionIcon component renders 1`] = `
     width: var(--sizes-3);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 

--- a/lib/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/lib/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -64,10 +64,10 @@ exports[`Button component Loading state renders a loading button 1`] = `
     padding-right: var(--space-5);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-fkUJsw-rloUt-isRounded-true {
@@ -309,10 +309,10 @@ exports[`Button component renders a button with an icon 1`] = `
     padding-right: var(--space-5);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
@@ -399,7 +399,7 @@ exports[`Button component renders a button with an icon 1`] = `
     BUTTON 
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-idQfaGE-css"
+      class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-idQfaGE-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -813,10 +813,10 @@ exports[`Button component renders a rounded button  1`] = `
     padding-right: var(--space-5);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-fkUJsw-rloUt-isRounded-true {
@@ -907,7 +907,7 @@ exports[`Button component renders a rounded button  1`] = `
     BUTTON 
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-idQfaGE-css"
+      class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-idQfaGE-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/lib/src/components/calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/lib/src/components/calendar/__snapshots__/Calendar.test.tsx.snap
@@ -90,10 +90,10 @@ exports[`Calendar component renders 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-iSnHBU-llheLm-size-xs {
@@ -210,7 +210,7 @@ exports[`Calendar component renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -226,7 +226,7 @@ exports[`Calendar component renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/carousel/__snapshots__/Carousel.test.tsx.snap
+++ b/lib/src/components/carousel/__snapshots__/Carousel.test.tsx.snap
@@ -109,10 +109,10 @@ exports[`Carousel component renders 1`] = `
 }
 
 @media  {
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
@@ -194,7 +194,7 @@ exports[`Carousel component renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-hemXWm-size-md"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -210,7 +210,7 @@ exports[`Carousel component renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-hemXWm-size-md"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
+++ b/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
@@ -163,10 +163,10 @@ exports[`DateField component renders a field in error state 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-klXesr-kUaMfZ-size-md {
@@ -304,7 +304,7 @@ exports[`DateField component renders a field in error state 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihFPSGE-css"
+            class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihFPSGE-css"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -325,7 +325,7 @@ exports[`DateField component renders a field in error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
+          class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihYlUBO-css"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -505,10 +505,10 @@ exports[`DateField component renders a field with a text input 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-klXesr-kUaMfZ-size-md {
@@ -604,7 +604,7 @@ exports[`DateField component renders a field with a text input 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihFPSGE-css"
+            class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihFPSGE-css"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
+++ b/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
@@ -163,10 +163,10 @@ exports[`DateField component renders a field in error state 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-klXesr-kUaMfZ-size-md {
@@ -304,7 +304,7 @@ exports[`DateField component renders a field in error state 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihFPSGE-css"
+            class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihFPSGE-css"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -325,7 +325,7 @@ exports[`DateField component renders a field in error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihYlUBO-css"
+          class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -505,10 +505,10 @@ exports[`DateField component renders a field with a text input 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-klXesr-kUaMfZ-size-md {
@@ -604,7 +604,7 @@ exports[`DateField component renders a field with a text input 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihFPSGE-css"
+            class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihFPSGE-css"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -113,10 +113,10 @@ exports[`DateInput component renders 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-klXesr-kUaMfZ-size-md {
@@ -188,7 +188,7 @@ exports[`DateInput component renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihFPSGE-css"
+        class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihFPSGE-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -113,10 +113,10 @@ exports[`DateInput component renders 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-klXesr-kUaMfZ-size-md {
@@ -188,7 +188,7 @@ exports[`DateInput component renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihFPSGE-css"
+        class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihFPSGE-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -88,10 +88,10 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-ixewiD-lgqbzh-size-sm {
@@ -151,7 +151,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+      class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -271,10 +271,10 @@ exports[`Dialog component with custom background renders 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-ixewiD-lgqbzh-size-sm {
@@ -347,7 +347,7 @@ exports[`Dialog component with custom background renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+        class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -449,10 +449,10 @@ exports[`Dialog component without close button renders 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-ixewiD-lgqbzh-size-sm {

--- a/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -148,10 +148,10 @@ exports[`FieldWrapper component renders 1`] = `
     font-size: var(--fontSizes-md);
   }
 
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -227,7 +227,7 @@ exports[`FieldWrapper component renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihYlUBO-css"
+        class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -148,10 +148,10 @@ exports[`FieldWrapper component renders 1`] = `
     font-size: var(--fontSizes-md);
   }
 
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -227,7 +227,7 @@ exports[`FieldWrapper component renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
+        class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihYlUBO-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/lib/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -38,10 +38,10 @@ exports[`FileInput component renders 1`] = `
     padding-right: var(--space-5);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
@@ -83,7 +83,7 @@ exports[`FileInput component renders 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-idQgHjC-css"
+      class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-idQgHjC-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/lib/src/components/icon/Icon.tsx
+++ b/lib/src/components/icon/Icon.tsx
@@ -12,7 +12,7 @@ export const StyledIcon = styled('svg', {
   verticalAlign: 'middle',
   variants: {
     size: {
-      sm: { size: '$1', strokeWidth: '1.25' },
+      sm: { size: '$1', strokeWidth: '1.5' },
       md: { size: '$2', strokeWidth: '1.75' },
       lg: { size: '$3', strokeWidth: '2' }
     }

--- a/lib/src/components/icon/Icon.tsx
+++ b/lib/src/components/icon/Icon.tsx
@@ -12,8 +12,8 @@ export const StyledIcon = styled('svg', {
   verticalAlign: 'middle',
   variants: {
     size: {
-      sm: { size: '$1', strokeWidth: '1.75' },
-      md: { size: '$2', strokeWidth: '2' },
+      sm: { size: '$1', strokeWidth: '1.25' },
+      md: { size: '$2', strokeWidth: '1.75' },
       lg: { size: '$3', strokeWidth: '2' }
     }
   }

--- a/lib/src/components/icon/__snapshots__/Icon.test.tsx.snap
+++ b/lib/src/components/icon/__snapshots__/Icon.test.tsx.snap
@@ -13,17 +13,17 @@ exports[`Icon component renders an icon 1`] = `
 }
 
 @media  {
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
 <div>
   <svg
     aria-hidden="true"
-    class="c-dbrbZt c-dbrbZt-hemXWm-size-md"
+    class="c-dbrbZt c-dbrbZt-dMrjnF-size-md"
     title="check"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"

--- a/lib/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/lib/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -105,10 +105,10 @@ exports[`InputField component renders a field in error state 1`] = `
     border: 1px solid var(--colors-danger);
   }
 
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -194,7 +194,7 @@ exports[`InputField component renders a field in error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihYlUBO-css"
+          class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/lib/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -105,10 +105,10 @@ exports[`InputField component renders a field in error state 1`] = `
     border: 1px solid var(--colors-danger);
   }
 
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -194,7 +194,7 @@ exports[`InputField component renders a field in error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
+          class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihYlUBO-css"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/notification-badge/__snapshots__/NotificationBadge.test.tsx.snap
+++ b/lib/src/components/notification-badge/__snapshots__/NotificationBadge.test.tsx.snap
@@ -63,10 +63,10 @@ exports[`NotificationBadge component renders a NotificationBadge 1`] = `
     border-radius: var(--radii-round);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
@@ -117,7 +117,7 @@ exports[`NotificationBadge component renders a NotificationBadge 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+        class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/lib/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -103,10 +103,10 @@ exports[`Password component renders a password field 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
@@ -200,7 +200,7 @@ exports[`Password component renders a password field 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+            class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/lib/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/lib/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -71,10 +71,10 @@ exports[`PasswordInput component renders 1`] = `
     width: var(--sizes-4);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 }
 
@@ -135,7 +135,7 @@ exports[`PasswordInput component renders 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+        class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -64,10 +64,10 @@ exports[`SearchInput component renders 1`] = `
     font-size: var(--fontSizes-md);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-hvMhuR-OveXb-size-md {
@@ -104,7 +104,7 @@ exports[`SearchInput component renders 1`] = `
     />
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-hvMhuR c-hvMhuR-OveXb-size-md c-hvMhuR-ihFPSGE-css"
+      class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-hvMhuR c-hvMhuR-OveXb-size-md c-hvMhuR-ihFPSGE-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -200,10 +200,10 @@ exports[`SearchInput component renders clear button 1`] = `
     font-size: var(--fontSizes-md);
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-hvMhuR-OveXb-size-md {
@@ -282,7 +282,7 @@ exports[`SearchInput component renders clear button 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-hemXWm-size-md c-dbrbZt-ihFPSGE-css"
+        class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-ihFPSGE-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/lib/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
@@ -413,10 +413,10 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     color: white;
   }
 
-  .c-dbrbZt-hemXWm-size-md {
+  .c-dbrbZt-dMrjnF-size-md {
     height: var(--sizes-2);
     width: var(--sizes-2);
-    stroke-width: 2;
+    stroke-width: 1.75;
   }
 
   .c-dQvJRf-byQUqd-status-success {
@@ -525,7 +525,7 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-hemXWm-size-md"
+            class="c-dbrbZt c-dbrbZt-dMrjnF-size-md"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/lib/src/components/toggle-group/__snapshots__/ToggleGroup.test.tsx.snap
+++ b/lib/src/components/toggle-group/__snapshots__/ToggleGroup.test.tsx.snap
@@ -121,10 +121,10 @@ exports[`ToggleGroup renders 1`] = `
     margin-right: var(--space-2);
   }
 
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-flWDnm-epWAHO-hasGap-true .c-iVViNQ {
@@ -192,7 +192,7 @@ exports[`ToggleGroup renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-eAiySG-size-sm"
+          class="c-dbrbZt c-dbrbZt-emECXH-size-sm"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/toggle-group/__snapshots__/ToggleGroup.test.tsx.snap
+++ b/lib/src/components/toggle-group/__snapshots__/ToggleGroup.test.tsx.snap
@@ -121,10 +121,10 @@ exports[`ToggleGroup renders 1`] = `
     margin-right: var(--space-2);
   }
 
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-flWDnm-epWAHO-hasGap-true .c-iVViNQ {
@@ -192,7 +192,7 @@ exports[`ToggleGroup renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-emECXH-size-sm"
+          class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/lib/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
+++ b/lib/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
@@ -29,10 +29,10 @@ exports[`ValidationError component renders a validation error 1`] = `
 }
 
 @media  {
-  .c-dbrbZt-eAiySG-size-sm {
+  .c-dbrbZt-emECXH-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.75;
+    stroke-width: 1.25;
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -76,7 +76,7 @@ exports[`ValidationError component renders a validation error 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-eAiySG-size-sm c-dbrbZt-ihYlUBO-css"
+      class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/lib/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
+++ b/lib/src/components/validation-error/__snapshots__/ValidationError.test.tsx.snap
@@ -29,10 +29,10 @@ exports[`ValidationError component renders a validation error 1`] = `
 }
 
 @media  {
-  .c-dbrbZt-emECXH-size-sm {
+  .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
-    stroke-width: 1.25;
+    stroke-width: 1.5;
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -76,7 +76,7 @@ exports[`ValidationError component renders a validation error 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c-dbrbZt c-dbrbZt-emECXH-size-sm c-dbrbZt-ihYlUBO-css"
+      class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihYlUBO-css"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >


### PR DESCRIPTION
The existing stroke-width values for our icons was a little high, making some icons difficult to read in small sizes.

Jira ticket: https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-103

Some examples running in the docs site locally:
<img width="661" alt="Screenshot 2022-07-28 at 17 13 27" src="https://user-images.githubusercontent.com/21319237/181586979-b572ef79-4f70-4120-8842-ad8da6cdc53f.png">

