### PR TITLE
feat: navigation - active state and focus fix, dropdown item title a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can read more about the components included in `@atom-learning/components` a
 
 ## Working with the repo locally ft. useful scripts
 
-We can run the documentation site locally, with hot-reloading triggered by changes in the library. This offers a low-friction dev environment where we can see the effects of any local changes when applied to all existing components. (Note: hot reoloading is currently only supported for changes to Typescript/.tsx files, not markdown files.)
+We can run the documentation site locally, with hot-reloading triggered by changes in the library. This offers a low-friction dev environment where we can see the effects of any local changes when applied to all existing components. (Note: hot reloading is currently only supported for changes to Typescript/.tsx files, not markdown files.)
 
 First, run `yarn build:docs && yarn dev:lib`. `yarn build:docs` collects the markdown documentation files for each component in `lib` into its `dist` directory, where the documentation site can find them. `yarn dev:lib` compiles the React component library and watches for changes.
 

--- a/lib/src/components/navigation/NavigationMenu.mdx
+++ b/lib/src/components/navigation/NavigationMenu.mdx
@@ -15,19 +15,13 @@ category: Navigation
   <NavigationMenu.Dropdown title="Theme">
     <NavigationMenu.DropdownContent>
       <NavigationMenu.DropdownItem href="/theme/colours">
-        <NavigationMenu.DropdownItemTitle>
-          Colours
-        </NavigationMenu.DropdownItemTitle
+        Colours
       </NavigationMenu.DropdownItem>
       <NavigationMenu.DropdownItem href="/theme/effects">
-        <NavigationMenu.DropdownItemTitle>
-          Effects
-        </NavigationMenu.DropdownItemTitle
+        Effects
       </NavigationMenu.DropdownItem>
       <NavigationMenu.DropdownItem href="/theme/icons">
-        <NavigationMenu.DropdownItemTitle>
-          Icons
-        </NavigationMenu.DropdownItemTitle
+        Icons
       </NavigationMenu.DropdownItem>
     </NavigationMenu.DropdownContent>
   </NavigationMenu.Dropdown>
@@ -96,10 +90,9 @@ In the below example the styling of `NavigationMenu.DropdownContent` has been ch
           <NavigationMenu.DropdownItemTitle>
             {item}
           </NavigationMenu.DropdownItemTitle
-          <NavigationMenu.DropdownItemSubtitle>
-
+          <Text>
             This is some example text about {item}
-          </NavigationMenu.DropdownItemSubtitle>
+          </Text>
         </NavigationMenu.DropdownItem>
       ))}
     </NavigationMenu.DropdownContent>
@@ -123,9 +116,7 @@ DropdownItem gives a lot of flexibility. It's an easy to compose it for own purp
       <NavigationMenu.DropdownItemTitle bold css={{ mb: '$3' }}>
         Example title
       </NavigationMenu.DropdownItemTitle>
-      <NavigationMenu.DropdownItemSubtitle size="sm">
-        This is example subtitle
-      </NavigationMenu.DropdownItemSubtitle>
+      <Text>This is example subtitle</Text>
     </Flex>
   </Grid>
 </NavigationMenu.DropdownItem>

--- a/lib/src/components/navigation/NavigationMenu.mdx
+++ b/lib/src/components/navigation/NavigationMenu.mdx
@@ -15,13 +15,19 @@ category: Navigation
   <NavigationMenu.Dropdown title="Theme">
     <NavigationMenu.DropdownContent>
       <NavigationMenu.DropdownItem href="/theme/colours">
-        Colours
+        <NavigationMenu.DropdownItemTitle>
+          Colours
+        </NavigationMenu.DropdownItemTitle
       </NavigationMenu.DropdownItem>
       <NavigationMenu.DropdownItem href="/theme/effects">
-        Effects
+        <NavigationMenu.DropdownItemTitle>
+          Effects
+        </NavigationMenu.DropdownItemTitle
       </NavigationMenu.DropdownItem>
       <NavigationMenu.DropdownItem href="/theme/icons">
-        Icons
+        <NavigationMenu.DropdownItemTitle>
+          Icons
+        </NavigationMenu.DropdownItemTitle
       </NavigationMenu.DropdownItem>
     </NavigationMenu.DropdownContent>
   </NavigationMenu.Dropdown>
