### PR TITLE
Add checkbox indeterminate state example to docs

### DIFF
--- a/lib/src/components/checkbox/Checkbox.mdx
+++ b/lib/src/components/checkbox/Checkbox.mdx
@@ -13,3 +13,7 @@ with more specific requirements.
 ```tsx preview
 <Checkbox />
 ```
+
+```tsx preview
+<Checkbox checked="indeterminate"/>
+```

--- a/site/src/sandbox/components.tsx
+++ b/site/src/sandbox/components.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Accordion,
   ActionIcon,
@@ -901,6 +900,11 @@ post.
             label="This is a checkbox"
             name="likeCheckboxes"
             description="This is the description. The reason we're using prose here is because the most common use case for this container size is longform text."
+          />
+          <CheckboxField
+            checked="indeterminate"
+            label="This is a checkbox to demonstrate the indeterminate state"
+            name="likeCheckboxes"
           />
           <RadioButtonField
             direction="row"


### PR DESCRIPTION
#### Description

The indeterminate state for checkboxes is already available in the design system however there’s no documentation that mentions that in the DS. This PR adds an example to the checkbox component page and the larger component page.

https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-109

<img width="589" alt="image" src="https://user-images.githubusercontent.com/11061661/188188095-81c45b38-fcd2-4685-93fc-a25c42cb1b1c.png">
