### PR TITLE
fix(TopBar): add size variant

### DIFF
--- a/lib/src/components/top-bar/TopBar.mdx
+++ b/lib/src/components/top-bar/TopBar.mdx
@@ -25,6 +25,40 @@ Alternatively, if you want to avoid wrapping groups of items with a `div` purely
 </TopBar>
 ```
 
+## TopBar Size Variant
+
+`TopBar` also takes in one of these size props `md | lg`, this size is used to dictate the height of the `TopBar` and the `TopBar.BrandLogo`.
+
+If size `md` is passed to the `TopBar` it will be 64px in height and the `TopBar.BrandLogo` will be 24px in height.
+
+```tsx preview
+<TopBar size="md">
+  <TopBar.Brand href="atomlearning.co.uk">
+    <TopBar.BrandLogo src={logo} />
+  </TopBar.Brand>
+</TopBar>
+```
+
+If size `lg` is passed to the `TopBar` it will be 96px in height and the `TopBar.BrandLogo` will be 32px in height.
+
+```tsx preview
+<TopBar size="lg">
+  <TopBar.Brand href="atomlearning.co.uk">
+    <TopBar.BrandLogo src={logo} />
+  </TopBar.Brand>
+</TopBar>
+```
+
+If no size prop is added to the `TopBar` by default it will have the size `md`.
+
+```tsx preview
+<TopBar>
+  <TopBar.Brand href="atomlearning.co.uk">
+    <TopBar.BrandLogo src={logo} />
+  </TopBar.Brand>
+</TopBar>
+```
+
 ## TopBar.Brand
 
 `TopBar.Brand` renders a styled link.

--- a/lib/src/components/top-bar/TopBar.mdx
+++ b/lib/src/components/top-bar/TopBar.mdx
@@ -27,12 +27,10 @@ Alternatively, if you want to avoid wrapping groups of items with a `div` purely
 
 ## TopBar Size Variant
 
-`TopBar` also takes in one of these size props `md | lg`, this size is used to dictate the height of the `TopBar` and the `TopBar.BrandLogo`.
-
-If size `md` is passed to the `TopBar` it will be 64px in height and the `TopBar.BrandLogo` will be 24px in height.
+TopBar has a default size of `md` which means that the default height of the component is 64px and the `Topbar.BrandLogo` is 24px.
 
 ```tsx preview
-<TopBar size="md">
+<TopBar>
   <TopBar.Brand href="atomlearning.co.uk">
     <TopBar.BrandLogo src={logo} />
   </TopBar.Brand>
@@ -43,16 +41,6 @@ If size `lg` is passed to the `TopBar` it will be 96px in height and the `TopBar
 
 ```tsx preview
 <TopBar size="lg">
-  <TopBar.Brand href="atomlearning.co.uk">
-    <TopBar.BrandLogo src={logo} />
-  </TopBar.Brand>
-</TopBar>
-```
-
-If no size prop is added to the `TopBar` by default it will have the size `md`.
-
-```tsx preview
-<TopBar>
   <TopBar.Brand href="atomlearning.co.uk">
     <TopBar.BrandLogo src={logo} />
   </TopBar.Brand>

