### PR TITLE
Add new 24px space option

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@atom-learning/icons": "1.5.0",
     "@atom-learning/jest-stitches": "1.0.10",
-    "@atom-learning/theme": "1.0.1",
+    "@atom-learning/theme": "2.0.0-beta.0",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@radix-ui/react-id": "0.1.5",
@@ -121,7 +121,7 @@
   },
   "peerDependencies": {
     "@atom-learning/icons": "^1.0.0",
-    "@atom-learning/theme": "^1.0.0",
+    "@atom-learning/theme": "^2.0.0-beta.0",
     "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },

--- a/lib/src/components/alert-dialog/AlertDialogContent.tsx
+++ b/lib/src/components/alert-dialog/AlertDialogContent.tsx
@@ -39,7 +39,7 @@ const StyledAlertDialogContent = styled(Content, {
   boxSizing: 'border-box',
   left: '50%',
   maxWidth: '90vw',
-  p: '$5',
+  p: '$6',
   position: 'fixed',
   top: '50%',
   transform: contentOnScreen,

--- a/lib/src/components/alert-dialog/alert-context/AlertDialog.tsx
+++ b/lib/src/components/alert-dialog/alert-context/AlertDialog.tsx
@@ -29,11 +29,11 @@ export const Alert: React.FC<AlertDialogContentProps> = ({
       onCloseAutoFocus={onClose}
       {...remainingProps}
     >
-      <Heading as={AlertDialog.Title} size="sm" css={{ mb: '$5' }}>
+      <Heading as={AlertDialog.Title} size="sm" css={{ mb: '$6' }}>
         {title}
       </Heading>
       {description && (
-        <Text as={AlertDialog.Description} css={{ mb: '$5' }}>
+        <Text as={AlertDialog.Description} css={{ mb: '$6' }}>
           {description}
         </Text>
       )}

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -92,13 +92,13 @@ export const StyledButton = styled('button', {
         fontSize: '$md',
         lineHeight: 1.5,
         height: '$4',
-        px: '$5'
+        px: '$6'
       },
       lg: {
         fontSize: '$lg',
         lineHeight: 1.5,
         height: '$5',
-        px: '$5'
+        px: '$6'
       }
     },
     isLoading: {

--- a/lib/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/lib/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -56,12 +56,12 @@ exports[`Button component Loading state renders a loading button 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -177,7 +177,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-DdIlq-isLoading-true c-fkUJsw-gsycxF-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-DdIlq-isLoading-true c-fkUJsw-gsycxF-cv"
     type="button"
   >
     <div
@@ -229,12 +229,12 @@ exports[`Button component renders a button 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 }
 
@@ -263,7 +263,7 @@ exports[`Button component renders a button 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gsycxF-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-gsycxF-cv"
     type="button"
   >
     BUTTON
@@ -301,12 +301,12 @@ exports[`Button component renders a button with an icon 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -393,7 +393,7 @@ exports[`Button component renders a button with an icon 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gsycxF-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-gsycxF-cv"
     type="button"
   >
     BUTTON 
@@ -432,12 +432,12 @@ exports[`Button component renders a disabled button 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 }
 
@@ -488,7 +488,7 @@ exports[`Button component renders a disabled button 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gsycxF-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-gsycxF-cv"
     disabled=""
     type="button"
   >
@@ -518,12 +518,12 @@ exports[`Button component renders a disabled warning outline button 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 }
 
@@ -574,7 +574,7 @@ exports[`Button component renders a disabled warning outline button 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md"
     disabled=""
     type="button"
   >
@@ -604,12 +604,12 @@ exports[`Button component renders a outline button 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 }
 
@@ -660,7 +660,7 @@ exports[`Button component renders a outline button 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-fSssiS-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-fSssiS-cv"
     type="button"
   >
     BUTTON
@@ -689,12 +689,12 @@ exports[`Button component renders a outline button with secondary theme 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 }
 
@@ -767,7 +767,7 @@ exports[`Button component renders a outline button with secondary theme 1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-skNNT-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-skNNT-cv"
     type="button"
   >
     BUTTON
@@ -805,12 +805,12 @@ exports[`Button component renders a rounded button  1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -901,7 +901,7 @@ exports[`Button component renders a rounded button  1`] = `
 
 <div>
   <button
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-rloUt-isRounded-true c-fkUJsw-gsycxF-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-rloUt-isRounded-true c-fkUJsw-gsycxF-cv"
     type="button"
   >
     BUTTON 

--- a/lib/src/components/combobox/ComboboxInput.tsx
+++ b/lib/src/components/combobox/ComboboxInput.tsx
@@ -20,7 +20,7 @@ export const ComboboxInput = styled(BaseComboboxInput, {
   fontFamily: '$body',
   height: '$4',
   pl: '$3',
-  pr: '$6',
+  pr: '$7',
   transition: 'all 100ms ease-out',
   width: '100%',
   '&::placeholder': {

--- a/lib/src/components/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/lib/src/components/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Combobox component renders 1`] = `
 @media  {
-  .c-bYKHLS {
+  .c-gVcItL {
     box-shadow: none;
     font-size: var(--fontSizes-md);
     -webkit-appearance: none;
@@ -20,22 +20,22 @@ exports[`Combobox component renders 1`] = `
     font-family: var(--fonts-body);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
     transition: all 100ms ease-out;
     width: 100%;
   }
 
-  .c-bYKHLS::placeholder {
+  .c-gVcItL::placeholder {
     color: var(--colors-tonal300);
     opacity: 1;
   }
 
-  .c-bYKHLS:focus-within {
+  .c-gVcItL:focus-within {
     border-color: var(--colors-primary);
     outline: none;
   }
 
-  .c-bYKHLS[disabled] {
+  .c-gVcItL[disabled] {
     background-color: var(--colors-tonal100);
     color: var(--colors-tonal400);
     cursor: not-allowed;
@@ -92,7 +92,7 @@ exports[`Combobox component renders 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Favourite fruit"
-      class="c-bYKHLS"
+      class="c-gVcItL"
       data-reach-combobox-input=""
       data-state="idle"
       id="fruit"

--- a/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
+++ b/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
@@ -69,18 +69,18 @@ exports[`DateField component renders a field in error state 1`] = `
     vertical-align: middle;
   }
 
-  .c-klXesr {
+  .c-umVOi {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-2);
     max-width: 90vw;
     padding: var(--sizes-2);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
     position: relative;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr {
+    .c-umVOi {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -88,25 +88,25 @@ exports[`DateField component renders a field in error state 1`] = `
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="top"] {
+    .c-umVOi[data-state="open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="right"] {
+    .c-umVOi[data-state="open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="bottom"] {
+    .c-umVOi[data-state="open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="left"] {
+    .c-umVOi[data-state="open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -169,7 +169,7 @@ exports[`DateField component renders a field in error state 1`] = `
     stroke-width: 1.5;
   }
 
-  .c-klXesr-kUaMfZ-size-md {
+  .c-umVOi-kUaMfZ-size-md {
     max-width: 400px;
   }
 
@@ -238,7 +238,7 @@ exports[`DateField component renders a field in error state 1`] = `
     width: 20px;
   }
 
-  .c-klXesr-icFLuKp-css {
+  .c-umVOi-icFLuKp-css {
     padding-right: var(--sizes-2);
   }
 
@@ -429,18 +429,18 @@ exports[`DateField component renders a field with a text input 1`] = `
     vertical-align: middle;
   }
 
-  .c-klXesr {
+  .c-umVOi {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-2);
     max-width: 90vw;
     padding: var(--sizes-2);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
     position: relative;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr {
+    .c-umVOi {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -448,25 +448,25 @@ exports[`DateField component renders a field with a text input 1`] = `
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="top"] {
+    .c-umVOi[data-state="open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="right"] {
+    .c-umVOi[data-state="open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="bottom"] {
+    .c-umVOi[data-state="open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="left"] {
+    .c-umVOi[data-state="open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -511,7 +511,7 @@ exports[`DateField component renders a field with a text input 1`] = `
     stroke-width: 1.5;
   }
 
-  .c-klXesr-kUaMfZ-size-md {
+  .c-umVOi-kUaMfZ-size-md {
     max-width: 400px;
   }
 }
@@ -559,7 +559,7 @@ exports[`DateField component renders a field with a text input 1`] = `
     width: 20px;
   }
 
-  .c-klXesr-icFLuKp-css {
+  .c-umVOi-icFLuKp-css {
     padding-right: var(--sizes-2);
   }
 }

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -59,18 +59,18 @@ exports[`DateInput component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-klXesr {
+  .c-umVOi {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-2);
     max-width: 90vw;
     padding: var(--sizes-2);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
     position: relative;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr {
+    .c-umVOi {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -78,25 +78,25 @@ exports[`DateInput component renders 1`] = `
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="top"] {
+    .c-umVOi[data-state="open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="right"] {
+    .c-umVOi[data-state="open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="bottom"] {
+    .c-umVOi[data-state="open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-klXesr[data-state="open"][data-side="left"] {
+    .c-umVOi[data-state="open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -119,7 +119,7 @@ exports[`DateInput component renders 1`] = `
     stroke-width: 1.5;
   }
 
-  .c-klXesr-kUaMfZ-size-md {
+  .c-umVOi-kUaMfZ-size-md {
     max-width: 400px;
   }
 }
@@ -161,7 +161,7 @@ exports[`DateInput component renders 1`] = `
     width: 20px;
   }
 
-  .c-klXesr-icFLuKp-css {
+  .c-umVOi-icFLuKp-css {
     padding-right: var(--sizes-2);
   }
 }

--- a/lib/src/components/dialog/DialogContent.tsx
+++ b/lib/src/components/dialog/DialogContent.tsx
@@ -48,7 +48,7 @@ const StyledDialogContent = styled(Content, {
   maxWidth: '90vw',
   maxHeight: '90vh',
   overflowY: 'auto',
-  p: '$5',
+  p: '$6',
   position: 'fixed',
   top: '50%',
   transform: contentOnScreen,

--- a/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     vertical-align: middle;
   }
 
-  .c-bnQNAg {
+  .c-cTcnwv {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -35,25 +35,25 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     max-width: 90vw;
     max-height: 90vh;
     overflow-y: auto;
-    padding: var(--space-5);
+    padding: var(--space-6);
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
     z-index: 1147483646;
   }
 
-  .c-bnQNAg:focus {
+  .c-cTcnwv:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-bnQNAg[data-state="open"] {
+    .c-cTcnwv[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-bnQNAg[data-state="closed"] {
+    .c-cTcnwv[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
@@ -94,7 +94,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-bnQNAg-lgqbzh-size-sm {
+  .c-cTcnwv-lgqbzh-size-sm {
     width: 480px;
   }
 }
@@ -137,7 +137,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
   aria-describedby="radix-5"
   aria-label="Dialog"
   aria-labelledby="radix-4"
-  class="c-bnQNAg c-bnQNAg-lgqbzh-size-sm"
+  class="c-cTcnwv c-cTcnwv-lgqbzh-size-sm"
   data-state="open"
   id="radix-3"
   role="dialog"
@@ -204,7 +204,7 @@ exports[`Dialog component with custom background renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-bnQNAg {
+  .c-cTcnwv {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -213,25 +213,25 @@ exports[`Dialog component with custom background renders 1`] = `
     max-width: 90vw;
     max-height: 90vh;
     overflow-y: auto;
-    padding: var(--space-5);
+    padding: var(--space-6);
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
     z-index: 1147483646;
   }
 
-  .c-bnQNAg:focus {
+  .c-cTcnwv:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-bnQNAg[data-state="open"] {
+    .c-cTcnwv[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-bnQNAg[data-state="closed"] {
+    .c-cTcnwv[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
@@ -277,7 +277,7 @@ exports[`Dialog component with custom background renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-bnQNAg-lgqbzh-size-sm {
+  .c-cTcnwv-lgqbzh-size-sm {
     width: 480px;
   }
 }
@@ -333,7 +333,7 @@ exports[`Dialog component with custom background renders 1`] = `
     aria-describedby="radix-20"
     aria-label="Dialog"
     aria-labelledby="radix-19"
-    class="c-bnQNAg c-bnQNAg-lgqbzh-size-sm"
+    class="c-cTcnwv c-cTcnwv-lgqbzh-size-sm"
     data-state="open"
     id="radix-18"
     role="dialog"
@@ -387,7 +387,7 @@ exports[`Dialog component without close button renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-bnQNAg {
+  .c-cTcnwv {
     background: white;
     border-radius: var(--radii-1);
     box-shadow: var(--shadows-3);
@@ -396,25 +396,25 @@ exports[`Dialog component without close button renders 1`] = `
     max-width: 90vw;
     max-height: 90vh;
     overflow-y: auto;
-    padding: var(--space-5);
+    padding: var(--space-6);
     position: fixed;
     top: 50%;
     transform: translate3d(-50%, -50%, 0);
     z-index: 1147483646;
   }
 
-  .c-bnQNAg:focus {
+  .c-cTcnwv:focus {
     outline: none;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-bnQNAg[data-state="open"] {
+    .c-cTcnwv[data-state="open"] {
       animation: k-iaWRFC 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-bnQNAg[data-state="closed"] {
+    .c-cTcnwv[data-state="closed"] {
       animation: k-gturUW 550ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 }
@@ -455,7 +455,7 @@ exports[`Dialog component without close button renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-bnQNAg-lgqbzh-size-sm {
+  .c-cTcnwv-lgqbzh-size-sm {
     width: 480px;
   }
 }
@@ -464,7 +464,7 @@ exports[`Dialog component without close button renders 1`] = `
   aria-describedby="radix-17"
   aria-label="Dialog"
   aria-labelledby="radix-16"
-  class="c-bnQNAg c-bnQNAg-lgqbzh-size-sm"
+  class="c-cTcnwv c-cTcnwv-lgqbzh-size-sm"
   data-state="open"
   id="radix-15"
   role="dialog"

--- a/lib/src/components/empty-state/EmptyState.tsx
+++ b/lib/src/components/empty-state/EmptyState.tsx
@@ -29,7 +29,7 @@ const EmptyStateContainer = styled(Flex, {
         p: '$6'
       },
       xl: {
-        p: '$6'
+        p: '$7'
       }
     }
   }

--- a/lib/src/components/empty-state/EmptyState.tsx
+++ b/lib/src/components/empty-state/EmptyState.tsx
@@ -26,7 +26,7 @@ const EmptyStateContainer = styled(Flex, {
         p: '$4'
       },
       lg: {
-        p: '$5'
+        p: '$6'
       },
       xl: {
         p: '$6'

--- a/lib/src/components/empty-state/EmptyStateBody.tsx
+++ b/lib/src/components/empty-state/EmptyStateBody.tsx
@@ -20,11 +20,11 @@ export const EmptyStateBody = styled(Text, {
       },
       lg: {
         fontSize: '$md',
-        mb: '$5'
+        mb: '$6'
       },
       xl: {
         fontSize: '$md',
-        mb: '$5'
+        mb: '$6'
       }
     }
   }

--- a/lib/src/components/empty-state/EmptyStateBody.tsx
+++ b/lib/src/components/empty-state/EmptyStateBody.tsx
@@ -24,7 +24,7 @@ export const EmptyStateBody = styled(Text, {
       },
       xl: {
         fontSize: '$md',
-        mb: '$6'
+        mb: '$7'
       }
     }
   }

--- a/lib/src/components/empty-state/EmptyStateImage.tsx
+++ b/lib/src/components/empty-state/EmptyStateImage.tsx
@@ -21,12 +21,12 @@ export const EmptyStateImage = styled(Image, {
       lg: {
         width: '190px',
         height: '142px',
-        mb: '$5'
+        mb: '$6'
       },
       xl: {
         width: '285px',
         height: '213px',
-        mb: '$5'
+        mb: '$6'
       }
     }
   }

--- a/lib/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/lib/src/components/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -30,12 +30,12 @@ exports[`FileInput component renders 1`] = `
 }
 
 @media  {
-  .c-fkUJsw-elrwsr-size-md {
+  .c-fkUJsw-eCHSBE-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
     height: var(--sizes-4);
-    padding-left: var(--space-5);
-    padding-right: var(--space-5);
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -78,7 +78,7 @@ exports[`FileInput component renders 1`] = `
 
 <div>
   <label
-    class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gsycxF-cv"
+    class="c-fkUJsw c-fkUJsw-eCHSBE-size-md c-fkUJsw-gsycxF-cv"
     type="button"
   >
     <svg

--- a/lib/src/components/flex/Flex.mdx
+++ b/lib/src/components/flex/Flex.mdx
@@ -9,8 +9,8 @@ category: Layout
 
 ```tsx preview
 <Flex css={{ justifyContent: 'space-between', width: '100%' }}>
-  <Box css={{ bg: '$primary', size: '$6' }} />
-  <Box css={{ bg: '$primary', size: '$6' }} />
-  <Box css={{ bg: '$primary', size: '$6' }} />
+  <Box css={{ bg: '$primary', size: '$7' }} />
+  <Box css={{ bg: '$primary', size: '$7' }} />
+  <Box css={{ bg: '$primary', size: '$7' }} />
 </Flex>
 ```

--- a/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -2,49 +2,49 @@
 
 exports[`MarkdownContent component renders 1`] = `
 @media  {
-  .c-dcjLby > .c-iSnHBU {
+  .c-darjOp > .c-iSnHBU {
     max-width: 65ch;
   }
 
-  .c-dcjLby > .c-iSnHBU:not(:first-child) {
-    margin-top: var(--space-5);
-  }
-
-  .c-dcjLby > .c-iSnHBU:not(:last-child) {
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-fIXJvv {
-    max-width: 75ch;
-  }
-
-  .c-dcjLby > .c-fIXJvv:not(:last-child) {
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-iQukjL {
-    max-width: 75ch;
-  }
-
-  .c-dcjLby > .c-iQukjL:not(:last-child) {
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-jpqjUq {
-    margin-top: var(--space-5);
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-eWgOGC {
-    display: block;
-  }
-
-  .c-dcjLby > .c-eWgOGC:not(:first-child) {
+  .c-darjOp > .c-iSnHBU:not(:first-child) {
     margin-top: var(--space-6);
   }
 
-  .c-dcjLby > .c-eWgOGC:not(:last-child) {
+  .c-darjOp > .c-iSnHBU:not(:last-child) {
     margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-fIXJvv {
+    max-width: 75ch;
+  }
+
+  .c-darjOp > .c-fIXJvv:not(:last-child) {
+    margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-iQukjL {
+    max-width: 75ch;
+  }
+
+  .c-darjOp > .c-iQukjL:not(:last-child) {
+    margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-jpqjUq {
+    margin-top: var(--space-6);
+    margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-eWgOGC {
+    display: block;
+  }
+
+  .c-darjOp > .c-eWgOGC:not(:first-child) {
+    margin-top: var(--space-7);
+  }
+
+  .c-darjOp > .c-eWgOGC:not(:last-child) {
+    margin-bottom: var(--space-7);
   }
 
   .c-jpqjUq {
@@ -352,7 +352,7 @@ exports[`MarkdownContent component renders 1`] = `
 
 <div>
   <div
-    class="c-dcjLby"
+    class="c-darjOp"
   >
     <hr
       class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"

--- a/lib/src/components/popover/PopoverContent.tsx
+++ b/lib/src/components/popover/PopoverContent.tsx
@@ -19,7 +19,7 @@ const StyledContent = styled(Content, {
   boxShadow: '$2',
   maxWidth: '90vw',
   p: '$sizes$2',
-  pr: '$6',
+  pr: '$7',
   position: 'relative',
   '@allowMotion': {
     animationDuration: '75ms',

--- a/lib/src/components/radio-button/RadioButtonGroup.tsx
+++ b/lib/src/components/radio-button/RadioButtonGroup.tsx
@@ -9,7 +9,7 @@ export const RadioButtonGroup = styled(RadioGroup.Root, {
     direction: {
       row: {
         flexDirection: 'row',
-        '& > *:not(:last-child)': { mr: '$5' }
+        '& > *:not(:last-child)': { mr: '$6' }
       },
       column: { flexDirection: 'column' }
     }

--- a/lib/src/components/radio-card/RadioCard.tsx
+++ b/lib/src/components/radio-card/RadioCard.tsx
@@ -24,7 +24,7 @@ export const StyledRadioCard = styled(RadioGroup.Item, {
     },
     size: {
       md: { px: '$4', py: '$3' },
-      lg: { px: '$5', py: '$4' }
+      lg: { px: '$6', py: '$4' }
     },
     isFullWidth: {
       true: { width: '100%' },

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -108,7 +108,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         {...remainingProps}
         value={inputValue}
         onChange={handleOnChange}
-        css={{ pr: size === 'sm' ? '$5' : '$6' }}
+        css={{ pr: size === 'sm' ? '$6' : '$7' }} // already updated the second one
       />
       {getIcon()}
     </Box>

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -108,7 +108,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         {...remainingProps}
         value={inputValue}
         onChange={handleOnChange}
-        css={{ pr: size === 'sm' ? '$6' : '$7' }} // already updated the second one
+        css={{ pr: size === 'sm' ? '$6' : '$7' }}
       />
       {getIcon()}
     </Box>

--- a/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -83,8 +83,8 @@ exports[`SearchInput component renders 1`] = `
     position: relative;
   }
 
-  .c-cNcGUX-icRYcAH-css {
-    padding-right: var(--space-6);
+  .c-cNcGUX-iIFRSO-css {
+    padding-right: var(--space-7);
   }
 
   .c-hvMhuR-ihFPSGE-css {
@@ -98,7 +98,7 @@ exports[`SearchInput component renders 1`] = `
     class="c-PJLV c-PJLV-icmpvrW-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-iIFRSO-css"
       type="search"
       value=""
     />
@@ -245,8 +245,8 @@ exports[`SearchInput component renders clear button 1`] = `
     position: relative;
   }
 
-  .c-cNcGUX-icRYcAH-css {
-    padding-right: var(--space-6);
+  .c-cNcGUX-iIFRSO-css {
+    padding-right: var(--space-7);
   }
 
   .c-hvMhuR-ihFPSGE-css {
@@ -271,7 +271,7 @@ exports[`SearchInput component renders clear button 1`] = `
     class="c-PJLV c-PJLV-icmpvrW-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-iIFRSO-css"
       type="search"
       value="testing"
     />

--- a/lib/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
+++ b/lib/src/components/select-field/__snapshots__/SelectField.test.tsx.snap
@@ -73,13 +73,13 @@ exports[`SelectField component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-beXZpM-ggkvuX-size-md {
+  .c-beXZpM-dazoWq-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
     font-size: var(--fontSizes-md);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
   }
 }
 
@@ -110,7 +110,7 @@ exports[`SelectField component renders 1`] = `
         </label>
       </div>
       <select
-        class="c-beXZpM c-beXZpM-ggkvuX-size-md"
+        class="c-beXZpM c-beXZpM-dazoWq-size-md"
         id="example"
         name="example"
       >

--- a/lib/src/components/select/Select.tsx
+++ b/lib/src/components/select/Select.tsx
@@ -41,7 +41,7 @@ const StyledSelect = styled('select', {
         fontSize: '$sm',
         height: '$3',
         pl: '$2',
-        pr: '$5'
+        pr: '$6'
       },
       md: {
         backgroundPosition: 'right $space$3 top 50%, 0 0',

--- a/lib/src/components/select/Select.tsx
+++ b/lib/src/components/select/Select.tsx
@@ -49,7 +49,7 @@ const StyledSelect = styled('select', {
         fontSize: '$md',
         height: '$4',
         pl: '$3',
-        pr: '$6'
+        pr: '$7'
       }
     },
     state: {

--- a/lib/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/lib/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -41,20 +41,20 @@ exports[`Select component renders a select with 3 options 1`] = `
 }
 
 @media  {
-  .c-beXZpM-ggkvuX-size-md {
+  .c-beXZpM-dazoWq-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
     font-size: var(--fontSizes-md);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
   }
 }
 
 <div>
   <select
     aria-label="dropdown"
-    class="c-beXZpM c-beXZpM-ggkvuX-size-md"
+    class="c-beXZpM c-beXZpM-dazoWq-size-md"
   >
     <option
       value="value1"
@@ -116,20 +116,20 @@ exports[`Select component renders an disabled select 1`] = `
 }
 
 @media  {
-  .c-beXZpM-ggkvuX-size-md {
+  .c-beXZpM-dazoWq-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
     font-size: var(--fontSizes-md);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
   }
 }
 
 <div>
   <select
     aria-label="dropdown"
-    class="c-beXZpM c-beXZpM-ggkvuX-size-md"
+    class="c-beXZpM c-beXZpM-dazoWq-size-md"
     disabled=""
   />
 </div>
@@ -176,20 +176,20 @@ exports[`Select component renders select with a default option 1`] = `
 }
 
 @media  {
-  .c-beXZpM-ggkvuX-size-md {
+  .c-beXZpM-dazoWq-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
     font-size: var(--fontSizes-md);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
   }
 }
 
 <div>
   <select
     aria-label="dropdown"
-    class="c-beXZpM c-beXZpM-ggkvuX-size-md"
+    class="c-beXZpM c-beXZpM-dazoWq-size-md"
   >
     <option
       disabled=""
@@ -259,20 +259,20 @@ exports[`Select component renders select with a disabled option 1`] = `
 }
 
 @media  {
-  .c-beXZpM-ggkvuX-size-md {
+  .c-beXZpM-dazoWq-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
     font-size: var(--fontSizes-md);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
   }
 }
 
 <div>
   <select
     aria-label="dropdown"
-    class="c-beXZpM c-beXZpM-ggkvuX-size-md"
+    class="c-beXZpM c-beXZpM-dazoWq-size-md"
   >
     <option
       value="value1"
@@ -340,20 +340,20 @@ exports[`Select component renders select with no options 1`] = `
 }
 
 @media  {
-  .c-beXZpM-ggkvuX-size-md {
+  .c-beXZpM-dazoWq-size-md {
     background-position: right var(--space-3) top 50%, 0 0;
     background-size: 20px auto, 100%;
     font-size: var(--fontSizes-md);
     height: var(--sizes-4);
     padding-left: var(--space-3);
-    padding-right: var(--space-6);
+    padding-right: var(--space-7);
   }
 }
 
 <div>
   <select
     aria-label="dropdown"
-    class="c-beXZpM c-beXZpM-ggkvuX-size-md"
+    class="c-beXZpM c-beXZpM-dazoWq-size-md"
   />
 </div>
 `;

--- a/lib/src/components/slider/Slider.mdx
+++ b/lib/src/components/slider/Slider.mdx
@@ -111,7 +111,7 @@ Should you wish to use the label with multiple values, you can use `Array.join()
 Depending on the background of your page, you can change the theme of the track to be either light or tonal using `theme="light"`. Default is `theme="tonal"`.
 
 ```tsx preview
-<Box css={{ p: '$5', bg: '$tonal100' }}>
+<Box css={{ p: '$6', bg: '$tonal100' }}>
   <Slider theme="light" defaultValue={[50]} css={{ width: '320px' }} />
 </Box>
 ```

--- a/lib/src/components/stack-content/StackContent.tsx
+++ b/lib/src/components/stack-content/StackContent.tsx
@@ -12,19 +12,19 @@ import { StyledText } from '../text/Text'
 const StyledStackContent = styled('div', {
   [`& > ${StyledHeading}`]: {
     maxWidth: '65ch',
-    '&:not(:first-child)': { mt: '$5' },
-    '&:not(:last-child)': { mb: '$5' }
+    '&:not(:first-child)': { mt: '$6' },
+    '&:not(:last-child)': { mb: '$6' }
   },
   [`& > ${StyledText}`]: {
     maxWidth: '75ch',
-    '&:not(:last-child)': { mb: '$5' }
+    '&:not(:last-child)': { mb: '$6' }
   },
   [`& > ${StyledList}`]: {
     maxWidth: '75ch',
-    '&:not(:last-child)': { mb: '$5' }
+    '&:not(:last-child)': { mb: '$6' }
   },
   [`& > ${StyledDivider}`]: {
-    my: '$5'
+    my: '$6'
   },
   [`& > ${StyledImage}`]: {
     display: 'block',

--- a/lib/src/components/stack-content/StackContent.tsx
+++ b/lib/src/components/stack-content/StackContent.tsx
@@ -28,8 +28,8 @@ const StyledStackContent = styled('div', {
   },
   [`& > ${StyledImage}`]: {
     display: 'block',
-    '&:not(:first-child)': { mt: '$6' },
-    '&:not(:last-child)': { mb: '$6' }
+    '&:not(:first-child)': { mt: '$7' },
+    '&:not(:last-child)': { mb: '$7' }
   }
 })
 

--- a/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
+++ b/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
@@ -2,49 +2,49 @@
 
 exports[`StackContent component renders a stack content 1`] = `
 @media  {
-  .c-dcjLby > .c-iSnHBU {
+  .c-darjOp > .c-iSnHBU {
     max-width: 65ch;
   }
 
-  .c-dcjLby > .c-iSnHBU:not(:first-child) {
-    margin-top: var(--space-5);
-  }
-
-  .c-dcjLby > .c-iSnHBU:not(:last-child) {
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-fIXJvv {
-    max-width: 75ch;
-  }
-
-  .c-dcjLby > .c-fIXJvv:not(:last-child) {
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-iQukjL {
-    max-width: 75ch;
-  }
-
-  .c-dcjLby > .c-iQukjL:not(:last-child) {
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-jpqjUq {
-    margin-top: var(--space-5);
-    margin-bottom: var(--space-5);
-  }
-
-  .c-dcjLby > .c-eWgOGC {
-    display: block;
-  }
-
-  .c-dcjLby > .c-eWgOGC:not(:first-child) {
+  .c-darjOp > .c-iSnHBU:not(:first-child) {
     margin-top: var(--space-6);
   }
 
-  .c-dcjLby > .c-eWgOGC:not(:last-child) {
+  .c-darjOp > .c-iSnHBU:not(:last-child) {
     margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-fIXJvv {
+    max-width: 75ch;
+  }
+
+  .c-darjOp > .c-fIXJvv:not(:last-child) {
+    margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-iQukjL {
+    max-width: 75ch;
+  }
+
+  .c-darjOp > .c-iQukjL:not(:last-child) {
+    margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-jpqjUq {
+    margin-top: var(--space-6);
+    margin-bottom: var(--space-6);
+  }
+
+  .c-darjOp > .c-eWgOGC {
+    display: block;
+  }
+
+  .c-darjOp > .c-eWgOGC:not(:first-child) {
+    margin-top: var(--space-7);
+  }
+
+  .c-darjOp > .c-eWgOGC:not(:last-child) {
+    margin-bottom: var(--space-7);
   }
 
   .c-iSnHBU {
@@ -172,7 +172,7 @@ exports[`StackContent component renders a stack content 1`] = `
 
 <div>
   <div
-    class="c-dcjLby"
+    class="c-darjOp"
   >
     <h2
       class="c-iSnHBU c-iSnHBU-fOoUdm-size-md"

--- a/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -42,30 +42,30 @@ exports[`Tabs component renders 1`] = `
 }
 
 @media  {
-  .c-dMeHjX-LDxTj-theme-light[data-state="active"] {
+  .c-dMeHjX-cNMtxb-theme-light[data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-dMeHjX-LDxTj-theme-light[data-state="inactive"] {
+  .c-dMeHjX-cNMtxb-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-dMeHjX-LDxTj-theme-light:not([data-disabled]):hover {
+  .c-dMeHjX-cNMtxb-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
-    background: rgba(30, 113, 246, 0.1);
+    background: rgba(15, 103, 245, 0.1);
   }
 
-  .c-dMeHjX-LDxTj-theme-light:not([data-disabled]):active {
+  .c-dMeHjX-cNMtxb-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
-    background: rgba(30, 113, 246, 0.2);
+    background: rgba(15, 103, 245, 0.2);
     box-shadow: none;
   }
 
-  .c-dMeHjX-LDxTj-theme-light[data-disabled],
-  .c-dMeHjX-LDxTj-theme-light[data-disabled]:hover {
+  .c-dMeHjX-cNMtxb-theme-light[data-disabled],
+  .c-dMeHjX-cNMtxb-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -100,7 +100,7 @@ exports[`Tabs component renders 1`] = `
       <button
         aria-controls="radix-2-content-tab1"
         aria-selected="true"
-        class="c-dMeHjX c-dMeHjX-LDxTj-theme-light"
+        class="c-dMeHjX c-dMeHjX-cNMtxb-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="active"
@@ -114,7 +114,7 @@ exports[`Tabs component renders 1`] = `
       <button
         aria-controls="radix-2-content-tab2"
         aria-selected="false"
-        class="c-dMeHjX c-dMeHjX-LDxTj-theme-light"
+        class="c-dMeHjX c-dMeHjX-cNMtxb-theme-light"
         data-orientation="horizontal"
         data-radix-collection-item=""
         data-state="inactive"
@@ -226,30 +226,30 @@ exports[`Tabs component renders mobile view 1`] = `
 }
 
 @media  {
-  .c-dMeHjX-LDxTj-theme-light[data-state="active"] {
+  .c-dMeHjX-cNMtxb-theme-light[data-state="active"] {
     color: var(--colors-primary);
     font-weight: 600;
     letter-spacing: -0.005em;
     box-shadow: inset 0 -2px 0 0 currentColor;
   }
 
-  .c-dMeHjX-LDxTj-theme-light[data-state="inactive"] {
+  .c-dMeHjX-cNMtxb-theme-light[data-state="inactive"] {
     color: var(--colors-tonal500);
   }
 
-  .c-dMeHjX-LDxTj-theme-light:not([data-disabled]):hover {
+  .c-dMeHjX-cNMtxb-theme-light:not([data-disabled]):hover {
     color: var(--colors-primary);
-    background: rgba(30, 113, 246, 0.1);
+    background: rgba(15, 103, 245, 0.1);
   }
 
-  .c-dMeHjX-LDxTj-theme-light:not([data-disabled]):active {
+  .c-dMeHjX-cNMtxb-theme-light:not([data-disabled]):active {
     color: var(--colors-primary);
-    background: rgba(30, 113, 246, 0.2);
+    background: rgba(15, 103, 245, 0.2);
     box-shadow: none;
   }
 
-  .c-dMeHjX-LDxTj-theme-light[data-disabled],
-  .c-dMeHjX-LDxTj-theme-light[data-disabled]:hover {
+  .c-dMeHjX-cNMtxb-theme-light[data-disabled],
+  .c-dMeHjX-cNMtxb-theme-light[data-disabled]:hover {
     color: var(--colors-tonal200);
     cursor: not-allowed;
   }
@@ -364,7 +364,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <button
           aria-controls="radix-5-content-tab1"
           aria-selected="true"
-          class="c-dMeHjX c-dMeHjX-LDxTj-theme-light"
+          class="c-dMeHjX c-dMeHjX-cNMtxb-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -378,7 +378,7 @@ exports[`Tabs component renders mobile view 1`] = `
         <button
           aria-controls="radix-5-content-tab2"
           aria-selected="false"
-          class="c-dMeHjX c-dMeHjX-LDxTj-theme-light"
+          class="c-dMeHjX c-dMeHjX-cNMtxb-theme-light"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"

--- a/lib/src/components/toast/Toast.tsx
+++ b/lib/src/components/toast/Toast.tsx
@@ -52,7 +52,7 @@ const StyledToast = styled('div', {
   minHeight: '$5',
   pl: '$4',
   position: 'relative',
-  pr: '$6',
+  pr: '$7',
   py: '$4',
   transition: 'background-color 50ms ease-out',
   width: '100%',

--- a/lib/src/components/toggle-group/ToggleGroupButton.tsx
+++ b/lib/src/components/toggle-group/ToggleGroupButton.tsx
@@ -13,8 +13,8 @@ const minHeight = {
 
 const px = {
   sm: '$4',
-  md: '$5',
-  lg: '$5'
+  md: '$6',
+  lg: '$6'
 }
 
 const spacingBetweenElements = {

--- a/site/package.json
+++ b/site/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@atom-learning/components": "0.0.0-semantically-released",
     "@atom-learning/icons": "1.9.0",
-    "@atom-learning/theme": "1.0.1",
+    "@atom-learning/theme": "2.0.0-beta.0",
     "@next/mdx": "^10.0.6",
     "@radix-ui/react-id": "0.1.5",
     "@stitches/react": "^1.2.5",

--- a/site/src/components/CodeBlock.tsx
+++ b/site/src/components/CodeBlock.tsx
@@ -56,7 +56,7 @@ const StyledLivePreview = styled(LivePreview, {
   },
   '@md': {
     mx: '-$6',
-    py: '$8'
+    py: '$9'
   }
 })
 const StyledLiveEditor = styled(LiveEditor, {

--- a/site/src/components/CodeBlock.tsx
+++ b/site/src/components/CodeBlock.tsx
@@ -23,7 +23,7 @@ const StyledPre = styled('pre', {
   fontSize: '$sm',
   fontWeight: 100,
   lineHeight: 1.5,
-  mb: '$5',
+  mb: '$6',
   mt: 0,
   mx: '-$4',
   overflow: 'hidden',
@@ -37,7 +37,7 @@ const StyledPre = styled('pre', {
   },
   '@md': {
     fontSize: '15px',
-    mx: '-$5'
+    mx: '-$6'
   }
 })
 const StyledLivePreview = styled(LivePreview, {
@@ -48,14 +48,14 @@ const StyledLivePreview = styled(LivePreview, {
   justifyContent: 'center',
   mx: '-$4',
   overflow: 'visible',
-  p: '$5',
+  p: '$6',
   whiteSpace: 'initial',
   '@sm': {
     borderRadius: '$1',
     mx: 0
   },
   '@md': {
-    mx: '-$5',
+    mx: '-$6',
     py: '$8'
   }
 })
@@ -63,7 +63,7 @@ const StyledLiveEditor = styled(LiveEditor, {
   '> textarea,> pre': {
     p: '$4',
     '@md': {
-      px: '$5',
+      px: '$6',
       py: '$sizes$2'
     }
   }
@@ -139,7 +139,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({
                 overflow: 'auto',
                 p: '$4',
                 '@md': {
-                  px: '$5',
+                  px: '$6',
                   py: '$sizes$2'
                 }
               })}`}

--- a/site/src/components/ColorPalette.tsx
+++ b/site/src/components/ColorPalette.tsx
@@ -41,7 +41,7 @@ export const ColorPalette: React.FC<ColorPaletteProps> = ({ colors, ...props }) 
           return (
             <Flex key={key} css={{ alignItems: 'center' }}>
               <Box
-                css={{ borderRadius: '$round', bg: `$${key}`, size: '$6' }}
+                css={{ borderRadius: '$round', bg: `$${key}`, size: '$7' }}
               />
               <Flex css={{ pl: '$3', flexDirection: 'column' }}>
                 <Text css={{ fontWeight: 600, mb: '$3' }}>{`$${key}`}</Text>

--- a/site/src/components/ColorPalette.tsx
+++ b/site/src/components/ColorPalette.tsx
@@ -21,17 +21,14 @@ const transformPalette = (colors) => {
   return palette
 }
 
-export const ColorPalette: React.FC<ColorPaletteProps> = ({
-  colors,
-  ...props
-}) => (
+export const ColorPalette: React.FC<ColorPaletteProps> = ({ colors, ...props }) => (
   <Flex css={{ flexDirection: 'column', flexWrap: 'wrap' }} {...props}>
     {Object.entries(transformPalette(colors)).map(([key, value]) => (
       <Flex
         css={{
           flexDirection: 'column',
           flexWrap: 'wrap',
-          py: '$5',
+          py: '$6',
           gap: '$3',
           '&:not(:last-child)': { borderBottom: '1px solid $tonal100' }
         }}

--- a/site/src/components/Group.tsx
+++ b/site/src/components/Group.tsx
@@ -11,7 +11,7 @@ const Section = ({ gap = '$2', direction = 'row', css = {}, ...props }) => (
     css={{
       flexWrap: 'wrap',
       flexDirection: direction,
-      mb: '$5',
+      mb: '$6',
       gap,
       ...(css as any)
     }}
@@ -25,7 +25,7 @@ export const Group: React.FC<GroupProps> & {
   Separator: typeof Separator
 } = ({ name, children }) => (
   <Box css={{ '@md': { mx: '-$8' }, mb: '$8' }}>
-    <Text size="xl" as="h2" css={{ fontWeight: 600, mb: '$5' }}>
+    <Text size="xl" as="h2" css={{ fontWeight: 600, mb: '$6' }}>
       {name}
     </Text>
     {children}

--- a/site/src/components/Group.tsx
+++ b/site/src/components/Group.tsx
@@ -24,12 +24,12 @@ export const Group: React.FC<GroupProps> & {
   Section: typeof Section
   Separator: typeof Separator
 } = ({ name, children }) => (
-  <Box css={{ '@md': { mx: '-$8' }, mb: '$8' }}>
+  <Box css={{ '@md': { mx: '-$9' }, mb: '$9' }}>
     <Text size="xl" as="h2" css={{ fontWeight: 600, mb: '$6' }}>
       {name}
     </Text>
     {children}
-    <Divider css={{ my: '$8' }} />
+    <Divider css={{ my: '$9' }} />
   </Box>
 )
 

--- a/site/src/components/IconTable.tsx
+++ b/site/src/components/IconTable.tsx
@@ -31,7 +31,7 @@ const IconTableItem = ({ name, Component }) => (
       flex: '1 0 auto',
       flexDirection: 'column',
       justifyContent: 'center',
-      p: '$5 $2',
+      p: '$6 $2',
       minWidth: 140,
       width: 'calc(100% / 5 - ($space$2 * 4))',
       position: 'relative',
@@ -87,7 +87,7 @@ export const IconTable: React.FC<IconTableProps> = ({ css }) => {
   )
 
   return (
-    <Box css={{ pt: '$5' }}>
+    <Box css={{ pt: '$6' }}>
       <SearchInput
         size="md"
         name="icon-search"

--- a/site/src/components/Pagination.tsx
+++ b/site/src/components/Pagination.tsx
@@ -50,7 +50,7 @@ export const Pagination: React.FC<PaginationProps> = ({
 
   return (
     <Box as="footer" css={{ bg: '$tonal50', mt: '$9' }}>
-      <Container css={{ display: 'flex', py: '$6', px: '$4' }}>
+      <Container css={{ display: 'flex', py: '$7', px: '$4' }}>
         {previousPage && (
           <PaginationItem align="left" label="Previous" page={previousPage} />
         )}

--- a/site/src/components/Pagination.tsx
+++ b/site/src/components/Pagination.tsx
@@ -49,7 +49,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   const previousPage = orderedPages[currentPageIndex - 1]
 
   return (
-    <Box as="footer" css={{ bg: '$tonal50', mt: '$8' }}>
+    <Box as="footer" css={{ bg: '$tonal50', mt: '$9' }}>
       <Container css={{ display: 'flex', py: '$6', px: '$4' }}>
         {previousPage && (
           <PaginationItem align="left" label="Previous" page={previousPage} />

--- a/site/src/components/PropsTable.tsx
+++ b/site/src/components/PropsTable.tsx
@@ -177,7 +177,7 @@ export const PropsTable: React.FC<PropsTableProps> = ({
 }) => {
   if (componentName.includes(',')) {
     return (
-      <Box css={{ mt: '$8' }}>
+      <Box css={{ mt: '$9' }}>
         <Heading as="h2" css={{ mb: '$6', color: '$tonal800' }}>
           API Reference
         </Heading>
@@ -191,7 +191,7 @@ export const PropsTable: React.FC<PropsTableProps> = ({
               </Heading>
               <PropsTableContent
                 component={componentProps}
-                css={{ mb: '$8', color: '$tonal800' }}
+                css={{ mb: '$9', color: '$tonal800' }}
               />
             </React.Fragment>
           )
@@ -204,7 +204,7 @@ export const PropsTable: React.FC<PropsTableProps> = ({
   if (!componentProps) return null
 
   return (
-    <Box css={{ mt: '$8' }}>
+    <Box css={{ mt: '$9' }}>
       <Heading as="h2" css={{ mb: '$4' }}>
         API Reference
       </Heading>

--- a/site/src/components/PropsTable.tsx
+++ b/site/src/components/PropsTable.tsx
@@ -143,7 +143,7 @@ const PropsTableContent: React.FC<{ css?: CSS; component: ComponentDoc }> = ({
 
             return (
               <tr key={key}>
-                <Cell css={{ pr: '$5' }}>
+                <Cell css={{ pr: '$6' }}>
                   <InlineCode>{name}</InlineCode>
                 </Cell>
                 <Cell>
@@ -178,7 +178,7 @@ export const PropsTable: React.FC<PropsTableProps> = ({
   if (componentName.includes(',')) {
     return (
       <Box css={{ mt: '$8' }}>
-        <Heading as="h2" css={{ mb: '$5', color: '$tonal800' }}>
+        <Heading as="h2" css={{ mb: '$6', color: '$tonal800' }}>
           API Reference
         </Heading>
         {componentName.split(',').map((component) => {

--- a/site/src/components/Scale.tsx
+++ b/site/src/components/Scale.tsx
@@ -41,7 +41,7 @@ export const Scale: React.FC<ScaleProps> = ({
         css={{
           alignItems: 'center',
           justifyContent: 'space-between',
-          py: '$5',
+          py: '$6',
           '&:not(:last-child)': {
             borderBottom: '1px solid $tonal100'
           }

--- a/site/src/components/navigation/Navigation.tsx
+++ b/site/src/components/navigation/Navigation.tsx
@@ -103,7 +103,7 @@ export const Navigation: React.FC<NavigationProps> = ({ items, version }) => {
           {version}
         </Badge>
         {Object.entries(items).map(([source, content]) => (
-          <Box css={{ mb: '$6' }} key={source}>
+          <Box css={{ mb: '7' }} key={source}>
             <Heading as="h2" size="sm" css={{ color: 'white', mb: '$4' }}>
               {capitalCase(source)}
             </Heading>

--- a/site/src/components/navigation/Navigation.tsx
+++ b/site/src/components/navigation/Navigation.tsx
@@ -93,7 +93,7 @@ export const Navigation: React.FC<NavigationProps> = ({ items, version }) => {
       <NavigationTrigger onClick={() => setMenuOpen(true)} />
       <StyledNavigation ref={ref} open={menuOpen}>
         <NextLink href="/">
-          <Image src={logo} css={{ cursor: 'pointer', mb: '$7', width: 80 }} />
+          <Image src={logo} css={{ cursor: 'pointer', mb: '$8', width: 80 }} />
         </NextLink>
         <Badge
           theme="success"

--- a/site/src/pages/[category]/[slug].tsx
+++ b/site/src/pages/[category]/[slug].tsx
@@ -53,7 +53,7 @@ const Page: React.FC<PageProps> = ({
       <Flex as="main" css={{ width: '100%', flexDirection: 'column' }}>
         <Box
           as="header"
-          css={{ bg: '$tonal50', pt: '128px', pb: '$8', '@md': { py: '$8' } }}
+          css={{ bg: '$tonal50', pt: '128px', pb: '$9', '@md': { py: '$9' } }}
         >
           <Container css={{ px: '$4' }}>
             <Heading as="h1" size="lg" css={data.component ? { mb: '$6' } : {}}>
@@ -67,9 +67,9 @@ const Page: React.FC<PageProps> = ({
             )}
           </Container>
         </Box>
-        <Container css={{ flex: 1, px: '$4', py: '$8' }}>
+        <Container css={{ flex: 1, px: '$4', py: '$9' }}>
           {data.description && (
-            <Text size="lg" css={{ mb: data.component ? '6' : '$8' }}>
+            <Text size="lg" css={{ mb: data.component ? '$6' : '$9' }}>
               {data.description}
             </Text>
           )}

--- a/site/src/pages/[category]/[slug].tsx
+++ b/site/src/pages/[category]/[slug].tsx
@@ -56,7 +56,7 @@ const Page: React.FC<PageProps> = ({
           css={{ bg: '$tonal50', pt: '128px', pb: '$8', '@md': { py: '$8' } }}
         >
           <Container css={{ px: '$4' }}>
-            <Heading as="h1" size="lg" css={data.component ? { mb: '$5' } : {}}>
+            <Heading as="h1" size="lg" css={data.component ? { mb: '$6' } : {}}>
               {data.title}
             </Heading>
             {data.component && (
@@ -69,7 +69,7 @@ const Page: React.FC<PageProps> = ({
         </Box>
         <Container css={{ flex: 1, px: '$4', py: '$8' }}>
           {data.description && (
-            <Text size="lg" css={{ mb: data.component ? '$5' : '$8' }}>
+            <Text size="lg" css={{ mb: data.component ? '6' : '$8' }}>
               {data.description}
             </Text>
           )}

--- a/site/src/pages/components.tsx
+++ b/site/src/pages/components.tsx
@@ -33,15 +33,15 @@ const Page: React.FC<PageProps> = ({ pages, version }) => (
     <Flex>
       <Navigation items={pages} version={version} />
       <Box as="main" css={{ width: '100%' }}>
-        <Box as="header" css={{ bg: '$tonal50', py: '$8' }}>
+        <Box as="header" css={{ bg: '$tonal50', py: '$9' }}>
           <Container css={{ px: '$4' }}>
             <Heading as="h1" size="lg">
               Components
             </Heading>
           </Container>
         </Box>
-        <Container css={{ px: '$4', py: '$8' }}>
-          <Text size="lg" css={{ mb: '$8' }}>
+        <Container css={{ px: '$4', py: '$9' }}>
+          <Text size="lg" css={{ mb: '$9' }}>
             An environment for displaying all of our components in various
             configurations to help test and validate design consistency
           </Text>

--- a/site/src/sandbox/components.tsx
+++ b/site/src/sandbox/components.tsx
@@ -100,7 +100,7 @@ const AlertComponent = () => {
 
 const Page = () => (
   <>
-    <Divider css={{ my: '$8' }} />
+    <Divider css={{ my: '$9' }} />
     <Group name="Assets">
       <Image src={logo} />
       <Text size="sm" css={{ mt: '$3', mb: '$6', color: '$tonal600' }}>

--- a/site/src/sandbox/components.tsx
+++ b/site/src/sandbox/components.tsx
@@ -103,24 +103,24 @@ const Page = () => (
     <Divider css={{ my: '$8' }} />
     <Group name="Assets">
       <Image src={logo} />
-      <Text size="sm" css={{ mt: '$3', mb: '$5', color: '$tonal600' }}>
+      <Text size="sm" css={{ mt: '$3', mb: '$6', color: '$tonal600' }}>
         @atom-learning/theme/lib/assets/logo.svg
       </Text>
       <Group.Separator />
       <Box css={{ m: '-$2', p: '$2', bg: '$tonal100', width: 'max-content' }}>
         <Image src={logoLight} />
       </Box>
-      <Text size="sm" css={{ mt: '$3', mb: '$5', color: '$tonal600' }}>
+      <Text size="sm" css={{ mt: '$3', mb: '$6', color: '$tonal600' }}>
         @atom-learning/theme/lib/assets/logo-light.svg
       </Text>
       <Group.Separator />
       <Image src={logoPrimary} />
-      <Text size="sm" css={{ mt: '$3', mb: '$5', color: '$tonal600' }}>
+      <Text size="sm" css={{ mt: '$3', mb: '$6', color: '$tonal600' }}>
         @atom-learning/theme/lib/assets/logo-primary.svg
       </Text>
     </Group>
     <Group name="Typography">
-      <Group.Section gap="$5" css={{ flexDirection: 'column' }}>
+      <Group.Section gap="$6" css={{ flexDirection: 'column' }}>
         <Heading size="xs">This is a heading size xs</Heading>
         <Heading size="sm">This is a heading size sm</Heading>
         <Heading size="md">This is a heading size md</Heading>
@@ -633,7 +633,7 @@ post.
       </Group.Section>
     </Group>
     <Group name="Links">
-      <Group.Section direction="column" gap="$5">
+      <Group.Section direction="column" gap="$6">
         <Text size="sm">
           This is a sm Paragraph with a <Link>Link</Link>. A really long
           paragraph of text, to demonstrate prose text, like for example.
@@ -684,7 +684,7 @@ post.
       </Group.Section>
     </Group>
     <Group name="Tables">
-      <Table css={{ borderCollapse: 'collapse', mb: '$5' }}>
+      <Table css={{ borderCollapse: 'collapse', mb: '$6' }}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>First Name</Table.HeaderCell>
@@ -825,7 +825,7 @@ post.
       <Group.Section>
         <Form
           onSubmit={() => null}
-          css={{ display: 'flex', gap: '$5', flexDirection: 'column' }}
+          css={{ display: 'flex', gap: '$6', flexDirection: 'column' }}
         >
           <InputField
             name="input"
@@ -1080,7 +1080,7 @@ post.
             <Slider defaultValue={[50]} css={{ width: '320px' }}>
               <Slider.Value value={[50]} />
             </Slider>
-            <Box css={{ p: '$5', bg: '$tonal100' }}>
+            <Box css={{ p: '$6', bg: '$tonal100' }}>
               <Slider
                 theme="light"
                 defaultValue={[50]}
@@ -1095,7 +1095,7 @@ post.
           onSubmit={() => null}
           css={{
             display: 'flex',
-            gap: '$5',
+            gap: '$6',
             flexDirection: 'column',
             width: '100%'
           }}
@@ -1230,7 +1230,7 @@ post.
       >
         <Carousel.ArrowPrevious css={{ position: 'absolute', left: '$2' }} />
         <Carousel.ArrowNext css={{ position: 'absolute', right: '$2' }} />
-        <Carousel.Slider aria-label="Example carousel" css={{ mb: '$5' }}>
+        <Carousel.Slider aria-label="Example carousel" css={{ mb: '$6' }}>
           <Carousel.Slide index={1} aria-label="Slide 1">
             <Box css={{ bg: '$primary', size: 200 }} />
           </Carousel.Slide>
@@ -1268,10 +1268,10 @@ post.
             <Button>Click for dialog</Button>
           </Dialog.Trigger>
           <Dialog.Content>
-            <Heading size="sm" css={{ mb: '$5' }}>
+            <Heading size="sm" css={{ mb: '$6' }}>
               Dialog
             </Heading>
-            <Text css={{ mb: '$5' }}>
+            <Text css={{ mb: '$6' }}>
               The `Dialog` can display any type of element as a trigger and has
               the content hidden by default
             </Text>
@@ -1289,10 +1289,10 @@ post.
             <Button>Click for nested surfaces</Button>
           </Dialog.Trigger>
           <Dialog.Content>
-            <Heading size="sm" css={{ mb: '$5' }}>
+            <Heading size="sm" css={{ mb: '$6' }}>
               Dialog
             </Heading>
-            <Text css={{ mb: '$5' }}>
+            <Text css={{ mb: '6' }}>
               The `Dialog` can display any type of element as a trigger and has
               the content hidden by default
             </Text>

--- a/site/src/utilities/transform-mdx.tsx
+++ b/site/src/utilities/transform-mdx.tsx
@@ -21,17 +21,17 @@ const components: MdxRemote.Components = {
       {...props}
       size="md"
       as="h2"
-      css={{ fontWeight: 600, mt: '$8', mb: '$5' }}
+      css={{ fontWeight: 600, mt: '$8', mb: '$6' }}
     />
   ),
   h3: (props) => (
-    <Heading {...props} as="h3" size="sm" css={{ mt: '$5', mb: '$4' }} />
+    <Heading {...props} as="h3" size="sm" css={{ mt: '$6', mb: '$4' }} />
   ),
   h4: (props) => (
-    <Heading {...props} as="h4" size="xs" css={{ mt: '$5', mb: '$4' }} />
+    <Heading {...props} as="h4" size="xs" css={{ mt: '$6', mb: '$4' }} />
   ),
-  p: (props) => <Text {...props} css={{ color: '$tonal700', mb: '$5' }} />,
-  ul: (props) => <List {...props} css={{ mb: '$5' }} />,
+  p: (props) => <Text {...props} css={{ color: '$tonal700', mb: '$6' }} />,
+  ul: (props) => <List {...props} css={{ mb: '$6' }} />,
   li: List.Item,
   inlineCode: InlineCode,
   blockquote: (props) => (
@@ -39,8 +39,8 @@ const components: MdxRemote.Components = {
       {...props}
       as="blockquote"
       css={{
-        pl: '$5',
-        my: '$5',
+        pl: '$6',
+        my: '$6',
         color: '$tonal500',
         borderLeft: '2px solid $colors$tonal400'
       }}
@@ -51,7 +51,7 @@ const components: MdxRemote.Components = {
   a: Link,
   code: CodeBlock,
   hr: (props) => <Divider {...props} css={{ my: '$8' }} />,
-  table: (props) => <Table {...props} css={{ mb: '$5' }} />,
+  table: (props) => <Table {...props} css={{ mb: '$6' }} />,
   td: (props) => <Cell size="md" appearance="content" {...props} />,
   th: (props) => <Cell size="md" appearance="heading" {...props} />,
   ColorPalette,

--- a/site/src/utilities/transform-mdx.tsx
+++ b/site/src/utilities/transform-mdx.tsx
@@ -21,7 +21,7 @@ const components: MdxRemote.Components = {
       {...props}
       size="md"
       as="h2"
-      css={{ fontWeight: 600, mt: '$8', mb: '$6' }}
+      css={{ fontWeight: 600, mt: '$9', mb: '$6' }}
     />
   ),
   h3: (props) => (
@@ -50,7 +50,7 @@ const components: MdxRemote.Components = {
   ),
   a: Link,
   code: CodeBlock,
-  hr: (props) => <Divider {...props} css={{ my: '$8' }} />,
+  hr: (props) => <Divider {...props} css={{ my: '$9' }} />,
   table: (props) => <Table {...props} css={{ mb: '$6' }} />,
   td: (props) => <Cell size="md" appearance="content" {...props} />,
   th: (props) => <Cell size="md" appearance="heading" {...props} />,

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,10 +32,10 @@
     chalk "^4.1.0"
     css "^3.0.0"
 
-"@atom-learning/theme@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-1.0.1.tgz#75b04b0f650d6194d26de9efaac7042ecc6f807a"
-  integrity sha512-vf18VU9LWXdv4JYmhn1vZXS6Nk/0HY/XNw0jVCpcn8xJhxPi6Y01zOaOxRpcvl+6hhKQtUKF36rHdn0VHgJ5ng==
+"@atom-learning/theme@2.0.0-beta.0":
+  version "2.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-2.0.0-beta.0.tgz#2c90c3a3d12d20778855d80779add13df377d40c"
+  integrity sha512-22nKpI9ieLBbeZ6J6MZ0M/Ti+N6yDUnVueHNWhEtC99rSDJMF/37XtS+3zi1ZYVk0OqEdbWYkyhC8oULmIcLng==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"


### PR DESCRIPTION
We need a `24px` option in our space scale. `24px` falls in between the current `$4` and `$5` values, so we have to update `$5` to `24px` and then bump `$6`, `$7` and `$8` up one each.

The scale is changed in the [theme repo here](https://github.com/Atom-Learning/theme/pull/19). In this PR we find every usage of the space scale `$5` or higher token and bump it up to the next token.

Jira ticket: https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-106