@@ -87,27 +93,40 @@ In the below example the styling of `NavigationMenu.DropdownContent` has been ch
     >
       {['colours', 'icons', 'effects', 'typography'].map((item) => (
         <NavigationMenu.DropdownItem href={`/theme/${item}`}>
-          <Text
-            css={{
-              mb: '0.75rem',
-              textTransform: 'capitalize'
-            }}
-          >
+          <NavigationMenu.DropdownItemTitle>
             {item}
-          </Text>
-          <Text
-            css={{
-              color: 'inherit',
-              lineHeight: 1.5,
-              fontWeight: 400,
-              fontSize: 14
-            }}
-          >
+          </NavigationMenu.DropdownItemTitle
+          <NavigationMenu.DropdownItemSubtitle>
+
             This is some example text about {item}
-          </Text>
+          </NavigationMenu.DropdownItemSubtitle>
         </NavigationMenu.DropdownItem>
       ))}
     </NavigationMenu.DropdownContent>
   </NavigationMenu.Dropdown>
 </NavigationMenu>
+```
+
+## DropdownItem composition example
+
+DropdownItem gives a lot of flexibility. It's an easy to compose it for own purposes.
+
+```
+<NavigationMenu.DropdownItem href="/" active>
+  <Grid
+    css={{
+      gridTemplateColumns: '1fr 7fr'
+    }}
+  >
+    <Icon is={Feed} size={'md'} />
+    <Flex css={{ flexDirection: 'column' }}>
+      <NavigationMenu.DropdownItemTitle bold css={{ mb: '$3' }}>
+        Example title
+      </NavigationMenu.DropdownItemTitle>
+      <NavigationMenu.DropdownItemSubtitle size="sm">
+        This is example subtitle
+      </NavigationMenu.DropdownItemSubtitle>
+    </Flex>
+  </Grid>
+</NavigationMenu.DropdownItem>
 ```

--- a/lib/src/components/navigation/NavigationMenu.test.tsx
+++ b/lib/src/components/navigation/NavigationMenu.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import * as React from 'react'
 
+import { Flex } from '../flex'
 import { NavigationMenu } from '.'
 
 const ExampleNav = () => (
@@ -11,13 +12,28 @@ const ExampleNav = () => (
     <NavigationMenu.Dropdown title="Theme">
       <NavigationMenu.DropdownContent>
         <NavigationMenu.DropdownItem href="https://app.atomlearning.co.uk/colours">
-          Colours
+          <Flex
+            css={{
+              flexDirection: 'column'
+            }}
+          >
+            <NavigationMenu.DropdownItemTitle bold>
+              Colours
+            </NavigationMenu.DropdownItemTitle>
+            <NavigationMenu.DropdownItemSubtitle>
+              Atom Learning color palette
+            </NavigationMenu.DropdownItemSubtitle>
+          </Flex>
         </NavigationMenu.DropdownItem>
         <NavigationMenu.DropdownItem href="https://app.atomlearning.co.uk/effects">
-          Effects
+          <NavigationMenu.DropdownItemTitle>
+            Effects
+          </NavigationMenu.DropdownItemTitle>
         </NavigationMenu.DropdownItem>
         <NavigationMenu.DropdownItem href="https://app.atomlearning.co.uk/icons">
-          Icons
+          <NavigationMenu.DropdownItemTitle>
+            Icons
+          </NavigationMenu.DropdownItemTitle>
         </NavigationMenu.DropdownItem>
       </NavigationMenu.DropdownContent>
     </NavigationMenu.Dropdown>

--- a/lib/src/components/navigation/NavigationMenu.test.tsx
+++ b/lib/src/components/navigation/NavigationMenu.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe'
 import * as React from 'react'
 
 import { Flex } from '../flex'
+import { Text } from '../text'
 import { NavigationMenu } from '.'
 
 const ExampleNav = () => (
@@ -17,23 +18,17 @@ const ExampleNav = () => (
               flexDirection: 'column'
             }}
           >
-            <NavigationMenu.DropdownItemTitle bold>
+            <NavigationMenu.DropdownItemTitle>
               Colours
             </NavigationMenu.DropdownItemTitle>
-            <NavigationMenu.DropdownItemSubtitle>
-              Atom Learning color palette
-            </NavigationMenu.DropdownItemSubtitle>
+            <Text>Atom Learning color palette</Text>
           </Flex>
         </NavigationMenu.DropdownItem>
         <NavigationMenu.DropdownItem href="https://app.atomlearning.co.uk/effects">
-          <NavigationMenu.DropdownItemTitle>
-            Effects
-          </NavigationMenu.DropdownItemTitle>
+          Effects
         </NavigationMenu.DropdownItem>
         <NavigationMenu.DropdownItem href="https://app.atomlearning.co.uk/icons">
-          <NavigationMenu.DropdownItemTitle>
-            Icons
-          </NavigationMenu.DropdownItemTitle>
+          Icons
         </NavigationMenu.DropdownItem>
       </NavigationMenu.DropdownContent>
     </NavigationMenu.Dropdown>

--- a/lib/src/components/navigation/NavigationMenu.tsx
+++ b/lib/src/components/navigation/NavigationMenu.tsx
@@ -10,6 +10,8 @@ import { NavigationMenuDropdown } from './NavigationMenuDropdown'
 import {
   NavigationMenuDropdownContent,
   NavigationMenuDropdownItem,
+  NavigationMenuDropdownItemTitle,
+  NavigationMenuDropdownItemSubtitle,
   NavigationMenuLink
 } from './NavigationMenuItem'
 
@@ -18,6 +20,8 @@ type NavigationMenuSubComponents = {
   Dropdown: typeof NavigationMenuDropdown
   DropdownContent: typeof NavigationMenuDropdownContent
   DropdownItem: typeof NavigationMenuDropdownItem
+  DropdownItemTitle: typeof NavigationMenuDropdownItemTitle
+  DropdownItemSubtitle: typeof NavigationMenuDropdownItemSubtitle
 }
 
 const delayedFadeIn = keyframes({
@@ -130,5 +134,7 @@ NavigationMenu.Link = NavigationMenuLink
 NavigationMenu.Dropdown = NavigationMenuDropdown
 NavigationMenu.DropdownContent = NavigationMenuDropdownContent
 NavigationMenu.DropdownItem = NavigationMenuDropdownItem
+NavigationMenu.DropdownItemTitle = NavigationMenuDropdownItemTitle
+NavigationMenu.DropdownItemSubtitle = NavigationMenuDropdownItemSubtitle
 
 NavigationMenu.displayName = 'NavigationMenu'

--- a/lib/src/components/navigation/NavigationMenu.tsx
+++ b/lib/src/components/navigation/NavigationMenu.tsx
@@ -11,7 +11,6 @@ import {
   NavigationMenuDropdownContent,
   NavigationMenuDropdownItem,
   NavigationMenuDropdownItemTitle,
-  NavigationMenuDropdownItemSubtitle,
   NavigationMenuLink
 } from './NavigationMenuItem'
 
@@ -21,7 +20,6 @@ type NavigationMenuSubComponents = {
   DropdownContent: typeof NavigationMenuDropdownContent
   DropdownItem: typeof NavigationMenuDropdownItem
   DropdownItemTitle: typeof NavigationMenuDropdownItemTitle
-  DropdownItemSubtitle: typeof NavigationMenuDropdownItemSubtitle
 }
 
 const delayedFadeIn = keyframes({
@@ -135,6 +133,5 @@ NavigationMenu.Dropdown = NavigationMenuDropdown
 NavigationMenu.DropdownContent = NavigationMenuDropdownContent
 NavigationMenu.DropdownItem = NavigationMenuDropdownItem
 NavigationMenu.DropdownItemTitle = NavigationMenuDropdownItemTitle
-NavigationMenu.DropdownItemSubtitle = NavigationMenuDropdownItemSubtitle
 
 NavigationMenu.displayName = 'NavigationMenu'

--- a/lib/src/components/navigation/NavigationMenuItem.tsx
+++ b/lib/src/components/navigation/NavigationMenuItem.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { CSS, styled, theme } from '~/stitches'
 
 import { Icon } from '../icon'
+import { Text } from '../text'
 
 const activeParentItemStyles = {
   fontWeight: 'bold',
@@ -43,7 +44,7 @@ const itemStyles = {
   '&:hover': { background: '$tonal50', color: '$tonal600' },
   '&:active': { background: '$tonal100', color: '$tonal600' },
   '&:focus-visible': {
-    boxShadow: `0 0 0 2px ${theme.colors.primary}`
+    boxShadow: `inset 0 0 0 2px ${theme.colors.primary}`
   },
   '&:disabled': {
     ...disabledStyles
@@ -71,7 +72,14 @@ const StyledLink = styled(NavigationMenuPrimitive.Link, itemStyles, {
       dropdownItem: {
         '&[data-active]': {
           background: '$primaryLight',
-          color: '$primary'
+          '*': {
+            color: '$primary'
+          },
+          '&:hover': { background: '$tonal50' },
+          '&:active': { background: '$tonal100' },
+          '&:focus-visible': {
+            boxShadow: `0 0 0 2px ${theme.colors.primary}`
+          }
         }
       },
       link: {
@@ -79,6 +87,21 @@ const StyledLink = styled(NavigationMenuPrimitive.Link, itemStyles, {
       }
     }
   }
+})
+
+export const NavigationMenuDropdownItemTitle = styled(Text, {
+  color: '$tonal500',
+  variants: {
+    bold: {
+      true: {
+        fontWeight: '600'
+      }
+    }
+  }
+})
+
+export const NavigationMenuDropdownItemSubtitle = styled(Text, {
+  color: '$tonal500'
 })
 
 export const NavigationMenuDropdownTrigger = React.forwardRef<

--- a/lib/src/components/navigation/NavigationMenuItem.tsx
+++ b/lib/src/components/navigation/NavigationMenuItem.tsx
@@ -44,7 +44,7 @@ const itemStyles = {
   '&:hover': { background: '$tonal50', color: '$tonal600' },
   '&:active': { background: '$tonal100', color: '$tonal600' },
   '&:focus-visible': {
-    boxShadow: `inset 0 0 0 2px ${theme.colors.primary}`
+    boxShadow: `inset 0 0 0 2px $colors$primary`
   },
   '&:disabled': {
     ...disabledStyles
@@ -78,7 +78,7 @@ const StyledLink = styled(NavigationMenuPrimitive.Link, itemStyles, {
           '&:hover': { background: '$tonal50' },
           '&:active': { background: '$tonal100' },
           '&:focus-visible': {
-            boxShadow: `0 0 0 2px ${theme.colors.primary}`
+            boxShadow: `0 0 0 2px $colors$primary}`
           }
         }
       },

--- a/lib/src/components/navigation/NavigationMenuItem.tsx
+++ b/lib/src/components/navigation/NavigationMenuItem.tsx
@@ -91,17 +91,7 @@ const StyledLink = styled(NavigationMenuPrimitive.Link, itemStyles, {
 
 export const NavigationMenuDropdownItemTitle = styled(Text, {
   color: '$tonal500',
-  variants: {
-    bold: {
-      true: {
-        fontWeight: '600'
-      }
-    }
-  }
-})
-
-export const NavigationMenuDropdownItemSubtitle = styled(Text, {
-  color: '$tonal500'
+  fontWeight: '600'
 })
 
 export const NavigationMenuDropdownTrigger = React.forwardRef<

--- a/lib/src/components/navigation/NavigationMenuItem.tsx
+++ b/lib/src/components/navigation/NavigationMenuItem.tsx
@@ -44,7 +44,7 @@ const itemStyles = {
   '&:hover': { background: '$tonal50', color: '$tonal600' },
   '&:active': { background: '$tonal100', color: '$tonal600' },
   '&:focus-visible': {
-    boxShadow: `inset 0 0 0 2px $colors$primary`
+    boxShadow: 'inset 0 0 0 2px $colors$primary'
   },
   '&:disabled': {
     ...disabledStyles
@@ -78,7 +78,7 @@ const StyledLink = styled(NavigationMenuPrimitive.Link, itemStyles, {
           '&:hover': { background: '$tonal50' },
           '&:active': { background: '$tonal100' },
           '&:focus-visible': {
-            boxShadow: `0 0 0 2px $colors$primary}`
+            boxShadow: '0 0 0 2px $colors$primary'
           }
         }
       },

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Nav component renders 1`] = `
     all: unset;
   }
 
-  .c-dVpnxX {
+  .c-hNVQIG {
     all: unset;
     position: relative;
     color: var(--colors-tonal400);
@@ -19,21 +19,21 @@ exports[`Nav component renders 1`] = `
     border-radius: var(--radii-1);
   }
 
