### PR TITLE
feat: added util to create variants based on theme tokens

### DIFF
--- a/lib/src/components/grid/Grid.tsx
+++ b/lib/src/components/grid/Grid.tsx
@@ -1,30 +1,12 @@
 import * as React from 'react'
 
-import { CSS, styled, theme } from '~/stitches'
-
-/**
- * output:
- * {
- *   0: {
- *     gap: '-$space$0',
- *   },
- *   ...etc.
- * }
- **/
-const gap = Object.keys(theme.space).reduce(
-  (acc, key) => ({
-    ...acc,
-    [key]: {
-      gap: `$space$${key}`
-    }
-  }),
-  {}
-) as Record<keyof typeof theme.space, CSS>
+import { styled } from '~/stitches'
+import { createThemeVariants } from '~/utilities'
 
 const GridContainer = styled('div', {
   display: 'grid',
   variants: {
-    gap
+    gap: createThemeVariants('space', { gap: '$key' })
   }
 })
 

--- a/lib/src/components/stack/Stack.tsx
+++ b/lib/src/components/stack/Stack.tsx
@@ -1,36 +1,8 @@
 import * as React from 'react'
 
-import { CSS, styled, theme } from '~/stitches'
+import { CSS, styled } from '~/stitches'
+import { createThemeVariants } from '~/utilities'
 import { CSSWrapper } from '~/utilities/css-wrapper'
-
-/**
- * output:
- * {
- *   0: {
- *     mt: `-$space$0`,
- *     ml: `-$space$0`,
- *     '& > *': {
- *       mt: `$space$0`,
- *       ml: `$space$0`
- *     }
- *   },
- *   ...etc.
- * }
- **/
-const gap = Object.keys(theme.space).reduce(
-  (acc, key) => ({
-    ...acc,
-    [key]: {
-      mt: `-$space$${key}`,
-      ml: `-$space$${key}`,
-      '& > *': {
-        mt: `$space$${key}`,
-        ml: `$space$${key}`
-      }
-    }
-  }),
-  {}
-) as Record<keyof typeof theme.space, CSS>
 
 const StyledStack = styled('div', {
   display: 'flex',
@@ -73,7 +45,14 @@ const StyledStack = styled('div', {
       false: {}
     },
     gap: {
-      ...gap,
+      ...createThemeVariants('space', {
+        mt: '-$key',
+        ml: '-$key',
+        '& > *': {
+          mt: '$key',
+          ml: '$key'
+        }
+      }),
       false: {}
     }
   }

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -2,4 +2,4 @@ export * from './components'
 
 export * from './stitches'
 
-export { focusVisibleStyleBlock } from '~/utilities'
+export { createThemeVariants, focusVisibleStyleBlock } from '~/utilities'

--- a/lib/src/utilities/create-theme-variants/createThemeVariants.test.ts
+++ b/lib/src/utilities/create-theme-variants/createThemeVariants.test.ts
@@ -1,0 +1,20 @@
+import { createThemeVariants } from './'
+
+describe('createThemeVariants', () => {
+  it('returns the correct CSS object', () => {
+    const result = createThemeVariants('space', { p: '$key' })
+
+    expect(result).toStrictEqual({
+      0: { p: '$space$0' },
+      1: { p: '$space$1' },
+      2: { p: '$space$2' },
+      3: { p: '$space$3' },
+      4: { p: '$space$4' },
+      5: { p: '$space$5' },
+      6: { p: '$space$6' },
+      7: { p: '$space$7' },
+      8: { p: '$space$8' },
+      9: { p: '$space$9' }
+    })
+  })
+})

--- a/lib/src/utilities/create-theme-variants/createThemeVariants.ts
+++ b/lib/src/utilities/create-theme-variants/createThemeVariants.ts
@@ -1,0 +1,36 @@
+import { Theme } from '@atom-learning/theme'
+
+import { CSS, theme } from '../../stitches'
+
+/**
+ * Generates a Stitches variants object based on keys in our theme.
+ * You can use the string `$key` in your CSS object, which will be replaced
+ * with the token from our theme.
+ *
+ *
+ * @example
+ * ```ts
+ * createThemeVariants('space', { p: '$key' })
+ *
+ * // Result:
+ * // {
+ * //   0: { p: '$space$0' },
+ * //   1: { p: '$space$1' },
+ * //   2: { p: '$space$2' },
+ * //   ...etc
+ * // }
+ * ```
+ */
+export const createThemeVariants = <ThemeProperty extends keyof Theme>(
+  themeProperty: ThemeProperty,
+  styles: CSS
+): Record<keyof typeof theme[ThemeProperty], CSS> =>
+  Object.keys(theme[themeProperty]).reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: JSON.parse(
+        JSON.stringify(styles).replace(/\$key/g, `$${themeProperty}$${key}`)
+      )
+    }),
+    {}
+  ) as Record<keyof typeof theme[ThemeProperty], CSS>

--- a/lib/src/utilities/create-theme-variants/index.ts
+++ b/lib/src/utilities/create-theme-variants/index.ts
@@ -1,0 +1,1 @@
+export { createThemeVariants } from './createThemeVariants'

--- a/lib/src/utilities/index.ts
+++ b/lib/src/utilities/index.ts
@@ -1,3 +1,4 @@
+export * from './create-theme-variants'
 export * from './css-wrapper'
 export * from './style'
 export * from './types'


### PR DESCRIPTION
Added a small utility function to create a set of Stitches variants based on tokens in our theme. We were doing this in a few different components, and as I was adding this for our Collapsible component (#401) I thought it would be good to have a util function instead.

### Example
```ts
createThemeVariants('space', { p: '$key' })

// { 
//   0: { p: '$space$0' },
//   1: { p: '$space$1' }, 
//   ...etc
// }