### PR TITLE
fix: empty state image margin

### DIFF
--- a/lib/src/components/empty-state/EmptyStateImage.tsx
+++ b/lib/src/components/empty-state/EmptyStateImage.tsx
@@ -3,37 +3,39 @@ import { Image } from '~/components/image'
 import { styled } from '~/stitches'
 
 const EmptyStateImageContainer = styled('div', {
+  height: 'auto',
   variants: {
     size: {
       xs: {
         width: '56px',
-        height: '32px',
+        maxHeight: '56px',
         mb: '$4'
       },
       sm: {
-        size: '84px',
+        width: '84px',
+        maxHeight: '84px',
         mb: '$4'
       },
       md: {
         width: '126px',
-        height: '72px',
+        maxHeight: '126px',
         mb: '$4'
       },
       lg: {
         width: '190px',
-        height: '142px',
+        maxHeight: '190px',
         mb: '$5'
       },
       xl: {
         width: '285px',
-        height: '213px',
+        maxHeight: '285px',
         mb: '$5'
       }
     }
   }
 })
 
-const StyledImage = styled(Image, { maxHeight: '100%' })
+const StyledImage = styled(Image, { objectFit: 'contain', maxHeight: '100%' })
 
 type EmptyStateImageProps = React.ComponentProps<
   typeof EmptyStateImageContainer


### PR DESCRIPTION
### Description

https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-133

Bug appeared on certain image aspect ratios following the previous change to the Empty State image, which was causing ti to break out of it's container or not fill it's container, meaning either too much or too little bottom margin. This sets the containing box to have a fixed width and variable height, as well as setting `objectFit: 'contain'` on the image.

### Screenshots

Here is a rundown of each size with images in both landscape and portrait aspects.

![image](https://user-images.githubusercontent.com/66493855/199210394-6cf9d023-d87c-4464-9bc8-305f445943ce.png)