--- a/lib/src/components/top-bar/TopBar.test.tsx
+++ b/lib/src/components/top-bar/TopBar.test.tsx
@@ -17,7 +17,7 @@ const ExampleTopBar = (size) => (
 )
 
 describe('TopBar component', () => {
-  it('renders without size prop', async () => {
+  it('renders', async () => {
     const { container } = render(<ExampleTopBar />, {
       container: document.body
     })
@@ -25,27 +25,13 @@ describe('TopBar component', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('has no programmatically detectable a11y issues, when no size prop is passed', async () => {
+  it('has no programmatically detectable a11y issues', async () => {
     const { container } = render(<ExampleTopBar />)
 
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('renders with the size prop md', async () => {
-    const { container } = render(<ExampleTopBar size="md" />, {
-      container: document.body
-    })
-
-    expect(container).toMatchSnapshot()
-  })
-
-  it('has no programmatically detectable a11y issues, when the size prop md is passed', async () => {
-    const { container } = render(<ExampleTopBar size="md" />)
-
-    expect(await axe(container)).toHaveNoViolations()
-  })
-
-  it('renders with the size prop lg', async () => {
+  it('renders the lg variant', async () => {
     const { container } = render(<ExampleTopBar size="lg" />, {
       container: document.body
     })
@@ -53,7 +39,7 @@ describe('TopBar component', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('has no programmatically detectable a11y issues, when the size prop lg is passed', async () => {
+  it('has no programmatically detectable a11y issues, in the lg variant', async () => {
     const { container } = render(<ExampleTopBar size="lg" />)
 
     expect(await axe(container)).toHaveNoViolations()

--- a/lib/src/components/top-bar/TopBar.test.tsx
+++ b/lib/src/components/top-bar/TopBar.test.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { TopBar } from '.'
 
-const ExampleTopBar = (size) => (
+const ExampleTopBar = ({size}) => (
   <TopBar size={size}>
     <TopBar.Brand href="atomlearning.co.uk">
       <TopBar.BrandName>Admin Panel</TopBar.BrandName>

--- a/lib/src/components/top-bar/TopBar.test.tsx
+++ b/lib/src/components/top-bar/TopBar.test.tsx
@@ -5,8 +5,8 @@ import * as React from 'react'
 
 import { TopBar } from '.'
 
-const ExampleTopBar = () => (
-  <TopBar>
+const ExampleTopBar = (size) => (
+  <TopBar size={size}>
     <TopBar.Brand href="atomlearning.co.uk">
       <TopBar.BrandName>Admin Panel</TopBar.BrandName>
     </TopBar.Brand>
@@ -17,7 +17,7 @@ const ExampleTopBar = () => (
 )
 
 describe('TopBar component', () => {
-  it('renders', async () => {
+  it('renders without size prop', async () => {
     const { container } = render(<ExampleTopBar />, {
       container: document.body
     })
@@ -25,8 +25,36 @@ describe('TopBar component', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('has no programmatically detectable a11y issues', async () => {
+  it('has no programmatically detectable a11y issues, when no size prop is passed', async () => {
     const { container } = render(<ExampleTopBar />)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders with the size prop md', async () => {
+    const { container } = render(<ExampleTopBar size="md" />, {
+      container: document.body
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues, when the size prop md is passed', async () => {
+    const { container } = render(<ExampleTopBar size="md" />)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders with the size prop lg', async () => {
+    const { container } = render(<ExampleTopBar size="lg" />, {
+      container: document.body
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues, when the size prop lg is passed', async () => {
+    const { container } = render(<ExampleTopBar size="lg" />)
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -49,6 +49,7 @@ const StyledRoot = styled('div', {
 
 const Container = styled(Flex, {
   alignItems: 'center',
+  mx: '$4',
   width: '100%',
   '@md': {
     mx: '$5'
@@ -70,7 +71,7 @@ const Container = styled(Flex, {
           '&[src$=".svg"]': {
             height: 32,
             width: 'auto'
-          },
+          }
         }
       }
     }

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -17,7 +17,7 @@ interface TopBarSubComponents {
 }
 
 const TopBarDivider = () => (
-  <Divider orientation="vertical" css={{ minHeight: 28, bg: '$tonal100' }} />
+  <Divider orientation="vertical" css={{ height: '$2', bg: '$tonal100' }} />
 )
 
 const StyledRoot = styled('div', {
@@ -38,26 +38,7 @@ const StyledRoot = styled('div', {
     },
     size: {
       md: {
-        height: '$6'
-      },
-      lg: {
-        height: '$7'
-      }
-    }
-  }
-})
-
-const Container = styled(Flex, {
-  alignItems: 'center',
-  mx: '$4',
-  width: '100%',
-  '@md': {
-    mx: '$5'
-  },
-  variants: {
-    size: {
-      md: {
-        height: '$4',
+        height: '$6',
         [`& ${TopBarBrandLogo}`]: {
           '&[src$=".svg"]': {
             height: 24,
@@ -66,7 +47,7 @@ const Container = styled(Flex, {
         }
       },
       lg: {
-        height: 80,
+        height: '$7',
         [`& ${TopBarBrandLogo}`]: {
           '&[src$=".svg"]': {
             height: 32,
@@ -75,6 +56,16 @@ const Container = styled(Flex, {
         }
       }
     }
+  }
+})
+
+const Container = styled(Flex, {
+  alignItems: 'center',
+  height: '$4',
+  mx: '$4',
+  width: '100%',
+  '@md': {
+    mx: '$5'
   }
 })
 
@@ -92,7 +83,7 @@ export const TopBar: React.FC<TopBarProps> & TopBarSubComponents = ({
 
   return (
     <StyledRoot hasScrolled={!!scrollPositionY} size={size}>
-      <Container size={size} {...props} />
+      <Container {...props} />
     </StyledRoot>
   )
 }

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -27,7 +27,6 @@ const StyledRoot = styled('div', {
   alignItems: 'center',
   width: '100vw',
   top: '0',
-  height: '$6',
   zIndex: 1,
   borderBottom: '1px solid $tonal100',
   transition: 'box-shadow .2s ease-out',
@@ -36,30 +35,63 @@ const StyledRoot = styled('div', {
       true: {
         boxShadow: '0px 4px 4px -2px rgba(31, 31, 31, 0.1);'
       }
+    },
+    size: {
+      md: {
+        height: '$6'
+      },
+      lg: {
+        height: '$7'
+      }
     }
   }
 })
 
 const Container = styled(Flex, {
   alignItems: 'center',
-  height: '$4',
-  mx: '$4',
   width: '100%',
   '@md': {
     mx: '$5'
+  },
+  variants: {
+    size: {
+      md: {
+        height: '$4',
+        [`& ${TopBarBrandLogo}`]: {
+          '&[src$=".svg"]': {
+            height: 24,
+            width: 'auto'
+          }
+        }
+      },
+      lg: {
+        height: 80,
+        [`& ${TopBarBrandLogo}`]: {
+          '&[src$=".svg"]': {
+            height: 32,
+            width: 'auto'
+          },
+        }
+      }
+    }
   }
 })
 
-interface TopBarProps {
+type StyledRootProps = React.ComponentProps<typeof StyledRoot>
+
+interface TopBarProps extends StyledRootProps {
   css?: CSS
 }
 
-export const TopBar: React.FC<TopBarProps> & TopBarSubComponents = (props) => {
+export const TopBar: React.FC<TopBarProps> & TopBarSubComponents = ({
+  size = 'md',
+  ...props
+}) => {
   const { y: scrollPositionY } = useScrollPosition()
 
   return (
-    <StyledRoot hasScrolled={!!scrollPositionY}>
-      <Container {...props} />
+    <StyledRoot hasScrolled={!!scrollPositionY} size={size}>
+      <Container size={size} {...props} />
     </StyledRoot>
   )
 }

--- a/lib/src/components/top-bar/TopBarBrand.tsx
+++ b/lib/src/components/top-bar/TopBarBrand.tsx
@@ -18,20 +18,19 @@ export const TopBarBrandLogo = ({
 }: TopBarBrandLogoProps): JSX.Element => {
   return (
     <Image
+      className="topbar-brand-logo"
       src={src}
       alt={alt}
       css={{
         mr: '$3',
         mb: '5px',
-        '&[src$=".svg"]': {
-          height: 24,
-          width: 'auto'
-        },
         ...css
       }}
     />
   )
 }
+
+TopBarBrandLogo.toString = () => '.topbar-brand-logo'
 
 export const TopBarBrandName = styled(Text, {
   color: '$tonal400'

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -1,228 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopBar component renders 1`] = `
-@media  {
-  .c-goJbTI {
-    background: white;
-    position: sticky;
-    display: flex;
-    align-items: center;
-    width: 100vw;
-    top: 0;
-    height: var(--sizes-6);
-    z-index: 1;
-    border-bottom: 1px solid var(--colors-tonal100);
-    transition: box-shadow .2s ease-out;
-  }
-
-  .c-dhzjXW {
-    display: flex;
-  }
-
-  .c-ftiHlK {
-    align-items: center;
-    height: var(--sizes-4);
-    margin-left: var(--space-4);
-    margin-right: var(--space-4);
-    width: 100%;
-  }
-
-@media (min-width: 800px) {
-    .c-ftiHlK {
-      margin-left: var(--space-5);
-      margin-right: var(--space-5);
-    }
-}
-
-  .c-dbEDIJ {
-    display: flex;
-    align-items: center;
-    text-decoration: none;
-    color: var(--colors-tonal400);
-  }
-
-  .c-dbEDIJ:hover,
-  .c-dbEDIJ:focus {
-    text-decoration: none;
-  }
-
-  .c-fIXJvv {
-    color: var(--colors-tonal600);
-    font-family: var(--fonts-body);
-    font-weight: 400;
-    margin: 0;
-  }
-
-  .c-fIXJvv > .c-fIXJvv:before,
-  .c-fIXJvv > .c-fIXJvv:after {
-    display: none;
-  }
-
-  .c-ldsiYK {
-    color: var(--colors-tonal400);
-  }
-
-  .c-fDzwZw {
-    align-items: center;
-    -webkit-appearance: none;
-    appearance: none;
-    background: white;
-    border: unset;
-    border-radius: var(--radii-0);
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    padding: unset;
-    transition: all 100ms ease-out;
-  }
-
-  .c-dbrbZt {
-    display: inline-block;
-    fill: none;
-    stroke: currentcolor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    vertical-align: middle;
-  }
-
-  .c-jpqjUq {
-    border: 0;
-    background: var(--colors-tonal200);
-  }
-}
-
-@media  {
-  .c-fIXJvv-gvmVBy-size-md {
-    font-size: var(--fontSizes-md);
-    line-height: 1.5;
-  }
-
-  .c-fIXJvv-gvmVBy-size-md::before {
-    content: '';
-    margin-bottom: -0.3864em;
-    display: table;
-  }
-
-  .c-fIXJvv-gvmVBy-size-md::after {
-    content: '';
-    margin-top: -0.3864em;
-    display: table;
-  }
-
-  .c-fDzwZw-PrXKS-size-md {
-    height: var(--sizes-4);
-    width: var(--sizes-4);
-  }
-
-  .c-dbrbZt-dMrjnF-size-md {
-    height: var(--sizes-2);
-    width: var(--sizes-2);
-    stroke-width: 1.75;
-  }
-
-  .c-jpqjUq-fKZlxR-orientation-vertical {
-    height: 100%;
-    width: 1px;
-    min-height: var(--sizes-3);
-  }
-}
-
-@media  {
-  .c-fDzwZw-otpKd-cv {
-    background: transparent;
-    color: var(--colors-tonal300);
-  }
-
-  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
-  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
-    color: var(--colors-primaryMid);
-  }
-
-  .c-fDzwZw-otpKd-cv:not(:disabled):active {
-    color: var(--colors-primaryDark);
-  }
-
-  .c-fDzwZw-otpKd-cv[disabled] {
-    color: var(--colors-tonal400);
-    cursor: not-allowed;
-  }
-}
-
-@media  {
-  .c-jpqjUq-ijAuhka-css {
-    min-height: 28px;
-    background: var(--colors-tonal100);
-  }
-}
-
-<body>
-  <div
-    class="c-goJbTI"
-  >
-    <div
-      class="c-dhzjXW c-ftiHlK"
-    >
-      <a
-        class="c-dbEDIJ"
-        href="atomlearning.co.uk"
-      >
-        <p
-          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
-        >
-          Admin Panel
-        </p>
-      </a>
-      <button
-        aria-label="Search"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14.412 14.412L20 20"
-          />
-          <circle
-            cx="10"
-            cy="10"
-            r="6"
-          />
-        </svg>
-      </button>
-      <hr
-        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
-      />
-      <button
-        aria-label="Light/Dark mode"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
-            fill-rule="evenodd"
-          />
-          <path
-            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-</body>
-`;
-
 exports[`TopBar component renders with the size prop lg 1`] = `
 @media  {
   .c-glwkin {
@@ -241,13 +18,15 @@ exports[`TopBar component renders with the size prop lg 1`] = `
     display: flex;
   }
 
-  .c-juHlLg {
+  .c-bywLwH {
     align-items: center;
+    margin-left: var(--space-4);
+    margin-right: var(--space-4);
     width: 100%;
   }
 
 @media (min-width: 800px) {
-    .c-juHlLg {
+    .c-bywLwH {
       margin-left: var(--space-5);
       margin-right: var(--space-5);
     }
@@ -355,13 +134,13 @@ exports[`TopBar component renders with the size prop lg 1`] = `
 }
 
 @media size {
-    .c-juHlLg-kUKTlI-size-md {
+    .c-bywLwH-kUKTlI-size-md {
       height: var(--sizes-4);
     }
 }
 
 @media size {
-    .c-juHlLg-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
+    .c-bywLwH-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
       height: 24px;
       width: auto;
     }
@@ -374,13 +153,13 @@ exports[`TopBar component renders with the size prop lg 1`] = `
 }
 
 @media size {
-    .c-juHlLg-hTLIsj-size-lg {
+    .c-bywLwH-hTLIsj-size-lg {
       height: 80px;
     }
 }
 
 @media size {
-    .c-juHlLg-hTLIsj-size-lg .topbar-brand-logo[src$=".svg"] {
+    .c-bywLwH-hTLIsj-size-lg .topbar-brand-logo[src$=".svg"] {
       height: 32px;
       width: auto;
     }
@@ -420,7 +199,7 @@ exports[`TopBar component renders with the size prop lg 1`] = `
     class="c-glwkin c-glwkin-ipiiai-size-lg"
   >
     <div
-      class="c-dhzjXW c-juHlLg c-juHlLg-hTLIsj-size-lg"
+      class="c-dhzjXW c-bywLwH c-bywLwH-hTLIsj-size-lg"
     >
       <a
         class="c-dbEDIJ"
@@ -500,13 +279,15 @@ exports[`TopBar component renders with the size prop md 1`] = `
     display: flex;
   }
 
-  .c-juHlLg {
+  .c-bywLwH {
     align-items: center;
+    margin-left: var(--space-4);
+    margin-right: var(--space-4);
     width: 100%;
   }
 
 @media (min-width: 800px) {
-    .c-juHlLg {
+    .c-bywLwH {
       margin-left: var(--space-5);
       margin-right: var(--space-5);
     }
@@ -614,13 +395,13 @@ exports[`TopBar component renders with the size prop md 1`] = `
 }
 
 @media size {
-    .c-juHlLg-kUKTlI-size-md {
+    .c-bywLwH-kUKTlI-size-md {
       height: var(--sizes-4);
     }
 }
 
 @media size {
-    .c-juHlLg-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
+    .c-bywLwH-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
       height: 24px;
       width: auto;
     }
@@ -660,7 +441,7 @@ exports[`TopBar component renders with the size prop md 1`] = `
     class="c-glwkin c-glwkin-byWREH-size-md"
   >
     <div
-      class="c-dhzjXW c-juHlLg c-juHlLg-kUKTlI-size-md"
+      class="c-dhzjXW c-bywLwH c-bywLwH-kUKTlI-size-md"
     >
       <a
         class="c-dbEDIJ"
@@ -740,13 +521,15 @@ exports[`TopBar component renders without size prop 1`] = `
     display: flex;
   }
 
-  .c-juHlLg {
+  .c-bywLwH {
     align-items: center;
+    margin-left: var(--space-4);
+    margin-right: var(--space-4);
     width: 100%;
   }
 
 @media (min-width: 800px) {
-    .c-juHlLg {
+    .c-bywLwH {
       margin-left: var(--space-5);
       margin-right: var(--space-5);
     }
@@ -879,7 +662,7 @@ exports[`TopBar component renders without size prop 1`] = `
     class="c-glwkin"
   >
     <div
-      class="c-dhzjXW c-juHlLg"
+      class="c-dhzjXW c-bywLwH"
     >
       <a
         class="c-dbEDIJ"

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopBar component renders with the size prop lg 1`] = `
+exports[`TopBar component renders 1`] = `
 @media  {
   .c-glwkin {
     background: white;
@@ -18,15 +18,238 @@ exports[`TopBar component renders with the size prop lg 1`] = `
     display: flex;
   }
 
-  .c-bywLwH {
+  .c-ftiHlK {
     align-items: center;
+    height: var(--sizes-4);
     margin-left: var(--space-4);
     margin-right: var(--space-4);
     width: 100%;
   }
 
 @media (min-width: 800px) {
-    .c-bywLwH {
+    .c-ftiHlK {
+      margin-left: var(--space-5);
+      margin-right: var(--space-5);
+    }
+}
+
+  .c-dbEDIJ {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: var(--colors-tonal400);
+  }
+
+  .c-dbEDIJ:hover,
+  .c-dbEDIJ:focus {
+    text-decoration: none;
+  }
+
+  .c-fIXJvv {
+    color: var(--colors-tonal600);
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
+  }
+
+  .c-ldsiYK {
+    color: var(--colors-tonal400);
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-jpqjUq {
+    border: 0;
+    background: var(--colors-tonal200);
+  }
+}
+
+@media  {
+  .c-fIXJvv-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-fDzwZw-PrXKS-size-md {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-dMrjnF-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 1.75;
+  }
+
+  .c-jpqjUq-fKZlxR-orientation-vertical {
+    height: 100%;
+    width: 1px;
+    min-height: var(--sizes-3);
+  }
+}
+
+@media  {
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-jpqjUq-ieFaPrQ-css {
+    height: var(--sizes-2);
+    background: var(--colors-tonal100);
+  }
+}
+
+<body>
+  <div
+    class="c-glwkin"
+  >
+    <div
+      class="c-dhzjXW c-ftiHlK"
+    >
+      <a
+        class="c-dbEDIJ"
+        href="atomlearning.co.uk"
+      >
+        <p
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
+        >
+          Admin Panel
+        </p>
+      </a>
+      <button
+        aria-label="Search"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.412 14.412L20 20"
+          />
+          <circle
+            cx="10"
+            cy="10"
+            r="6"
+          />
+        </svg>
+      </button>
+      <hr
+        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ieFaPrQ-css"
+      />
+      <button
+        aria-label="Light/Dark mode"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
+            fill-rule="evenodd"
+          />
+          <path
+            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`TopBar component renders the lg variant 1`] = `
+@media  {
+  .c-glwkin {
+    background: white;
+    position: sticky;
+    display: flex;
+    align-items: center;
+    width: 100vw;
+    top: 0;
+    z-index: 1;
+    border-bottom: 1px solid var(--colors-tonal100);
+    transition: box-shadow .2s ease-out;
+  }
+
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-ftiHlK {
+    align-items: center;
+    height: var(--sizes-4);
+    margin-left: var(--space-4);
+    margin-right: var(--space-4);
+    width: 100%;
+  }
+
+@media (min-width: 800px) {
+    .c-ftiHlK {
       margin-left: var(--space-5);
       margin-right: var(--space-5);
     }
@@ -128,38 +351,13 @@ exports[`TopBar component renders with the size prop lg 1`] = `
 
 @media  {
 @media size {
-    .c-glwkin-byWREH-size-md {
-      height: var(--sizes-6);
-    }
-}
-
-@media size {
-    .c-bywLwH-kUKTlI-size-md {
-      height: var(--sizes-4);
-    }
-}
-
-@media size {
-    .c-bywLwH-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
-      height: 24px;
-      width: auto;
-    }
-}
-
-@media size {
-    .c-glwkin-ipiiai-size-lg {
+    .c-glwkin-dzdwkc-size-lg {
       height: var(--sizes-7);
     }
 }
 
 @media size {
-    .c-bywLwH-hTLIsj-size-lg {
-      height: 80px;
-    }
-}
-
-@media size {
-    .c-bywLwH-hTLIsj-size-lg .topbar-brand-logo[src$=".svg"] {
+    .c-glwkin-dzdwkc-size-lg .topbar-brand-logo[src$=".svg"] {
       height: 32px;
       width: auto;
     }
@@ -188,260 +386,18 @@ exports[`TopBar component renders with the size prop lg 1`] = `
 }
 
 @media  {
-  .c-jpqjUq-ijAuhka-css {
-    min-height: 28px;
-    background: var(--colors-tonal100);
-  }
-}
-
-<body>
-  <div
-    class="c-glwkin c-glwkin-ipiiai-size-lg"
-  >
-    <div
-      class="c-dhzjXW c-bywLwH c-bywLwH-hTLIsj-size-lg"
-    >
-      <a
-        class="c-dbEDIJ"
-        href="atomlearning.co.uk"
-      >
-        <p
-          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
-        >
-          Admin Panel
-        </p>
-      </a>
-      <button
-        aria-label="Search"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14.412 14.412L20 20"
-          />
-          <circle
-            cx="10"
-            cy="10"
-            r="6"
-          />
-        </svg>
-      </button>
-      <hr
-        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
-      />
-      <button
-        aria-label="Light/Dark mode"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
-            fill-rule="evenodd"
-          />
-          <path
-            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`TopBar component renders with the size prop md 1`] = `
-@media  {
-  .c-glwkin {
-    background: white;
-    position: sticky;
-    display: flex;
-    align-items: center;
-    width: 100vw;
-    top: 0;
-    z-index: 1;
-    border-bottom: 1px solid var(--colors-tonal100);
-    transition: box-shadow .2s ease-out;
-  }
-
-  .c-dhzjXW {
-    display: flex;
-  }
-
-  .c-bywLwH {
-    align-items: center;
-    margin-left: var(--space-4);
-    margin-right: var(--space-4);
-    width: 100%;
-  }
-
-@media (min-width: 800px) {
-    .c-bywLwH {
-      margin-left: var(--space-5);
-      margin-right: var(--space-5);
-    }
-}
-
-  .c-dbEDIJ {
-    display: flex;
-    align-items: center;
-    text-decoration: none;
-    color: var(--colors-tonal400);
-  }
-
-  .c-dbEDIJ:hover,
-  .c-dbEDIJ:focus {
-    text-decoration: none;
-  }
-
-  .c-fIXJvv {
-    color: var(--colors-tonal600);
-    font-family: var(--fonts-body);
-    font-weight: 400;
-    margin: 0;
-  }
-
-  .c-fIXJvv > .c-fIXJvv:before,
-  .c-fIXJvv > .c-fIXJvv:after {
-    display: none;
-  }
-
-  .c-ldsiYK {
-    color: var(--colors-tonal400);
-  }
-
-  .c-fDzwZw {
-    align-items: center;
-    -webkit-appearance: none;
-    appearance: none;
-    background: white;
-    border: unset;
-    border-radius: var(--radii-0);
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    padding: unset;
-    transition: all 100ms ease-out;
-  }
-
-  .c-dbrbZt {
-    display: inline-block;
-    fill: none;
-    stroke: currentcolor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    vertical-align: middle;
-  }
-
-  .c-jpqjUq {
-    border: 0;
-    background: var(--colors-tonal200);
-  }
-}
-
-@media  {
-  .c-fIXJvv-gvmVBy-size-md {
-    font-size: var(--fontSizes-md);
-    line-height: 1.5;
-  }
-
-  .c-fIXJvv-gvmVBy-size-md::before {
-    content: '';
-    margin-bottom: -0.3864em;
-    display: table;
-  }
-
-  .c-fIXJvv-gvmVBy-size-md::after {
-    content: '';
-    margin-top: -0.3864em;
-    display: table;
-  }
-
-  .c-fDzwZw-PrXKS-size-md {
-    height: var(--sizes-4);
-    width: var(--sizes-4);
-  }
-
-  .c-dbrbZt-dMrjnF-size-md {
+  .c-jpqjUq-ieFaPrQ-css {
     height: var(--sizes-2);
-    width: var(--sizes-2);
-    stroke-width: 1.75;
-  }
-
-  .c-jpqjUq-fKZlxR-orientation-vertical {
-    height: 100%;
-    width: 1px;
-    min-height: var(--sizes-3);
-  }
-}
-
-@media  {
-@media size {
-    .c-glwkin-byWREH-size-md {
-      height: var(--sizes-6);
-    }
-}
-
-@media size {
-    .c-bywLwH-kUKTlI-size-md {
-      height: var(--sizes-4);
-    }
-}
-
-@media size {
-    .c-bywLwH-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
-      height: 24px;
-      width: auto;
-    }
-}
-}
-
-@media  {
-  .c-fDzwZw-otpKd-cv {
-    background: transparent;
-    color: var(--colors-tonal300);
-  }
-
-  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
-  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
-    color: var(--colors-primaryMid);
-  }
-
-  .c-fDzwZw-otpKd-cv:not(:disabled):active {
-    color: var(--colors-primaryDark);
-  }
-
-  .c-fDzwZw-otpKd-cv[disabled] {
-    color: var(--colors-tonal400);
-    cursor: not-allowed;
-  }
-}
-
-@media  {
-  .c-jpqjUq-ijAuhka-css {
-    min-height: 28px;
     background: var(--colors-tonal100);
   }
 }
 
 <body>
   <div
-    class="c-glwkin c-glwkin-byWREH-size-md"
+    class="c-glwkin c-glwkin-dzdwkc-size-lg"
   >
     <div
-      class="c-dhzjXW c-bywLwH c-bywLwH-kUKTlI-size-md"
+      class="c-dhzjXW c-ftiHlK"
     >
       <a
         class="c-dbEDIJ"
@@ -475,228 +431,7 @@ exports[`TopBar component renders with the size prop md 1`] = `
         </svg>
       </button>
       <hr
-        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
-      />
-      <button
-        aria-label="Light/Dark mode"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
-            fill-rule="evenodd"
-          />
-          <path
-            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`TopBar component renders without size prop 1`] = `
-@media  {
-  .c-glwkin {
-    background: white;
-    position: sticky;
-    display: flex;
-    align-items: center;
-    width: 100vw;
-    top: 0;
-    z-index: 1;
-    border-bottom: 1px solid var(--colors-tonal100);
-    transition: box-shadow .2s ease-out;
-  }
-
-  .c-dhzjXW {
-    display: flex;
-  }
-
-  .c-bywLwH {
-    align-items: center;
-    margin-left: var(--space-4);
-    margin-right: var(--space-4);
-    width: 100%;
-  }
-
-@media (min-width: 800px) {
-    .c-bywLwH {
-      margin-left: var(--space-5);
-      margin-right: var(--space-5);
-    }
-}
-
-  .c-dbEDIJ {
-    display: flex;
-    align-items: center;
-    text-decoration: none;
-    color: var(--colors-tonal400);
-  }
-
-  .c-dbEDIJ:hover,
-  .c-dbEDIJ:focus {
-    text-decoration: none;
-  }
-
-  .c-fIXJvv {
-    color: var(--colors-tonal600);
-    font-family: var(--fonts-body);
-    font-weight: 400;
-    margin: 0;
-  }
-
-  .c-fIXJvv > .c-fIXJvv:before,
-  .c-fIXJvv > .c-fIXJvv:after {
-    display: none;
-  }
-
-  .c-ldsiYK {
-    color: var(--colors-tonal400);
-  }
-
-  .c-fDzwZw {
-    align-items: center;
-    -webkit-appearance: none;
-    appearance: none;
-    background: white;
-    border: unset;
-    border-radius: var(--radii-0);
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    padding: unset;
-    transition: all 100ms ease-out;
-  }
-
-  .c-dbrbZt {
-    display: inline-block;
-    fill: none;
-    stroke: currentcolor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    vertical-align: middle;
-  }
-
-  .c-jpqjUq {
-    border: 0;
-    background: var(--colors-tonal200);
-  }
-}
-
-@media  {
-  .c-fIXJvv-gvmVBy-size-md {
-    font-size: var(--fontSizes-md);
-    line-height: 1.5;
-  }
-
-  .c-fIXJvv-gvmVBy-size-md::before {
-    content: '';
-    margin-bottom: -0.3864em;
-    display: table;
-  }
-
-  .c-fIXJvv-gvmVBy-size-md::after {
-    content: '';
-    margin-top: -0.3864em;
-    display: table;
-  }
-
-  .c-fDzwZw-PrXKS-size-md {
-    height: var(--sizes-4);
-    width: var(--sizes-4);
-  }
-
-  .c-dbrbZt-dMrjnF-size-md {
-    height: var(--sizes-2);
-    width: var(--sizes-2);
-    stroke-width: 1.75;
-  }
-
-  .c-jpqjUq-fKZlxR-orientation-vertical {
-    height: 100%;
-    width: 1px;
-    min-height: var(--sizes-3);
-  }
-}
-
-@media  {
-  .c-fDzwZw-otpKd-cv {
-    background: transparent;
-    color: var(--colors-tonal300);
-  }
-
-  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
-  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
-    color: var(--colors-primaryMid);
-  }
-
-  .c-fDzwZw-otpKd-cv:not(:disabled):active {
-    color: var(--colors-primaryDark);
-  }
-
-  .c-fDzwZw-otpKd-cv[disabled] {
-    color: var(--colors-tonal400);
-    cursor: not-allowed;
-  }
-}
-
-@media  {
-  .c-jpqjUq-ijAuhka-css {
-    min-height: 28px;
-    background: var(--colors-tonal100);
-  }
-}
-
-<body>
-  <div
-    class="c-glwkin"
-  >
-    <div
-      class="c-dhzjXW c-bywLwH"
-    >
-      <a
-        class="c-dbEDIJ"
-        href="atomlearning.co.uk"
-      >
-        <p
-          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
-        >
-          Admin Panel
-        </p>
-      </a>
-      <button
-        aria-label="Search"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14.412 14.412L20 20"
-          />
-          <circle
-            cx="10"
-            cy="10"
-            r="6"
-          />
-        </svg>
-      </button>
-      <hr
-        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
+        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ieFaPrQ-css"
       />
       <button
         aria-label="Light/Dark mode"

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -92,6 +92,15 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
+  .c-glwkin-daNQNf-size-md {
+    height: var(--sizes-6);
+  }
+
+  .c-glwkin-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
+    height: 24px;
+    width: auto;
+  }
+
   .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
@@ -157,7 +166,7 @@ exports[`TopBar component renders 1`] = `
 
 <body>
   <div
-    class="c-glwkin"
+    class="c-glwkin c-glwkin-daNQNf-size-md"
   >
     <div
       class="c-dhzjXW c-ftiHlK"
@@ -314,6 +323,15 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
+  .c-glwkin-daNQNf-size-md {
+    height: var(--sizes-6);
+  }
+
+  .c-glwkin-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
+    height: 24px;
+    width: auto;
+  }
+
   .c-fIXJvv-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
@@ -347,21 +365,15 @@ exports[`TopBar component renders the lg variant 1`] = `
     width: 1px;
     min-height: var(--sizes-3);
   }
-}
 
-@media  {
-@media size {
-    .c-glwkin-dzdwkc-size-lg {
-      height: var(--sizes-7);
-    }
-}
+  .c-glwkin-lcsdih-size-lg {
+    height: var(--sizes-7);
+  }
 
-@media size {
-    .c-glwkin-dzdwkc-size-lg .topbar-brand-logo[src$=".svg"] {
-      height: 32px;
-      width: auto;
-    }
-}
+  .c-glwkin-lcsdih-size-lg .topbar-brand-logo[src$=".svg"] {
+    height: 32px;
+    width: auto;
+  }
 }
 
 @media  {
@@ -394,7 +406,7 @@ exports[`TopBar component renders the lg variant 1`] = `
 
 <body>
   <div
-    class="c-glwkin c-glwkin-dzdwkc-size-lg"
+    class="c-glwkin c-glwkin-lcsdih-size-lg"
   >
     <div
       class="c-dhzjXW c-ftiHlK"

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -222,3 +222,721 @@ exports[`TopBar component renders 1`] = `
   </div>
 </body>
 `;
+
+exports[`TopBar component renders with the size prop lg 1`] = `
+@media  {
+  .c-glwkin {
+    background: white;
+    position: sticky;
+    display: flex;
+    align-items: center;
+    width: 100vw;
+    top: 0;
+    z-index: 1;
+    border-bottom: 1px solid var(--colors-tonal100);
+    transition: box-shadow .2s ease-out;
+  }
+
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-juHlLg {
+    align-items: center;
+    width: 100%;
+  }
+
+@media (min-width: 800px) {
+    .c-juHlLg {
+      margin-left: var(--space-5);
+      margin-right: var(--space-5);
+    }
+}
+
+  .c-dbEDIJ {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: var(--colors-tonal400);
+  }
+
+  .c-dbEDIJ:hover,
+  .c-dbEDIJ:focus {
+    text-decoration: none;
+  }
+
+  .c-fIXJvv {
+    color: var(--colors-tonal600);
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
+  }
+
+  .c-ldsiYK {
+    color: var(--colors-tonal400);
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-jpqjUq {
+    border: 0;
+    background: var(--colors-tonal200);
+  }
+}
+
+@media  {
+  .c-fIXJvv-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-fDzwZw-PrXKS-size-md {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-dMrjnF-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 1.75;
+  }
+
+  .c-jpqjUq-fKZlxR-orientation-vertical {
+    height: 100%;
+    width: 1px;
+    min-height: var(--sizes-3);
+  }
+}
+
+@media  {
+@media size {
+    .c-glwkin-byWREH-size-md {
+      height: var(--sizes-6);
+    }
+}
+
+@media size {
+    .c-juHlLg-kUKTlI-size-md {
+      height: var(--sizes-4);
+    }
+}
+
+@media size {
+    .c-juHlLg-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
+      height: 24px;
+      width: auto;
+    }
+}
+
+@media size {
+    .c-glwkin-ipiiai-size-lg {
+      height: var(--sizes-7);
+    }
+}
+
+@media size {
+    .c-juHlLg-hTLIsj-size-lg {
+      height: 80px;
+    }
+}
+
+@media size {
+    .c-juHlLg-hTLIsj-size-lg .topbar-brand-logo[src$=".svg"] {
+      height: 32px;
+      width: auto;
+    }
+}
+}
+
+@media  {
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-jpqjUq-ijAuhka-css {
+    min-height: 28px;
+    background: var(--colors-tonal100);
+  }
+}
+
+<body>
+  <div
+    class="c-glwkin c-glwkin-ipiiai-size-lg"
+  >
+    <div
+      class="c-dhzjXW c-juHlLg c-juHlLg-hTLIsj-size-lg"
+    >
+      <a
+        class="c-dbEDIJ"
+        href="atomlearning.co.uk"
+      >
+        <p
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
+        >
+          Admin Panel
+        </p>
+      </a>
+      <button
+        aria-label="Search"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.412 14.412L20 20"
+          />
+          <circle
+            cx="10"
+            cy="10"
+            r="6"
+          />
+        </svg>
+      </button>
+      <hr
+        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
+      />
+      <button
+        aria-label="Light/Dark mode"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
+            fill-rule="evenodd"
+          />
+          <path
+            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`TopBar component renders with the size prop md 1`] = `
+@media  {
+  .c-glwkin {
+    background: white;
+    position: sticky;
+    display: flex;
+    align-items: center;
+    width: 100vw;
+    top: 0;
+    z-index: 1;
+    border-bottom: 1px solid var(--colors-tonal100);
+    transition: box-shadow .2s ease-out;
+  }
+
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-juHlLg {
+    align-items: center;
+    width: 100%;
+  }
+
+@media (min-width: 800px) {
+    .c-juHlLg {
+      margin-left: var(--space-5);
+      margin-right: var(--space-5);
+    }
+}
+
+  .c-dbEDIJ {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: var(--colors-tonal400);
+  }
+
+  .c-dbEDIJ:hover,
+  .c-dbEDIJ:focus {
+    text-decoration: none;
+  }
+
+  .c-fIXJvv {
+    color: var(--colors-tonal600);
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
+  }
+
+  .c-ldsiYK {
+    color: var(--colors-tonal400);
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-jpqjUq {
+    border: 0;
+    background: var(--colors-tonal200);
+  }
+}
+
+@media  {
+  .c-fIXJvv-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-fDzwZw-PrXKS-size-md {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-dMrjnF-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 1.75;
+  }
+
+  .c-jpqjUq-fKZlxR-orientation-vertical {
+    height: 100%;
+    width: 1px;
+    min-height: var(--sizes-3);
+  }
+}
+
+@media  {
+@media size {
+    .c-glwkin-byWREH-size-md {
+      height: var(--sizes-6);
+    }
+}
+
+@media size {
+    .c-juHlLg-kUKTlI-size-md {
+      height: var(--sizes-4);
+    }
+}
+
+@media size {
+    .c-juHlLg-kUKTlI-size-md .topbar-brand-logo[src$=".svg"] {
+      height: 24px;
+      width: auto;
+    }
+}
+}
+
+@media  {
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-jpqjUq-ijAuhka-css {
+    min-height: 28px;
+    background: var(--colors-tonal100);
+  }
+}
+
+<body>
+  <div
+    class="c-glwkin c-glwkin-byWREH-size-md"
+  >
+    <div
+      class="c-dhzjXW c-juHlLg c-juHlLg-kUKTlI-size-md"
+    >
+      <a
+        class="c-dbEDIJ"
+        href="atomlearning.co.uk"
+      >
+        <p
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
+        >
+          Admin Panel
+        </p>
+      </a>
+      <button
+        aria-label="Search"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.412 14.412L20 20"
+          />
+          <circle
+            cx="10"
+            cy="10"
+            r="6"
+          />
+        </svg>
+      </button>
+      <hr
+        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
+      />
+      <button
+        aria-label="Light/Dark mode"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
+            fill-rule="evenodd"
+          />
+          <path
+            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`TopBar component renders without size prop 1`] = `
+@media  {
+  .c-glwkin {
+    background: white;
+    position: sticky;
+    display: flex;
+    align-items: center;
+    width: 100vw;
+    top: 0;
+    z-index: 1;
+    border-bottom: 1px solid var(--colors-tonal100);
+    transition: box-shadow .2s ease-out;
+  }
+
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-juHlLg {
+    align-items: center;
+    width: 100%;
+  }
+
+@media (min-width: 800px) {
+    .c-juHlLg {
+      margin-left: var(--space-5);
+      margin-right: var(--space-5);
+    }
+}
+
+  .c-dbEDIJ {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: var(--colors-tonal400);
+  }
+
+  .c-dbEDIJ:hover,
+  .c-dbEDIJ:focus {
+    text-decoration: none;
+  }
+
+  .c-fIXJvv {
+    color: var(--colors-tonal600);
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
+
+  .c-fIXJvv > .c-fIXJvv:before,
+  .c-fIXJvv > .c-fIXJvv:after {
+    display: none;
+  }
+
+  .c-ldsiYK {
+    color: var(--colors-tonal400);
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-jpqjUq {
+    border: 0;
+    background: var(--colors-tonal200);
+  }
+}
+
+@media  {
+  .c-fIXJvv-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-fIXJvv-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-fDzwZw-PrXKS-size-md {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-dbrbZt-dMrjnF-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 1.75;
+  }
+
+  .c-jpqjUq-fKZlxR-orientation-vertical {
+    height: 100%;
+    width: 1px;
+    min-height: var(--sizes-3);
+  }
+}
+
+@media  {
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+@media  {
+  .c-jpqjUq-ijAuhka-css {
+    min-height: 28px;
+    background: var(--colors-tonal100);
+  }
+}
+
+<body>
+  <div
+    class="c-glwkin"
+  >
+    <div
+      class="c-dhzjXW c-juHlLg"
+    >
+      <a
+        class="c-dbEDIJ"
+        href="atomlearning.co.uk"
+      >
+        <p
+          class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-ldsiYK"
+        >
+          Admin Panel
+        </p>
+      </a>
+      <button
+        aria-label="Search"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.412 14.412L20 20"
+          />
+          <circle
+            cx="10"
+            cy="10"
+            r="6"
+          />
+        </svg>
+      </button>
+      <hr
+        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ijAuhka-css"
+      />
+      <button
+        aria-label="Light/Dark mode"
+        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7 14a2 2 0 110-4 2 2 0 010 4z"
+            fill-rule="evenodd"
+          />
+          <path
+            d="M7 17A5 5 0 017 7h9a5 5 0 010 10H7z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
Ticket: https://atomlearningltd.atlassian.net/browse/DS-129

**This PR is blocking this task** https://atomlearningltd.atlassian.net/jira/software/projects/STU/boards/1?selectedIssue=STU-729 as we need to make the changes to the DS Component before we can use the Component locally in the Student App.

From our discussion with @avirati  @hollg  @andoulla and @MiguelGDLR  we needed to allow the option to increase the height of the `TopBar` Component so it would be easier for the Student Pod to use and customise the `Topbar` to their specific needs. This was done by implementing a size variant for the `TopBar`, following these designs https://www.figma.com/file/KjgQh7eTwEfJmH6e56k9mX/DS-Documentation?node-id=2973%3A5433

During my discussion with @hollg he suggested the ideal solution would be if each size of the TopBar would automatically set the size of the `TopBarBrandLogo`  Component.  So to accomplish this I followed the stitches  [documentation](https://stitches.dev/docs/styling#target-a-react-component) as this is an implementation which has never been done before in the DS Repo. It also involves adding classes  and the `.toString`  method which we have been reluctant to use. But @hollg was fine with this as the Components using this implementation are specifically scoped to the `TopBar` and using this weird implementation would allow us to create a nice API for the consumer.

## TopBar and TopBarBrandLogo `md` size variant
![Screenshot 2022-09-28 at 12 15 37](https://user-images.githubusercontent.com/51544354/192781056-9e9d7db0-cc30-4058-8572-3de2c93f0d21.png)

## TopBar and TopBarBrandLogo `lg` size variant
![Screenshot 2022-09-28 at 12 16 24](https://user-images.githubusercontent.com/51544354/192781109-d792dd89-9fc5-49f4-ad0e-eb98e98fe055.png)





