### PR TITLE
RFC: DataTable Adapter pattern

### DIFF
--- a/lib/sandbox/index.tsx
+++ b/lib/sandbox/index.tsx
@@ -1,22 +1,58 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { reset } from 'stitches-reset'
-
-import { Box, Flex, globalCss } from '../src'
+import { createColumnHelper } from '@tanstack/react-table'
+import { Box, Flex, globalCss, DataTable, useDataTable, Tooltip } from '../src'
 
 globalCss({ ...reset, '*': { boxSizing: 'border-box' } })()
-
+const columnHelper = createColumnHelper<{
+  firstName: string
+  lastName: string
+}>()
 const App = () => (
-  <Flex
-    css={{
-      minHeight: '100vh',
-      justifyContent: 'center',
-      alignItems: 'center',
-      flexDirection: 'column'
-    }}
-  >
-    <Box />
-  </Flex>
+  <Tooltip.Provider>
+    <Flex
+      css={{
+        minHeight: '100vh',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column'
+      }}
+    >
+      <Box css={{ width: '700px' }}>
+        <DataTable
+          data={[
+            { firstName: 'william', lastName: 'johnson' },
+            { firstName: 'patty', lastName: 'fontaine' }
+          ]}
+          columns={[
+            columnHelper.accessor('firstName', {
+              cell: (info) => info.getValue()
+            }),
+            columnHelper.accessor('lastName', {
+              cell: (info) => info.getValue()
+            })
+          ]}
+        >
+          <ExampleAdapter>
+            <DataTable.Table />
+            <DataTable.Pagination pageSize={1} />
+          </ExampleAdapter>
+        </DataTable>
+      </Box>
+    </Flex>
+  </Tooltip.Provider>
 )
+
+const ExampleAdapter = ({ children }) => {
+  const { getState } = useDataTable()
+  const {
+    pagination: { pageIndex }
+  } = getState()
+
+  console.log('pageIndex:', pageIndex)
+
+  return children
+}
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/lib/src/components/data-table/DataTable.mdx
+++ b/lib/src/components/data-table/DataTable.mdx
@@ -154,3 +154,35 @@ If `DataTable`'s `isSortable` state is `true`, then `DataTable.Header` will be c
 ### Pagination
 
 `DataTable.Pagination` can be passed as a child to `DataTable` to render the pagination UI and configure the parent `DataTable` to paginate its data.
+
+## Adapter Pattern
+
+Adapters are used to get data _out_ of a `DataTable`. Many tables are used only to display data. But if your table allows the user to update that data in the client, you might need to synchronise those changes with systems outside of the `DataTable`.
+
+Adapters are components that call `useDataTable` and use its output to update other state, fire events, synchronise with external systems via network requests, etc. They must do two things:
+
+1. subscribe to `useDataTable` to get some update(s) from `DataTable`'s internal state
+2. `render children` so that they can be nested with other `DataTable` components
+
+```tsx
+const ExampleDataTableAdapter = () => {
+  const { getState } = useDataTable()
+
+  const {
+    pagination: { pageIndex }
+  } = getState()
+
+  console.log('Page index is:', pageIndex)
+}
+
+const App = () => {
+  return (
+    <DataTable columns={columns} data={data}>
+      <ExampleDataTableAdapter>
+        <DataTable.Table sortable css={{ mb: '$4' }} />
+        <DataTable.Pagination pageSize={5} />
+      </ExampleDataTableAdapter>
+    </DataTable>
+  )
+}
+```


### PR DESCRIPTION
# The problem
In the GT pod we've come up against the need to get data _out_ of a `DataTable`. We're going to introduce table rows that can be re-ordered via drag and drop. This will change the internal state of the `DataTable`, but we also need to be able to synchronise external changes. In this particular case, we eventually need to pass the updated order into an API request to update the database after the user has confirmed the changes in the UI.

This RFC is an attempt to codify a generic pattern for solving this problem. **It is not a suggestion for anything new to _build_ in the library**.

# Suggest solution: adapter pattern
The temptation to build a new abstraction into the `DataTable` API is _huge_, but while we're relatively early in its lifetime and we're yet to see a range of different use cases for this functionality play out, a well-documented and simple-to-use solution that lives wholly in the implementation seems safest to me.

My suggestion for that pattern is the creation of specific "adapter" components which subscribe to `useDataTable()` and then use its output to fire events, sync with a database over the network, update other context providers, etc.

```tsx
const ExampleDataTableAdapter = () => {
  const { getState } = useDataTable()

  const {
    pagination: { pageIndex }
  } = getState()

  console.log('Page index is:', pageIndex)
}

const App = () => {
  return (
    <DataTable columns={columns} data={data}>
      <ExampleDataTableAdapter>
        <DataTable.Table sortable css={{ mb: '$4' }} />
        <DataTable.Pagination pageSize={5} />
      </ExampleDataTableAdapter>
    </DataTable>
  )
}
```

# Alternatives considered

One possible solution for the use case outlined above would be to include a separate `DataTable.DnDContextProvider` component in the `DataTable` API which takes an `onSortChange` prop. We could include all the logic we need in that function without problem. 

But we will have a nicer overall API if we abstract that context provider away so that the consumer doesn't need to use it directly. Ideally we want to replicate the pattern of the `DataTable.Pagination` pattern wherever possible; in this case I think that means passing `sortable` (or some other prop) to the table rows and having the `DataTable` components figure the rest out for you automatically. 

Additionally, that `DataTable.DndContextProvider` would only allow the consumer to sync changes based on the drag-and-drop sort order changing. What if they want to sync changes based on something else? Do we need to add a new such component for every use case, each taking a different type of event handler? This would suck.

An obvious alternative idea might be to build a universal `onChange` prop into the `DataTable` itself. It could take the output of the `useDataTable` hook as its input. But we wouldn't be able to call _other_ hooks in that function (because it wouldn't be either a React component or a hook itself). I suspect it will be common to want to synchronise changes in a `DataTable` with state in another context provider (and this will be what we hope to do in GT Pod's initial use case).

The workaround for this problem would be to call the second hook in the same component that renders the `DataTable` and use its output in the function passed to `onChange`.