### PR TITLE
Fix: Reduce dialog z-index value

### DIFF
--- a/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     vertical-align: middle;
   }
 
-  .c-ixewiD {
+  .c-bnQNAg {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -39,26 +39,26 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
-    z-index: 2147483646;
+    z-index: 1147483646;
   }
 
-  .c-ixewiD:focus {
+  .c-bnQNAg:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-ixewiD[data-state="open"] {
+    .c-bnQNAg[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-ixewiD[data-state="closed"] {
+    .c-bnQNAg[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
-  .c-gJNIBC {
+  .c-hImYEd {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
@@ -66,17 +66,17 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     left: 0;
     position: fixed;
     overflow-y: auto;
-    z-index: 2147483646;
+    z-index: 1147483646;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-gJNIBC[data-state="open"] {
+    .c-hImYEd[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-gJNIBC[data-state="closed"] {
+    .c-hImYEd[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
@@ -94,7 +94,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-ixewiD-lgqbzh-size-sm {
+  .c-bnQNAg-lgqbzh-size-sm {
     width: 480px;
   }
 }
@@ -137,7 +137,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
   aria-describedby="radix-5"
   aria-label="Dialog"
   aria-labelledby="radix-4"
-  class="c-ixewiD c-ixewiD-lgqbzh-size-sm"
+  class="c-bnQNAg c-bnQNAg-lgqbzh-size-sm"
   data-state="open"
   id="radix-3"
   role="dialog"
@@ -204,7 +204,7 @@ exports[`Dialog component with custom background renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-ixewiD {
+  .c-bnQNAg {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -217,26 +217,26 @@ exports[`Dialog component with custom background renders 1`] = `
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
-    z-index: 2147483646;
+    z-index: 1147483646;
   }
 
-  .c-ixewiD:focus {
+  .c-bnQNAg:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-ixewiD[data-state="open"] {
+    .c-bnQNAg[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-ixewiD[data-state="closed"] {
+    .c-bnQNAg[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
-  .c-gJNIBC {
+  .c-hImYEd {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
@@ -244,17 +244,17 @@ exports[`Dialog component with custom background renders 1`] = `
     left: 0;
     position: fixed;
     overflow-y: auto;
-    z-index: 2147483646;
+    z-index: 1147483646;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-gJNIBC[data-state="open"] {
+    .c-hImYEd[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-gJNIBC[data-state="closed"] {
+    .c-hImYEd[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
@@ -277,7 +277,7 @@ exports[`Dialog component with custom background renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-ixewiD-lgqbzh-size-sm {
+  .c-bnQNAg-lgqbzh-size-sm {
     width: 480px;
   }
 }
@@ -317,7 +317,7 @@ exports[`Dialog component with custom background renders 1`] = `
 }
 
 <div
-  class="c-gJNIBC"
+  class="c-hImYEd"
   data-state="open"
   id="modal_overlay"
   style="pointer-events: auto;"
@@ -333,7 +333,7 @@ exports[`Dialog component with custom background renders 1`] = `
     aria-describedby="radix-20"
     aria-label="Dialog"
     aria-labelledby="radix-19"
-    class="c-ixewiD c-ixewiD-lgqbzh-size-sm"
+    class="c-bnQNAg c-bnQNAg-lgqbzh-size-sm"
     data-state="open"
     id="radix-18"
     role="dialog"
@@ -387,7 +387,7 @@ exports[`Dialog component without close button renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-ixewiD {
+  .c-bnQNAg {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -400,26 +400,26 @@ exports[`Dialog component without close button renders 1`] = `
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
-    z-index: 2147483646;
+    z-index: 1147483646;
   }
 
-  .c-ixewiD:focus {
+  .c-bnQNAg:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-ixewiD[data-state="open"] {
+    .c-bnQNAg[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-ixewiD[data-state="closed"] {
+    .c-bnQNAg[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
-  .c-gJNIBC {
+  .c-hImYEd {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
@@ -427,17 +427,17 @@ exports[`Dialog component without close button renders 1`] = `
     left: 0;
     position: fixed;
     overflow-y: auto;
-    z-index: 2147483646;
+    z-index: 1147483646;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-gJNIBC[data-state="open"] {
+    .c-hImYEd[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-gJNIBC[data-state="closed"] {
+    .c-hImYEd[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
@@ -455,7 +455,7 @@ exports[`Dialog component without close button renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-ixewiD-lgqbzh-size-sm {
+  .c-bnQNAg-lgqbzh-size-sm {
     width: 480px;
   }
 }
@@ -464,7 +464,7 @@ exports[`Dialog component without close button renders 1`] = `
   aria-describedby="radix-17"
   aria-label="Dialog"
   aria-labelledby="radix-16"
-  class="c-ixewiD c-ixewiD-lgqbzh-size-sm"
+  class="c-bnQNAg c-bnQNAg-lgqbzh-size-sm"
   data-state="open"
   id="radix-15"
   role="dialog"

--- a/lib/src/constants/dialog.ts
+++ b/lib/src/constants/dialog.ts
@@ -1,1 +1,1 @@
-export const DIALOG_Z_INDEX = 2147483646
+export const DIALOG_Z_INDEX = 1147483646


### PR DESCRIPTION
#### Description

The `z-index` value of the reCAPTURE image challenge is `2000000000` - which is less than the current z-index of our dialogs thus gets hidden behind our dialogs and prohibits signups. This [PR](https://github.com/Atom-Learning/atom-core/pull/2165) attempted to override the z-index of the reCAPTURE image challenge, however, the [solution wont work on Chrome](https://caniuse.com/css-has). @Mhoog and I tried a few other CSS selections, but there is no "safe" solution we can use without the worry that something in the DOM might change and without using `:has`


