### PR TITLE
fix: empty state image size

### DIFF
--- a/lib/src/components/empty-state/EmptyStateImage.tsx
+++ b/lib/src/components/empty-state/EmptyStateImage.tsx
@@ -5,27 +5,27 @@ export const EmptyStateImage = styled(Image, {
   variants: {
     size: {
       xs: {
-        width: '56px',
-        height: '32px',
+        width: '56px !important',
+        height: '32px !important',
         mb: '$4'
       },
       sm: {
-        size: '84px',
+        size: '84px !important',
         mb: '$4'
       },
       md: {
-        width: '126px',
-        height: '72px',
+        width: '126px !important',
+        height: '72px !important',
         mb: '$4'
       },
       lg: {
-        width: '190px',
-        height: '142px',
+        width: '190px !important',
+        height: '142px !important',
         mb: '$5'
       },
       xl: {
-        width: '285px',
-        height: '213px',
+        width: '285px !important',
+        height: '213px !important',
         mb: '$5'
       }
     }


### PR DESCRIPTION
### Description

Small bug fix for the Empty State image, if you used an SVG as the image default SVG sizes were overriding the sizes passed in, meaning the image needed to be sized using a box.

This fix makes the passed in sizes take precedence rather than using an outer box which would add bloat to the dom.

https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-122

### Screenshots

Fixed:
![image](https://user-images.githubusercontent.com/66493855/191248715-232e7688-f51a-4fe3-a069-f68e218bb314.png)
Broken:
![image](https://user-images.githubusercontent.com/66493855/191248784-a98bbbaf-1752-4ae0-b36c-cdf850daeef1.png)