-  .c-dVpnxX:hover {
+  .c-hNVQIG:hover {
     background: var(--colors-tonal50);
     color: var(--colors-tonal600);
   }
 
-  .c-dVpnxX:active {
+  .c-hNVQIG:active {
     background: var(--colors-tonal100);
     color: var(--colors-tonal600);
   }
 
-  .c-dVpnxX:focus-visible {
-    box-shadow: 0 0 0 2px var(--colors-primary);
+  .c-hNVQIG:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--colors-primary);
   }
 
-  .c-dVpnxX:disabled {
+  .c-hNVQIG:disabled {
     background: none;
     color: var(--colors-tonal400);
     opacity: 30%;
@@ -173,7 +173,7 @@ exports[`Nav component renders 1`] = `
           class="c-leHWbT"
         >
           <a
-            class="c-dVpnxX c-govTNd c-govTNd-ctVDrw-elementType-link"
+            class="c-hNVQIG c-govTNd c-govTNd-ctVDrw-elementType-link"
             data-radix-collection-item=""
             href="/introduction"
           >
@@ -184,7 +184,7 @@ exports[`Nav component renders 1`] = `
           <button
             aria-controls="radix-1-content-Theme"
             aria-expanded="false"
-            class="c-dVpnxX c-gWdZwW"
+            class="c-hNVQIG c-gWdZwW"
             data-radix-collection-item=""
             data-state="closed"
             id="radix-1-trigger-Theme"

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Nav component renders 1`] = `
     all: unset;
   }
 
-  .c-hNVQIG {
+  .c-dIYQCX {
     all: unset;
     position: relative;
     color: var(--colors-tonal400);
@@ -19,21 +19,21 @@ exports[`Nav component renders 1`] = `
     border-radius: var(--radii-1);
   }
 
-  .c-hNVQIG:hover {
+  .c-dIYQCX:hover {
     background: var(--colors-tonal50);
     color: var(--colors-tonal600);
   }
 
-  .c-hNVQIG:active {
+  .c-dIYQCX:active {
     background: var(--colors-tonal100);
     color: var(--colors-tonal600);
   }
 
-  .c-hNVQIG:focus-visible {
+  .c-dIYQCX:focus-visible {
     box-shadow: inset 0 0 0 2px var(--colors-primary);
   }
 
-  .c-hNVQIG:disabled {
+  .c-dIYQCX:disabled {
     background: none;
     color: var(--colors-tonal400);
     opacity: 30%;
@@ -173,7 +173,7 @@ exports[`Nav component renders 1`] = `
           class="c-leHWbT"
         >
           <a
-            class="c-hNVQIG c-govTNd c-govTNd-ctVDrw-elementType-link"
+            class="c-dIYQCX c-govTNd c-govTNd-ctVDrw-elementType-link"
             data-radix-collection-item=""
             href="/introduction"
           >
@@ -184,7 +184,7 @@ exports[`Nav component renders 1`] = `
           <button
             aria-controls="radix-1-content-Theme"
             aria-expanded="false"
-            class="c-hNVQIG c-gWdZwW"
+            class="c-dIYQCX c-gWdZwW"
             data-radix-collection-item=""
             data-state="closed"
             id="radix-1-trigger-Theme"


### PR DESCRIPTION
## Description

### Added new NavigationMenu elements:
- NavigationMenuDropdownItemTitle
- NavigationMenuDropdownItemSubtitle

both items added to makes navigation dropdown item elements consistent across applications.

![Zrzut ekranu 2022-10-31 o 13 58 25](https://user-images.githubusercontent.com/23363033/199013382-0b196fbd-f247-4a37-848c-25447d61c4e3.png)
![Zrzut ekranu 2022-10-31 o 13 58 35](https://user-images.githubusercontent.com/23363033/199013401-43131b1b-5a41-40c3-bfe6-c887a6740dec.png)

### Fixes for Dropdown `active` state:
- hover
- active
- focus

+ added text, icon (img) proper colors on active state.

https://user-images.githubusercontent.com/23363033/199012856-92da5a65-d1c2-4e59-b23d-e17026080e0d.mov
![Zrzut ekranu 2022-10-31 o 11 35 50](https://user-images.githubusercontent.com/23363033/199013022-9aadbf1a-c6f7-4ade-aa89-7b8ce2198b4b.png)

### Fix for focus state:
Before:
![Zrzut ekranu 2022-10-31 o 11 32 14](https://user-images.githubusercontent.com/23363033/199012697-ab8e3c5e-ec20-4a3f-8c95-fc3cf671eef5.png)

After:
![Zrzut ekranu 2022-10-31 o 11 35 35](https://user-images.githubusercontent.com/23363033/199012704-f5dbf64b-d7aa-4934-b6bb-74dbdd8404b6.png)
