### PR TITLE
fix: add portal and zindex to date-input

### DIFF
--- a/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
+++ b/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
@@ -69,49 +69,6 @@ exports[`DateField component renders a field in error state 1`] = `
     vertical-align: middle;
   }
 
-  .c-iKnjyA {
-    background: white;
-    border-radius: var(--radii-1);
-    box-shadow: var(--shadows-2);
-    max-width: 90vw;
-    padding: var(--sizes-2);
-    padding-right: var(--space-6);
-    position: relative;
-    z-index: 10;
-  }
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA {
-      animation-duration: 75ms;
-      animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-      will-change: transform, opacity;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="top"] {
-      animation-name: k-ftcNPK;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="right"] {
-      animation-name: k-hbaHED;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="bottom"] {
-      animation-name: k-daNevH;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="left"] {
-      animation-name: k-fvyGIa;
-    }
-}
-
   .c-fNCeYG {
     color: var(--colors-danger);
     margin-left: var(--space-1);
@@ -173,10 +130,6 @@ exports[`DateField component renders a field in error state 1`] = `
     height: var(--sizes-2);
     width: var(--sizes-2);
     stroke-width: 1.75;
-  }
-
-  .c-iKnjyA-kUaMfZ-size-md {
-    max-width: 400px;
   }
 
   .c-fZTBsJ-bXVTjQ-state-error {
@@ -247,10 +200,6 @@ exports[`DateField component renders a field in error state 1`] = `
     position: absolute;
     top: 0;
     right: 0;
-  }
-
-  .c-iKnjyA-icFLuKp-css {
-    padding-right: var(--sizes-2);
   }
 
   .c-dhzjXW-ijkHUQU-css {
@@ -432,49 +381,6 @@ exports[`DateField component renders a field with a text input 1`] = `
     stroke-linejoin: round;
     vertical-align: middle;
   }
-
-  .c-iKnjyA {
-    background: white;
-    border-radius: var(--radii-1);
-    box-shadow: var(--shadows-2);
-    max-width: 90vw;
-    padding: var(--sizes-2);
-    padding-right: var(--space-6);
-    position: relative;
-    z-index: 10;
-  }
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA {
-      animation-duration: 75ms;
-      animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-      will-change: transform, opacity;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="top"] {
-      animation-name: k-ftcNPK;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="right"] {
-      animation-name: k-hbaHED;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="bottom"] {
-      animation-name: k-daNevH;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="left"] {
-      animation-name: k-fvyGIa;
-    }
-}
 }
 
 @media  {
@@ -515,10 +421,6 @@ exports[`DateField component renders a field with a text input 1`] = `
     width: var(--sizes-2);
     stroke-width: 1.75;
   }
-
-  .c-iKnjyA-kUaMfZ-size-md {
-    max-width: 400px;
-  }
 }
 
 @media  {
@@ -557,10 +459,6 @@ exports[`DateField component renders a field with a text input 1`] = `
     position: absolute;
     top: 0;
     right: 0;
-  }
-
-  .c-iKnjyA-icFLuKp-css {
-    padding-right: var(--sizes-2);
   }
 }
 

--- a/lib/src/components/date-input/DateInput.tsx
+++ b/lib/src/components/date-input/DateInput.tsx
@@ -11,6 +11,7 @@ import { Input } from '../input/Input'
 import { Popover } from '../popover/Popover'
 import { DEFAULT_DATE_FORMAT } from './constants'
 import { useDate } from './use-date'
