### PR TITLE
Fix: field element prop warnings for `fieldId`

### DIFF
--- a/lib/src/components/checkbox-field/CheckboxField.tsx
+++ b/lib/src/components/checkbox-field/CheckboxField.tsx
@@ -2,18 +2,14 @@ import * as React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
 import { Checkbox } from '~/components/checkbox'
-import { InlineFieldWrapper } from '~/components/field-wrapper'
-import { useFieldError, ValidationOptions } from '~/components/form'
-import { CSS } from '~/stitches'
+import {
+  InlineFieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
+import { useFieldError } from '~/components/form'
 
-type CheckboxFieldProps = {
-  css?: CSS
-  defaultChecked?: boolean
-  label: string
-  description?: string
-  name: string
-  validation?: ValidationOptions
-} & React.ComponentProps<typeof Checkbox>
+type CheckboxFieldProps = React.ComponentProps<typeof Checkbox> &
+  FieldElementWrapperProps
 
 enum CheckboxValue {
   ON = 'on',

--- a/lib/src/components/date-field/DateField.tsx
+++ b/lib/src/components/date-field/DateField.tsx
@@ -2,18 +2,13 @@ import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import { DateInput, DateInputProps } from '~/components/date-input'
-import { FieldWrapper } from '~/components/field-wrapper'
-import { useFieldError, ValidationOptions } from '~/components/form'
-import type { CSS } from '~/stitches'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
+import { useFieldError } from '~/components/form'
 
-type DateFieldProps = DateInputProps & {
-  css?: CSS
-  description?: string
-  label: string
-  name: string
-  prompt?: { link: string; label: string }
-  validation?: ValidationOptions
-}
+type DateFieldProps = DateInputProps & FieldElementWrapperProps
 
 export const DateField: React.FC<DateFieldProps> = ({
   css,

--- a/lib/src/components/field-wrapper/FieldWrapper.tsx
+++ b/lib/src/components/field-wrapper/FieldWrapper.tsx
@@ -5,6 +5,7 @@ import { Flex } from '~/components/flex'
 import { Label } from '~/components/label'
 import { Link } from '~/components/link'
 import { InlineMessage } from '~/components/inline-message'
+import { ValidationOptions } from '~/components/form'
 import type { CSS } from '~/stitches'
 
 import { Description } from './FieldDescription'
@@ -19,6 +20,11 @@ export type FieldWrapperProps = {
   description?: string
   required?: boolean
   hideLabel?: boolean
+}
+
+export type FieldElementWrapperProps = Omit<FieldWrapperProps, 'fieldId'> & {
+  name: string
+  validation?: ValidationOptions
 }
 
 export const FieldWrapper: React.FC<FieldWrapperProps> = ({

--- a/lib/src/components/field-wrapper/index.ts
+++ b/lib/src/components/field-wrapper/index.ts
@@ -1,3 +1,6 @@
-export type { FieldWrapperProps } from './FieldWrapper'
+export type {
+  FieldWrapperProps,
+  FieldElementWrapperProps
+} from './FieldWrapper'
 export { FieldWrapper } from './FieldWrapper'
 export { InlineFieldWrapper } from './InlineFieldWrapper'

--- a/lib/src/components/input-field/InputField.tsx
+++ b/lib/src/components/input-field/InputField.tsx
@@ -1,19 +1,14 @@
 import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { FieldWrapper } from '~/components/field-wrapper'
-import { useFieldError, ValidationOptions } from '~/components/form'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
+import { useFieldError } from '~/components/form'
 import { Input, InputProps } from '~/components/input'
-import type { CSS } from '~/stitches'
 
-type InputFieldProps = InputProps & {
-  css?: CSS
-  description?: string
-  label: string
-  name: string
-  prompt?: { link: string; label: string }
-  validation?: ValidationOptions
-}
+type InputFieldProps = InputProps & FieldElementWrapperProps
 
 export const InputField: React.FC<InputFieldProps> = ({
   css,

--- a/lib/src/components/password-field/PasswordField.tsx
+++ b/lib/src/components/password-field/PasswordField.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { FieldWrapper } from '~/components/field-wrapper'
-import type { ValidationOptions } from '~/components/form'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
 import { useFieldError } from '~/components/form'
-import { InputProps } from '~/components/input'
 import { PasswordInput } from '~/components/password-input'
 import { CSS } from '~/stitches'
 
-type PasswordFieldProps = InputProps & {
-  description?: string
-  hidePasswordText?: string
-  label?: string
-  name: string
-  prompt?: { label: string; link: string }
-  showPasswordText?: string
-  validation?: ValidationOptions
-}
+type PasswordFieldProps = React.ComponentProps<typeof PasswordInput> &
+  Omit<FieldElementWrapperProps, 'label'> & {
+    label?: string
+  }
 
 export const PasswordField: React.FC<PasswordFieldProps> = ({
   css = {},

--- a/lib/src/components/radio-button-field/RadioButtonField.tsx
+++ b/lib/src/components/radio-button-field/RadioButtonField.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
+import { FieldElementWrapperProps } from '~/components/field-wrapper'
 import { Description as FieldDescription } from '~/components/field-wrapper/FieldDescription'
-import { useFieldError, ValidationOptions } from '~/components/form'
+import { useFieldError } from '~/components/form'
 import { Label } from '~/components/label'
 import { RadioButtonGroup } from '~/components/radio-button'
 import { InlineMessage } from '~/components/inline-message'
-import { CSS, styled } from '~/stitches'
+import { styled } from '~/stitches'
 
 import { RadioField } from './RadioField'
 
@@ -14,16 +15,8 @@ const Fieldset = styled('fieldset', {
   all: 'unset'
 })
 
-type RadioButtonFieldProps = {
-  css?: CSS
-  defaultValue?: string
-  label: string
-  name: string
-  direction?: 'row' | 'column'
-  description?: string
-  validation?: ValidationOptions
-  onValueChange?: (value: string) => void
-}
+type RadioButtonFieldProps = React.ComponentProps<typeof RadioButtonGroup> &
+  FieldElementWrapperProps
 
 export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
   Item: typeof RadioField

--- a/lib/src/components/search-field/SearchField.tsx
+++ b/lib/src/components/search-field/SearchField.tsx
@@ -1,18 +1,14 @@
 import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { FieldWrapper } from '~/components/field-wrapper'
-import { useFieldError, ValidationOptions } from '~/components/form'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
+import { useFieldError } from '~/components/form'
 import { SearchInput, SearchInputProps } from '~/components/search-input'
-import type { CSS } from '~/stitches'
 
-type SearchFieldProps = SearchInputProps & {
-  description?: string
-  label: string
-  name: string
-  prompt?: { link: string; label: string }
-  validation?: ValidationOptions
-}
+type SearchFieldProps = SearchInputProps & FieldElementWrapperProps
 
 export const SearchField: React.FC<SearchFieldProps> = ({
   css,

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -9,7 +9,7 @@ import { CSS, styled } from '~/stitches'
 import { useCallbackRef } from '~/utilities/hooks/useCallbackRef'
 
 export type SearchInputProps = React.ComponentProps<typeof Input> & {
-  size: 'sm' | 'md'
+  size?: 'sm' | 'md'
   css?: CSS
   value?: string
   clearText?: string

--- a/lib/src/components/select-field/SelectField.tsx
+++ b/lib/src/components/select-field/SelectField.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { FieldWrapper, FieldWrapperProps } from '~/components/field-wrapper'
-import { useFieldError, ValidationOptions } from '~/components/form'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
+import { useFieldError } from '~/components/form'
 import { Select, SelectProps } from '~/components/select'
 
-type SelectFieldProps = SelectProps &
-  Omit<FieldWrapperProps, 'fieldId' | 'error'> & {
-    name: string
-    validation?: ValidationOptions
-  }
+type SelectFieldProps = SelectProps & FieldElementWrapperProps
 
 export const SelectField: React.FC<SelectFieldProps> = ({
   css = undefined,

--- a/lib/src/components/slider-field/SliderField.tsx
+++ b/lib/src/components/slider-field/SliderField.tsx
@@ -1,21 +1,19 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
-import { FieldWrapper } from '~/components/field-wrapper'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
 import { Slider, SliderProps } from '~/components/slider'
 import { SliderStepsType } from '~/components/slider/SliderSteps'
-import type { CSS } from '~/stitches'
 
 import { SliderValueType } from '../slider/SliderValue'
 
 type SliderFieldProps = SliderProps &
   SliderStepsType &
-  SliderValueType & {
-    css?: CSS
-    label: string
-    name: string
-    defaultValue: number[]
-  }
+  SliderValueType &
+  FieldElementWrapperProps
 
 export const SliderField: React.FC<SliderFieldProps> = ({
   css,

--- a/lib/src/components/textarea-field/TextareaField.tsx
+++ b/lib/src/components/textarea-field/TextareaField.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import type { FieldWrapperProps } from '~/components/field-wrapper'
-import { FieldWrapper } from '~/components/field-wrapper'
-import { useFieldError, ValidationOptions } from '~/components/form'
+import {
+  FieldWrapper,
+  FieldElementWrapperProps
+} from '~/components/field-wrapper'
+import { useFieldError } from '~/components/form'
 import { Textarea, TextareaProps } from '~/components/textarea'
 
-type TextareaFieldProps = TextareaProps &
-  Omit<FieldWrapperProps, 'fieldId' | 'error'> & {
-    name: string
-    validation?: ValidationOptions
-  }
+type TextareaFieldProps = TextareaProps & FieldElementWrapperProps
 
 export const TextareaField: React.FC<TextareaFieldProps> = ({
   css = undefined,


### PR DESCRIPTION
### Description
When using `<TextareaField />` or `<SelectField />` components TS complains saying that the `fieldId` prop is required because their component props extend from `FieldWrapperProps`, but when you add the prop we get a warning in the console: `React does not recognize the 'fieldId' prop on a DOM element.`. In https://github.com/Atom-Learning/components/commit/ee8f9ad66f74e26c047b37c5436e27a329e2ff47 I omit `fieldId` from the props, however in e0b149a29507720f31f69930b384c014c3af3cc9 I created a type that we can use for field elements that are wrapped with `FieldWrapper` in order to not repeat the type and keep it consistent.

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/11061661/196185018-4266df9d-27ae-4dbb-88f2-cff6f9c918e8.png">
