### PR TITLE
feat: calendar year picker

### DIFF
--- a/lib/src/components/calendar/Calendar.test.tsx
+++ b/lib/src/components/calendar/Calendar.test.tsx
@@ -36,6 +36,57 @@ describe('Calendar component', () => {
     expect(await screen.queryByText('Dec 2021')).not.toBeInTheDocument()
   })
 
+  it('opens the change year view when year is clicked', async () => {
+    render(<Calendar {...props} />)
+
+    const yearButton = await screen.findByText('Dec 2021')
+    fireEvent.click(yearButton)
+
+    expect(await screen.queryByText('Dec 2021')).not.toBeInTheDocument()
+    expect(await screen.findByText('2020')).toBeVisible()
+  })
+
+  it('changes year when change year arrows are pressed', async () => {
+    render(<Calendar {...props} />)
+
+    const yearButton = await screen.findByText('Dec 2021')
+    fireEvent.click(yearButton)
+
+    const arrow = await screen.findByLabelText('Next year')
+    fireEvent.click(arrow)
+
+    expect(await screen.queryByText('2021')).not.toBeInTheDocument()
+    expect(await screen.findByText('2025')).toBeVisible()
+  })
+
+  it('cannot select year later than max date year', async () => {
+    render(<Calendar {...props} maxDate={new Date('2025-01-01')} />)
+
+    const yearButton = await screen.findByText('Dec 2021')
+    fireEvent.click(yearButton)
+
+    const arrow = await screen.findByLabelText('Next year')
+    fireEvent.click(arrow)
+
+    expect(await screen.queryByText('2021')).not.toBeInTheDocument()
+    expect(await screen.findByText('2025')).toBeVisible()
+    expect(await screen.queryByText('2026')).not.toBeInTheDocument()
+  })
+
+  it('cannot select year earlier than min date year', async () => {
+    render(<Calendar {...props} minDate={new Date('2000-01-01')} />)
+
+    const yearButton = await screen.findByText('Dec 2021')
+    fireEvent.click(yearButton)
+
+    const arrow = await screen.findByLabelText('Previous year')
+    fireEvent.click(arrow)
+
+    expect(await screen.queryByText('2021')).not.toBeInTheDocument()
+    expect(await screen.findByText('2000')).toBeVisible()
+    expect(await screen.queryByText('1999')).not.toBeInTheDocument()
+  })
+
   it('renders translated weekday names', async () => {
     render(
       <Calendar

--- a/lib/src/components/calendar/Calendar.tsx
+++ b/lib/src/components/calendar/Calendar.tsx
@@ -160,6 +160,9 @@ export const Calendar: React.FC<CalendarProps> = ({
         >
           {yearList.map((year, i) => {
             const isCurrentYear = year === date.getFullYear()
+            if (!year)
+              return <Box key={i} css={{ width: '$6', height: '$4' }} />
+
             return (
               <StyledButton
                 key={`${year}${i}`}
@@ -167,9 +170,8 @@ export const Calendar: React.FC<CalendarProps> = ({
                 isRounded
                 onClick={() => handleSetYear(year)}
                 selected={isCurrentYear}
-                disabled={year === 0}
               >
-                {year !== 0 && year}
+                {year}
               </StyledButton>
             )
           })}

--- a/lib/src/components/calendar/Calendar.tsx
+++ b/lib/src/components/calendar/Calendar.tsx
@@ -6,13 +6,13 @@ import * as React from 'react'
 import { ActionIcon } from '~/components/action-icon'
 import { Box } from '~/components/box'
 import { Flex } from '~/components/flex'
-import { Heading } from '~/components/heading'
 import { Icon } from '~/components/icon'
 import { Text } from '~/components/text'
+import { Button } from '~/components/button'
 import type { CSS } from '~/stitches'
 import { styled } from '~/stitches'
 
-import { monthNamesShort, weekdayNamesShort } from './constants'
+import { monthNamesShort, weekdayNamesShort, DEFAULT_LABELS } from './constants'
 import { Day } from './Day'
 
 const Grid = styled('div', {
@@ -21,10 +21,35 @@ const Grid = styled('div', {
   gridGap: '$1 $2'
 })
 
+const StyledButton = styled(Button, {
+  color: '$tonal600',
+  p: '$3',
+  width: '$6',
+  variants: {
+    selected: {
+      false: {
+        color: '$tonal600 !important',
+        fontWeight: '400',
+        '&:hover': {
+          bg: '$tonal100 !important',
+          color: '$tonal600 !important'
+        },
+        '&[disabled]': { bg: 'white !important' }
+      }
+    }
+  }
+})
+
 export type CalendarTranslationProps = {
   monthNames?: string[]
   weekdayNames?: string[]
-  labels?: { open: string; next: string; previous: string }
+  labels?: {
+    open: string
+    next: string
+    previous: string
+    nextYear: string
+    previousYear: string
+  }
 }
 
 type CalendarProps = DayzedInterface &
@@ -32,6 +57,7 @@ type CalendarProps = DayzedInterface &
     css?: CSS
     refDateToday?: React.RefObject<HTMLButtonElement>
     refDateSelected?: React.RefObject<HTMLButtonElement>
+    setYear: (date: Date) => Promise<void>
   }
 
 const offsetWeekdayNames = (
@@ -50,12 +76,44 @@ export const Calendar: React.FC<CalendarProps> = ({
   firstDayOfWeek = 0,
   monthNames = monthNamesShort,
   weekdayNames = weekdayNamesShort,
-  labels = { next: 'Next month', previous: 'Previous month' },
+  labels = DEFAULT_LABELS,
+  date = new Date(),
+  minDate,
+  maxDate,
+  setYear,
   ...remainingProps
 }) => {
+  const [showYears, setShowYears] = React.useState<boolean>(false)
+  const [currentYear, setCurrentYear] = React.useState<number>(
+    date?.getFullYear()
+  )
+
+  const handleSetYear = (year: number): void => {
+    const newDate = date
+    newDate.setFullYear(year)
+    setYear(newDate)
+    setShowYears(false)
+  }
+
+  const isAtMinYear = minDate && currentYear - 16 <= minDate.getFullYear()
+  const isAtMaxYear = maxDate && currentYear >= maxDate.getFullYear()
+
+  const yearList = Array.from({ length: 16 }, (_, i) => {
+    const year = currentYear - i
+    if (
+      (maxDate && year > maxDate.getFullYear()) ||
+      (minDate && year < minDate.getFullYear())
+    )
+      return 0
+    return year
+  })
+
   const { calendars, getBackProps, getForwardProps, getDateProps } = useDayzed({
     firstDayOfWeek,
     showOutsideDays: true,
+    date,
+    minDate,
+    maxDate,
     ...remainingProps
   })
 
@@ -67,70 +125,112 @@ export const Calendar: React.FC<CalendarProps> = ({
     >
       <Flex css={{ position: 'absolute', top: 0, right: '-$1' }}>
         <ActionIcon
-          label={labels.previous}
+          label={labels[showYears ? 'previousYear' : 'previous']}
           theme="neutral"
           size="lg"
-          {...getBackProps({ calendars })}
+          {...(!showYears && getBackProps({ calendars }))}
+          {...(showYears && {
+            onClick: () => setCurrentYear(currentYear - 16)
+          })}
+          disabled={showYears && isAtMinYear}
         >
           <Icon is={ChevronLeft} />
         </ActionIcon>
         <ActionIcon
-          label={labels.next}
+          label={labels[showYears ? 'nextYear' : 'next']}
           theme="neutral"
           size="lg"
-          {...getForwardProps({ calendars })}
+          {...(!showYears && getForwardProps({ calendars }))}
+          {...(showYears && {
+            onClick: () => setCurrentYear(currentYear + 16)
+          })}
+          disabled={showYears && isAtMaxYear}
         >
           <Icon is={ChevronRight} />
         </ActionIcon>
       </Flex>
-      {calendars.map(({ month, year, weeks }) => (
-        <Box key={`${month}${year}`}>
-          <Flex css={{ height: '$4', alignItems: 'center', mb: '$4' }}>
-            <Heading size="xs">
-              {monthNames[month]} {year}
-            </Heading>
-          </Flex>
-          <Grid css={{ mb: '$3' }}>
-            {offsetWeekdayNames(weekdayNames, firstDayOfWeek).map((weekday) => (
-              <Text
-                as="span"
-                size="sm"
-                key={`${month}${year}${weekday}`}
-                css={{ fontWeight: 600, textAlign: 'center' }}
+      {showYears && (
+        <Grid
+          css={{
+            gridTemplateColumns: 'repeat(4, 1fr)',
+            pt: '$7',
+            direction: 'rtl',
+            gridGap: '$3 $1'
+          }}
+        >
+          {yearList.map((year, i) => {
+            const isCurrentYear = year === date.getFullYear()
+            return (
+              <StyledButton
+                key={`${year}${i}`}
+                theme={isCurrentYear ? 'primary' : 'neutral'}
+                isRounded
+                onClick={() => handleSetYear(year)}
+                selected={isCurrentYear}
+                disabled={year === 0}
               >
-                {weekday}
-              </Text>
-            ))}
-          </Grid>
-          <Grid>
-            {weeks.map((week, weekIndex) =>
-              week.map((dateObj, index) => {
-                const key = `${month}${year}${weekIndex}${index}`
-
-                if (!dateObj) return <div key={key} />
-
-                const { date, selected, today, prevMonth, nextMonth } = dateObj
-
-                return (
-                  <Day
-                    isOutsideMonth={prevMonth || nextMonth}
-                    isSelected={selected}
-                    isToday={today}
-                    key={key}
-                    ref={
-                      selected ? refDateSelected : today ? refDateToday : null
-                    }
-                    {...getDateProps({ dateObj })}
-                    type="button"
+                {year !== 0 && year}
+              </StyledButton>
+            )
+          })}
+        </Grid>
+      )}
+      {!showYears &&
+        calendars.map(({ month, year, weeks }) => (
+          <Box key={`${month}${year}`}>
+            <Flex css={{ height: '$4', alignItems: 'center', mb: '$4' }}>
+              <Button
+                theme="neutral"
+                css={{ px: '0', color: '$tonal600' }}
+                onClick={() => setShowYears(true)}
+              >
+                {monthNames[month]} {year}
+              </Button>
+            </Flex>
+            <Grid css={{ mb: '$3' }}>
+              {offsetWeekdayNames(weekdayNames, firstDayOfWeek).map(
+                (weekday) => (
+                  <Text
+                    as="span"
+                    size="sm"
+                    key={`${month}${year}${weekday}`}
+                    css={{ fontWeight: 600, textAlign: 'center' }}
                   >
-                    {date.getDate()}
-                  </Day>
+                    {weekday}
+                  </Text>
                 )
-              })
-            )}
-          </Grid>
-        </Box>
-      ))}
+              )}
+            </Grid>
+            <Grid>
+              {weeks.map((week, weekIndex) =>
+                week.map((dateObj, index) => {
+                  const key = `${month}${year}${weekIndex}${index}`
+
+                  if (!dateObj) return <div key={key} />
+
+                  const { date, selected, today, prevMonth, nextMonth } =
+                    dateObj
+
+                  return (
+                    <Day
+                      isOutsideMonth={prevMonth || nextMonth}
+                      isSelected={selected}
+                      isToday={today}
+                      key={key}
+                      ref={
+                        selected ? refDateSelected : today ? refDateToday : null
+                      }
+                      {...getDateProps({ dateObj })}
+                      type="button"
+                    >
+                      {date.getDate()}
+                    </Day>
+                  )
+                })
+              )}
+            </Grid>
+          </Box>
+        ))}
     </Box>
   )
 }

--- a/lib/src/components/calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/lib/src/components/calendar/__snapshots__/Calendar.test.tsx.snap
@@ -30,11 +30,21 @@ exports[`Calendar component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-iSnHBU {
-    color: var(--colors-tonal600);
-    font-family: var(--fonts-display);
-    font-weight: 700;
-    margin: 0;
+  .c-fkUJsw {
+    align-items: center;
+    background: unset;
+    border: unset;
+    border-radius: var(--radii-0);
+    cursor: pointer;
+    display: flex;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    justify-content: center;
+    padding: unset;
+    text-decoration: none;
+    transition: all 100ms ease-out;
+    white-space: nowrap;
+    width: max-content;
   }
 
   .c-fPxPMR {
@@ -96,23 +106,12 @@ exports[`Calendar component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-iSnHBU-llheLm-size-xs {
-    font-family: var(--fonts-body);
-    font-weight: 600;
+  .c-fkUJsw-elrwsr-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
-  }
-
-  .c-iSnHBU-llheLm-size-xs::before {
-    content: '';
-    margin-bottom: -0.3864em;
-    display: table;
-  }
-
-  .c-iSnHBU-llheLm-size-xs::after {
-    content: '';
-    margin-top: -0.3864em;
-    display: table;
+    height: var(--sizes-4);
+    padding-left: var(--space-5);
+    padding-right: var(--space-5);
   }
 
   .c-fIXJvv-bndJoy-size-sm {
@@ -160,6 +159,27 @@ exports[`Calendar component renders 1`] = `
     color: var(--colors-tonal400);
     cursor: not-allowed;
   }
+
+  .c-fkUJsw-iRJCoR-cv {
+    background: white;
+    color: var(--colors-primary);
+  }
+
+  .c-fkUJsw-iRJCoR-cv[disabled] {
+    background: var(--colors-tonal100);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-iRJCoR-cv:not([disabled]):hover,
+  .c-fkUJsw-iRJCoR-cv:not([disabled]):focus {
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--colors-primary);
+  }
+
+  .c-fkUJsw-iRJCoR-cv:not([disabled]):active {
+    background: rgba(255, 255, 255, 0.75);
+  }
 }
 
 @media  {
@@ -184,6 +204,12 @@ exports[`Calendar component renders 1`] = `
     height: var(--sizes-4);
     align-items: center;
     margin-bottom: var(--space-4);
+  }
+
+  .c-fkUJsw-ikwYYXS-css {
+    padding-left: 0;
+    padding-right: 0;
+    color: var(--colors-tonal600);
   }
 
   .c-fPxPMR-ihbtntv-css {
@@ -242,13 +268,14 @@ exports[`Calendar component renders 1`] = `
       <div
         class="c-dhzjXW c-dhzjXW-iePfWBT-css"
       >
-        <h2
-          class="c-iSnHBU c-iSnHBU-llheLm-size-xs"
+        <button
+          class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-iRJCoR-cv c-fkUJsw-ikwYYXS-css"
+          type="button"
         >
           Dec
            
           2021
-        </h2>
+        </button>
       </div>
       <div
         class="c-fPxPMR c-fPxPMR-ihbtntv-css"

--- a/lib/src/components/calendar/constants.ts
+++ b/lib/src/components/calendar/constants.ts
@@ -22,3 +22,11 @@ export const weekdayNamesShort = [
   'Fri',
   'Sat'
 ]
+
+export const DEFAULT_LABELS = {
+  open: 'Open calendar',
+  next: 'Next month',
+  previous: 'Previous month',
+  nextYear: 'Next year',
+  previousYear: 'Previous year'
+}

--- a/lib/src/components/date-input/DateInput.tsx
+++ b/lib/src/components/date-input/DateInput.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { ActionIcon } from '../action-icon/ActionIcon'
 import { Box } from '../box/Box'
 import { Calendar, CalendarTranslationProps } from '../calendar/Calendar'
+import { DEFAULT_LABELS } from '../calendar/constants'
 import { Icon } from '../icon/Icon'
 import { Input } from '../input/Input'
 import { Popover } from '../popover/Popover'
@@ -31,18 +32,20 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       monthNames,
       weekdayNames,
       size = 'md',
-      labels = {
-        open: 'Open calendar',
-        next: 'Next month',
-        previous: 'Previous month'
-      },
+      labels,
       revalidate,
       onChange,
+      minDate,
+      maxDate,
       ...remainingProps
     },
     ref
   ) => {
     const { date, dateString, setDate } = useDate(initialDate, dateFormat)
+    const updatedLabels = {
+      ...DEFAULT_LABELS,
+      ...labels
+    }
 
     const [calendarOpen, setCalendarOpen] = React.useState(false)
 
@@ -69,7 +72,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
             <ActionIcon
               css={{ position: 'absolute', top: 0, right: 0 }}
               disabled={disabled}
-              label={labels.open}
+              label={updatedLabels.open}
               size={size === 'sm' ? 'md' : 'lg'}
               theme="neutral"
             >
@@ -98,12 +101,18 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                 await setDate(date.date, false)
                 if (revalidate) revalidate()
               }}
+              setYear={async (date) => {
+                await setDate(date, false)
+                if (revalidate) revalidate()
+              }}
+              minDate={minDate}
+              maxDate={maxDate}
               refDateToday={refDateToday}
               refDateSelected={refDateSelected}
               firstDayOfWeek={firstDayOfWeek}
               monthNames={monthNames}
               weekdayNames={weekdayNames}
-              labels={labels}
+              labels={updatedLabels}
             />
           </Popover.Content>
         </Popover>


### PR DESCRIPTION
### Description

As we have added the date input for DOB on the new signup flow in core, we wanted to add a year selector to the calendar. You can now click on the year when viewing the calendar, and you'll be shown a grid of years you can click on and scroll through with the arrows. Clicking a year sets the year for the current set date but keeps the day and month, and takes you back to the calendar screen.

This year grid is constrained within the minDate and maxDate values (if set), so you can't use it to set a date you otherwise wouldn't be able to set.

### Screenshots

![image](https://user-images.githubusercontent.com/66493855/183103253-df7214be-ff24-49ac-ab5b-b78f35e3eb32.png)
![image](https://user-images.githubusercontent.com/66493855/183103189-35d3d863-2519-4061-a172-3a1919dc12e2.png)
![image](https://user-images.githubusercontent.com/66493855/183103306-bb3b7c86-c999-4122-89d7-f9e689402c4d.png)
![image](https://user-images.githubusercontent.com/66493855/183103697-5a683f36-db5d-4506-a4ae-5896a57f197d.png)
![image](https://user-images.githubusercontent.com/66493855/183103362-525233bb-817b-4eee-b30b-4b7f4a10af03.png)
![image](https://user-images.githubusercontent.com/66493855/183103512-dd5e493c-f48b-446c-9499-be77c72d48df.png)