+import { DIALOG_Z_INDEX } from '~/constants/zIndices'
 
 export type DateInputProps = Omit<DayzedInterface, 'onDateSelected'> &
   CalendarTranslationProps & {
@@ -79,42 +80,44 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
               <Icon is={CalendarEvent} />
             </ActionIcon>
           </Popover.Trigger>
-          <Popover.Content
-            css={{ pr: '$sizes$2' }}
-            side="bottom"
-            align="end"
-            showCloseButton={false}
-            onOpenAutoFocus={(e) => {
-              e.preventDefault()
-              if (date) {
-                refDateSelected.current?.focus()
-              } else {
-                refDateToday.current?.focus()
-              }
-            }}
-          >
-            <Calendar
-              date={date || new Date()}
-              selected={date}
-              onDateSelected={async (date) => {
-                setCalendarOpen(false)
-                await setDate(date.date, false)
-                if (revalidate) revalidate()
+          <Popover.Portal>
+            <Popover.Content
+              css={{ pr: '$sizes$2', zIndex: DIALOG_Z_INDEX }}
+              side="bottom"
+              align="end"
+              showCloseButton={false}
+              onOpenAutoFocus={(e) => {
+                e.preventDefault()
+                if (date) {
+                  refDateSelected.current?.focus()
+                } else {
+                  refDateToday.current?.focus()
+                }
               }}
-              setYear={async (date) => {
-                await setDate(date, false)
-                if (revalidate) revalidate()
-              }}
-              minDate={minDate}
-              maxDate={maxDate}
-              refDateToday={refDateToday}
-              refDateSelected={refDateSelected}
-              firstDayOfWeek={firstDayOfWeek}
-              monthNames={monthNames}
-              weekdayNames={weekdayNames}
-              labels={updatedLabels}
-            />
-          </Popover.Content>
+            >
+              <Calendar
+                date={date || new Date()}
+                selected={date}
+                onDateSelected={async (date) => {
+                  setCalendarOpen(false)
+                  await setDate(date.date, false)
+                  if (revalidate) revalidate()
+                }}
+                setYear={async (date) => {
+                  await setDate(date, false)
+                  if (revalidate) revalidate()
+                }}
+                minDate={minDate}
+                maxDate={maxDate}
+                refDateToday={refDateToday}
+                refDateSelected={refDateSelected}
+                firstDayOfWeek={firstDayOfWeek}
+                monthNames={monthNames}
+                weekdayNames={weekdayNames}
+                labels={updatedLabels}
+              />
+            </Popover.Content>
+          </Popover.Portal>
         </Popover>
       </Box>
     )

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -58,49 +58,6 @@ exports[`DateInput component renders 1`] = `
     stroke-linejoin: round;
     vertical-align: middle;
   }
-
-  .c-iKnjyA {
-    background: white;
-    border-radius: var(--radii-1);
-    box-shadow: var(--shadows-2);
-    max-width: 90vw;
-    padding: var(--sizes-2);
-    padding-right: var(--space-6);
-    position: relative;
-    z-index: 10;
-  }
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA {
-      animation-duration: 75ms;
-      animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-      will-change: transform, opacity;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="top"] {
-      animation-name: k-ftcNPK;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="right"] {
-      animation-name: k-hbaHED;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="bottom"] {
-      animation-name: k-daNevH;
-    }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .c-iKnjyA[data-state="open"][data-side="left"] {
-      animation-name: k-fvyGIa;
-    }
-}
 }
 
 @media  {
@@ -118,10 +75,6 @@ exports[`DateInput component renders 1`] = `
     height: var(--sizes-2);
     width: var(--sizes-2);
     stroke-width: 1.75;
-  }
-
-  .c-iKnjyA-kUaMfZ-size-md {
-    max-width: 400px;
   }
 }
 
@@ -155,10 +108,6 @@ exports[`DateInput component renders 1`] = `
     position: absolute;
     top: 0;
     right: 0;
-  }
-
-  .c-iKnjyA-icFLuKp-css {
-    padding-right: var(--sizes-2);
   }
 }
 


### PR DESCRIPTION
When rendering a `DateInput` within a `Dialog`, the `Popover` thats rendered when you click "Open calender" gets cut off within the `Dialog` as it overflows the content area. This update wraps the `Popover` in a `Portal` to allow it to correctly render outside of the bounds of the containing `Dialog`, and also adds a higher z-index to ensure it renders on top of the parent dialog.

Unfortunately, I couldn't add a test for this behaviour as it relies on `toBeVisible` to recognise the bounding box of the `Dialog` and the pixels that are overflowing https://github.com/testing-library/jest-dom#tobevisible

### Before

![Screenshot 2022-10-24 at 16 11 21](https://user-images.githubusercontent.com/3226804/197561291-0751a9f1-43b4-48f6-8bf9-5abe5c2f22b9.png)

### After

![Screenshot 2022-10-24 at 16 11 34](https://user-images.githubusercontent.com/3226804/197561294-e9df4bdf-ca93-45e7-8af5-cb8917ae17e6.png)
