### PR TITLE
fix stepper state updates

### DIFF
--- a/lib/src/components/stepper/Stepper.mdx
+++ b/lib/src/components/stepper/Stepper.mdx
@@ -84,7 +84,7 @@ Below is an example that shows how to use the controlled component. Each object 
       status: 'active'
     },
     {
-      label: 'Step 4',
+      label: 'Step 3',
       status: 'default'
     }
   ]}
@@ -109,11 +109,35 @@ Below is an example that shows how to hide step labels
       status: 'active'
     },
     {
-      label: 'Step 4',
+      label: 'Step 3',
       status: 'default'
     }
   ]}
   hideLabels={true}
+>
+  <Stepper.Steps />
+</Stepper>
+```
+
+The root `Stepper` component also allows the user to pass a `showCompletedIcons` prop in order to replace step numbers with tick icons when the step has been completed. This defaults to `false`.
+
+```tsx preview
+<Stepper
+  steps={[
+    {
+      label: 'Step 1',
+      status: 'completed'
+    },
+    {
+      label: 'Step 2',
+      status: 'active'
+    },
+    {
+      label: 'Step 3',
+      status: 'default'
+    }
+  ]}
+  showCompletedIcons
 >
   <Stepper.Steps />
 </Stepper>

--- a/lib/src/components/stepper/Stepper.test.tsx
+++ b/lib/src/components/stepper/Stepper.test.tsx
@@ -308,4 +308,21 @@ describe('Stepper', () => {
     const expectedSteps = screen.queryAllByLabelText('step', { exact: false })
     expect(expectedSteps).toHaveLength(0)
   })
+
+  it('replaces completed step numbers with icons when prop passed in', () => {
+    const steps: Step[] = [
+      { label: 'Step 1', status: 'completed' },
+      { label: 'Step 2', status: 'active' },
+      { label: 'Step 3', status: 'default' }
+    ]
+
+    render(
+      <Stepper steps={steps} showCompletedIcons>
+        <Stepper.Steps />
+      </Stepper>
+    )
+
+    expect(screen.queryByText('1')).not.toBeInTheDocument()
+    expect(screen.getByText('2')).toBeVisible()
+  })
 })

--- a/lib/src/components/stepper/Stepper.tsx
+++ b/lib/src/components/stepper/Stepper.tsx
@@ -21,6 +21,7 @@ export const Stepper: React.FC<IStepperProps> & {
   direction = 'horizontal',
   steps,
   hideLabels = false,
+  showCompletedIcons = false,
   css
 }) => {
   invariant(
@@ -39,6 +40,7 @@ export const Stepper: React.FC<IStepperProps> & {
       direction={direction}
       steps={steps || Array(count).fill('')}
       hideLabels={hideLabels}
+      showCompletedIcons={showCompletedIcons}
     >
       <Box
         aria-label="progress"

--- a/lib/src/components/stepper/StepperStepBullet.tsx
+++ b/lib/src/components/stepper/StepperStepBullet.tsx
@@ -10,12 +10,12 @@ export const StepperStepBullet = styled(Flex, {
   size: '$3',
   borderRadius: '50%',
   border: 'none',
-  bg: '$tonal50',
+  bg: '$tonal100',
   zIndex: 1,
   flex: 'none',
   variants: {
     status: {
-      default: { bg: '$tonal50', color: '$tonal300' },
+      default: { bg: '$tonal100', color: '$tonal300' },
       active: {
         bg: 'white',
         color: '$primaryMid',

--- a/lib/src/components/stepper/StepperStepContainer.tsx
+++ b/lib/src/components/stepper/StepperStepContainer.tsx
@@ -16,6 +16,7 @@ export const StepperStepContainer = styled(Flex, {
     outline: 'none'
   },
   variants: {
+    canInteract: { true: {} },
     direction: {
       vertical: {
         py: '$3',
@@ -39,12 +40,25 @@ export const StepperStepContainer = styled(Flex, {
       }
     },
     separator: {
-      default: { '&:not(:last-child)::after': { bg: '$tonal50' } },
+      default: { '&:not(:last-child)::after': { bg: '$tonal100' } },
       active: { '&:not(:last-child)::after': { bg: '$primary' } },
-      success: { '&:not(:last-child)::after': { bg: '$success' } }
+      success: { '&:not(:last-child)::after': { bg: '$success' } },
+      viewed: { '&:not(:last-child)::after': { bg: '$tonal200' } }
     },
     status: {
-      completed: {
+      completed: {},
+      active: {},
+      default: {},
+      viewed: {},
+      success: {},
+      reviewed: {}
+    }
+  },
+  compoundVariants: [
+    {
+      canInteract: true,
+      status: 'completed',
+      css: {
         '&:hover': {
           '& :first-child': { bg: '$primaryMid', color: 'white !important' },
           '& :last-child': { color: '$primaryMid' }
@@ -55,8 +69,12 @@ export const StepperStepContainer = styled(Flex, {
             outlineOffset: '2px'
           }
         }
-      },
-      active: {
+      }
+    },
+    {
+      canInteract: true,
+      status: 'active',
+      css: {
         '&:hover': {
           '& :first-child': { borderColor: '$tonal400', color: '$tonal600' },
           '& :last-child': { color: '$tonal600' }
@@ -67,18 +85,28 @@ export const StepperStepContainer = styled(Flex, {
             outlineOffset: '2px'
           }
         }
-      },
-      default: {},
-      viewed: {
+      }
+    },
+    {
+      canInteract: true,
+      status: 'viewed',
+      css: {
+        '&:hover': {
+          '& :first-child': { borderColor: '$tonal400', color: '$tonal600' },
+          '& :last-child': { color: '$tonal600' }
+        },
         '&:focus-visible': {
           '& :first-child': {
             outline: '2px solid $primary !important',
             outlineOffset: '2px !important'
           }
         }
-      },
-      success: {},
-      reviewed: {
+      }
+    },
+    {
+      canInteract: true,
+      status: 'reviewed',
+      css: {
         '&:focus-visible': {
           '& :first-child': {
             outline: '2px solid $primary !important',
@@ -87,5 +115,5 @@ export const StepperStepContainer = styled(Flex, {
         }
       }
     }
-  }
+  ]
 })

--- a/lib/src/components/stepper/StepperSteps.tsx
+++ b/lib/src/components/stepper/StepperSteps.tsx
@@ -30,7 +30,8 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({ css }) => {
     allowSkip,
     direction,
     hideLabels,
-    completedSteps
+    completedSteps,
+    showCompletedIcons
   } = useStepper()
 
   const getBulletStatus = (index: number) => {
@@ -57,8 +58,12 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({ css }) => {
       return Status.SUCCESS
     }
 
-    if (bulletStatus === Status.VIEWED || index < Math.max(...viewedSteps)) {
+    if (bulletStatus === Status.COMPLETED || index < Math.max(...viewedSteps)) {
       return Status.ACTIVE
+    }
+
+    if (bulletStatus === Status.VIEWED) {
+      return Status.VIEWED
     }
 
     return Status.DEFAULT
@@ -68,20 +73,21 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({ css }) => {
     <StepperStepsContainer css={css} direction={direction}>
       {steps.map((step, index) => {
         const bulletStatus = getBulletStatus(index)
-        const seperatorStatus = getSeparatorStatus(index)
+        const separatorStatus = getSeparatorStatus(index)
 
         return (
           <StepperStepContainer
             tabIndex={0}
             key={`step_${index}`}
             direction={direction}
-            separator={seperatorStatus}
+            separator={separatorStatus}
             status={bulletStatus}
             css={
               direction === 'horizontal'
                 ? { width: `calc(100% / ${steps.length})` }
                 : { height: `calc(100% / ${steps.length})` }
             }
+            canInteract={allowSkip}
           >
             <StepperStepBullet
               as={allowSkip ? 'button' : 'div'}
@@ -99,7 +105,12 @@ export const StepperSteps: React.FC<IStepperStepsProps> = ({ css }) => {
                   allowSkip && viewedSteps.includes(index) ? 'pointer' : 'auto'
               }}
             >
-              {step.status === 'success' ? <Icon is={Ok} /> : index + 1}
+              {step.status === Status.SUCCESS ||
+              (showCompletedIcons && bulletStatus === Status.COMPLETED) ? (
+                <Icon is={Ok} />
+              ) : (
+                index + 1
+              )}
             </StepperStepBullet>
 
             {step.label && !hideLabels && (

--- a/lib/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/lib/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
     outline: none;
   }
 
-  .c-eqmUPO {
+  .c-iXIhNm {
     position: relative;
     padding: var(--space-2);
     justify-content: center;
@@ -53,7 +53,7 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
     width: var(--sizes-3);
     border-radius: 50%;
     border: none;
-    background: var(--colors-tonal50);
+    background: var(--colors-tonal100);
     z-index: 1;
     flex: none;
   }
@@ -85,51 +85,23 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
     top: 14px;
   }
 
-  .c-boNUgq-iPHtVM-separator-default:not(:last-child)::after {
-    background: var(--colors-tonal50);
+  .c-boNUgq-eoIvAE-separator-default:not(:last-child)::after {
+    background: var(--colors-tonal100);
   }
 
-  .c-boNUgq-jCkdlW-status-active:hover :first-child {
-    border-color: var(--colors-tonal400);
-    color: var(--colors-tonal600);
-  }
-
-  .c-boNUgq-jCkdlW-status-active:hover :last-child {
-    color: var(--colors-tonal600);
-  }
-
-  .c-boNUgq-jCkdlW-status-active:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary);
-    outline-offset: 2px;
-  }
-
-  .c-eqmUPO-gjRYFk-status-active {
+  .c-iXIhNm-gjRYFk-status-active {
     background: white;
     color: var(--colors-primaryMid);
     border: 2px solid;
     border-color: currentColor;
   }
 
-  .c-eqmUPO-gMtQgP-status-default {
-    background: var(--colors-tonal50);
+  .c-iXIhNm-fkZUVj-status-default {
+    background: var(--colors-tonal100);
     color: var(--colors-tonal300);
   }
 
-  .c-boNUgq-dKQwO-status-completed:hover :first-child {
-    background: var(--colors-primaryMid);
-    color: white !important;
-  }
-
-  .c-boNUgq-dKQwO-status-completed:hover :last-child {
-    color: var(--colors-primaryMid);
-  }
-
-  .c-boNUgq-dKQwO-status-completed:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary);
-    outline-offset: 2px;
-  }
-
-  .c-eqmUPO-lkRQpS-status-completed {
+  .c-iXIhNm-lkRQpS-status-completed {
     background: var(--colors-primary);
     color: white;
   }
@@ -138,22 +110,12 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
     background: var(--colors-primary);
   }
 
-  .c-boNUgq-iIblYT-status-reviewed:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
-    outline-offset: 2px !important;
-  }
-
-  .c-eqmUPO-bHjIVm-status-reviewed {
+  .c-iXIhNm-bHjIVm-status-reviewed {
     background: var(--colors-primaryMid);
     color: white;
   }
 
-  .c-boNUgq-iIblYT-status-viewed:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
-    outline-offset: 2px !important;
-  }
-
-  .c-eqmUPO-kDTefL-status-viewed {
+  .c-iXIhNm-kDTefL-status-viewed {
     background: white;
     border: 2px solid var(--colors-tonal200);
     color: var(--colors-tonal600);
@@ -163,7 +125,7 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
     background: var(--colors-success);
   }
 
-  .c-eqmUPO-fpBJZl-status-success {
+  .c-iXIhNm-fpBJZl-status-success {
     background: var(--colors-success);
     color: white;
   }
@@ -229,6 +191,53 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
   .c-fkUJsw-gsycxF-cv:not([disabled]):active {
     background: var(--colors-primaryDark);
   }
+
+  .c-boNUgq-jCkdlW-cv:hover :first-child {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-jCkdlW-cv:hover :last-child {
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-jCkdlW-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary);
+    outline-offset: 2px;
+  }
+
+  .c-boNUgq-dKQwO-cv:hover :first-child {
+    background: var(--colors-primaryMid);
+    color: white !important;
+  }
+
+  .c-boNUgq-dKQwO-cv:hover :last-child {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-boNUgq-dKQwO-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary);
+    outline-offset: 2px;
+  }
+
+  .c-boNUgq-iIblYT-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary) !important;
+    outline-offset: 2px !important;
+  }
+
+  .c-boNUgq-fCshQK-cv:hover :first-child {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-fCshQK-cv:hover :last-child {
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-fCshQK-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary) !important;
+    outline-offset: 2px !important;
+  }
 }
 
 @media  {
@@ -273,35 +282,35 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
       class="c-dhzjXW c-knmidH c-knmidH-iTKOFX-direction-vertical"
     >
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-bQZyjU-direction-vertical c-boNUgq-iPHtVM-separator-default c-boNUgq-jCkdlW-status-active c-dhzjXW-ieTCIBM-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-bQZyjU-direction-vertical c-boNUgq-eoIvAE-separator-default c-boNUgq-jCkdlW-cv c-dhzjXW-ieTCIBM-css"
         tabindex="0"
       >
         <button
           aria-current="step"
           aria-label="step 1"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gjRYFk-status-active c-dhzjXW-igsmDXe-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-gjRYFk-status-active c-dhzjXW-igsmDXe-css"
         >
           1
         </button>
       </div>
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-bQZyjU-direction-vertical c-boNUgq-iPHtVM-separator-default c-dhzjXW-ieTCIBM-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-bQZyjU-direction-vertical c-boNUgq-eoIvAE-separator-default c-dhzjXW-ieTCIBM-css"
         tabindex="0"
       >
         <button
           aria-label="step 2"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gMtQgP-status-default c-dhzjXW-idGcKFW-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-fkZUVj-status-default c-dhzjXW-idGcKFW-css"
         >
           2
         </button>
       </div>
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-bQZyjU-direction-vertical c-boNUgq-iPHtVM-separator-default c-dhzjXW-ieTCIBM-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-bQZyjU-direction-vertical c-boNUgq-eoIvAE-separator-default c-dhzjXW-ieTCIBM-css"
         tabindex="0"
       >
         <button
           aria-label="step 3"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gMtQgP-status-default c-dhzjXW-idGcKFW-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-fkZUVj-status-default c-dhzjXW-idGcKFW-css"
         >
           3
         </button>
@@ -361,7 +370,7 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     outline: none;
   }
 
-  .c-eqmUPO {
+  .c-iXIhNm {
     position: relative;
     padding: var(--space-2);
     justify-content: center;
@@ -370,7 +379,7 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     width: var(--sizes-3);
     border-radius: 50%;
     border: none;
-    background: var(--colors-tonal50);
+    background: var(--colors-tonal100);
     z-index: 1;
     flex: none;
   }
@@ -415,51 +424,23 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     top: 14px;
   }
 
-  .c-boNUgq-iPHtVM-separator-default:not(:last-child)::after {
-    background: var(--colors-tonal50);
+  .c-boNUgq-eoIvAE-separator-default:not(:last-child)::after {
+    background: var(--colors-tonal100);
   }
 
-  .c-boNUgq-jCkdlW-status-active:hover :first-child {
-    border-color: var(--colors-tonal400);
-    color: var(--colors-tonal600);
-  }
-
-  .c-boNUgq-jCkdlW-status-active:hover :last-child {
-    color: var(--colors-tonal600);
-  }
-
-  .c-boNUgq-jCkdlW-status-active:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary);
-    outline-offset: 2px;
-  }
-
-  .c-eqmUPO-gjRYFk-status-active {
+  .c-iXIhNm-gjRYFk-status-active {
     background: white;
     color: var(--colors-primaryMid);
     border: 2px solid;
     border-color: currentColor;
   }
 
-  .c-eqmUPO-gMtQgP-status-default {
-    background: var(--colors-tonal50);
+  .c-iXIhNm-fkZUVj-status-default {
+    background: var(--colors-tonal100);
     color: var(--colors-tonal300);
   }
 
-  .c-boNUgq-dKQwO-status-completed:hover :first-child {
-    background: var(--colors-primaryMid);
-    color: white !important;
-  }
-
-  .c-boNUgq-dKQwO-status-completed:hover :last-child {
-    color: var(--colors-primaryMid);
-  }
-
-  .c-boNUgq-dKQwO-status-completed:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary);
-    outline-offset: 2px;
-  }
-
-  .c-eqmUPO-lkRQpS-status-completed {
+  .c-iXIhNm-lkRQpS-status-completed {
     background: var(--colors-primary);
     color: white;
   }
@@ -468,22 +449,12 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     background: var(--colors-primary);
   }
 
-  .c-boNUgq-iIblYT-status-reviewed:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
-    outline-offset: 2px !important;
-  }
-
-  .c-eqmUPO-bHjIVm-status-reviewed {
+  .c-iXIhNm-bHjIVm-status-reviewed {
     background: var(--colors-primaryMid);
     color: white;
   }
 
-  .c-boNUgq-iIblYT-status-viewed:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
-    outline-offset: 2px !important;
-  }
-
-  .c-eqmUPO-kDTefL-status-viewed {
+  .c-iXIhNm-kDTefL-status-viewed {
     background: white;
     border: 2px solid var(--colors-tonal200);
     color: var(--colors-tonal600);
@@ -493,7 +464,7 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     background: var(--colors-success);
   }
 
-  .c-eqmUPO-fpBJZl-status-success {
+  .c-iXIhNm-fpBJZl-status-success {
     background: var(--colors-success);
     color: white;
   }
@@ -583,6 +554,53 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
   .c-fkUJsw-gsycxF-cv:not([disabled]):active {
     background: var(--colors-primaryDark);
   }
+
+  .c-boNUgq-jCkdlW-cv:hover :first-child {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-jCkdlW-cv:hover :last-child {
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-jCkdlW-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary);
+    outline-offset: 2px;
+  }
+
+  .c-boNUgq-dKQwO-cv:hover :first-child {
+    background: var(--colors-primaryMid);
+    color: white !important;
+  }
+
+  .c-boNUgq-dKQwO-cv:hover :last-child {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-boNUgq-dKQwO-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary);
+    outline-offset: 2px;
+  }
+
+  .c-boNUgq-iIblYT-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary) !important;
+    outline-offset: 2px !important;
+  }
+
+  .c-boNUgq-fCshQK-cv:hover :first-child {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-fCshQK-cv:hover :last-child {
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-fCshQK-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary) !important;
+    outline-offset: 2px !important;
+  }
 }
 
 @media  {
@@ -638,7 +656,7 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
           aria-current="step"
           aria-label=""
           aria-labelledby="step-0"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-fpBJZl-status-success c-dhzjXW-idGcKFW-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-fpBJZl-status-success c-dhzjXW-idGcKFW-css"
         >
           <svg
             aria-hidden="true"
@@ -659,13 +677,13 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
         </span>
       </div>
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-iPHtVM-separator-default c-boNUgq-jCkdlW-status-active c-dhzjXW-ikOanEY-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-eoIvAE-separator-default c-dhzjXW-ikOanEY-css"
         tabindex="0"
       >
         <div
           aria-label=""
           aria-labelledby="step-1"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gjRYFk-status-active c-dhzjXW-idGcKFW-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-gjRYFk-status-active c-dhzjXW-idGcKFW-css"
         >
           2
         </div>
@@ -731,7 +749,7 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     outline: none;
   }
 
-  .c-eqmUPO {
+  .c-iXIhNm {
     position: relative;
     padding: var(--space-2);
     justify-content: center;
@@ -740,7 +758,7 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     width: var(--sizes-3);
     border-radius: 50%;
     border: none;
-    background: var(--colors-tonal50);
+    background: var(--colors-tonal100);
     z-index: 1;
     flex: none;
   }
@@ -772,33 +790,19 @@ exports[`Stepper renders the correct number of bullets 1`] = `
     top: 14px;
   }
 
-  .c-boNUgq-iPHtVM-separator-default:not(:last-child)::after {
-    background: var(--colors-tonal50);
+  .c-boNUgq-eoIvAE-separator-default:not(:last-child)::after {
+    background: var(--colors-tonal100);
   }
 
-  .c-boNUgq-jCkdlW-status-active:hover :first-child {
-    border-color: var(--colors-tonal400);
-    color: var(--colors-tonal600);
-  }
-
-  .c-boNUgq-jCkdlW-status-active:hover :last-child {
-    color: var(--colors-tonal600);
-  }
-
-  .c-boNUgq-jCkdlW-status-active:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary);
-    outline-offset: 2px;
-  }
-
-  .c-eqmUPO-gjRYFk-status-active {
+  .c-iXIhNm-gjRYFk-status-active {
     background: white;
     color: var(--colors-primaryMid);
     border: 2px solid;
     border-color: currentColor;
   }
 
-  .c-eqmUPO-gMtQgP-status-default {
-    background: var(--colors-tonal50);
+  .c-iXIhNm-fkZUVj-status-default {
+    background: var(--colors-tonal100);
     color: var(--colors-tonal300);
   }
 }
@@ -846,6 +850,20 @@ exports[`Stepper renders the correct number of bullets 1`] = `
   .c-fkUJsw-gsycxF-cv:not([disabled]):active {
     background: var(--colors-primaryDark);
   }
+
+  .c-boNUgq-jCkdlW-cv:hover :first-child {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-jCkdlW-cv:hover :last-child {
+    color: var(--colors-tonal600);
+  }
+
+  .c-boNUgq-jCkdlW-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary);
+    outline-offset: 2px;
+  }
 }
 
 @media  {
@@ -886,35 +904,35 @@ exports[`Stepper renders the correct number of bullets 1`] = `
       class="c-dhzjXW c-knmidH c-knmidH-ejCoEP-direction-horizontal"
     >
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-iPHtVM-separator-default c-boNUgq-jCkdlW-status-active c-dhzjXW-ibJjasZ-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-eoIvAE-separator-default c-boNUgq-jCkdlW-cv c-dhzjXW-ibJjasZ-css"
         tabindex="0"
       >
         <button
           aria-current="step"
           aria-label="step 1"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gjRYFk-status-active c-dhzjXW-igsmDXe-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-gjRYFk-status-active c-dhzjXW-igsmDXe-css"
         >
           1
         </button>
       </div>
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-iPHtVM-separator-default c-dhzjXW-ibJjasZ-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-eoIvAE-separator-default c-dhzjXW-ibJjasZ-css"
         tabindex="0"
       >
         <button
           aria-label="step 2"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gMtQgP-status-default c-dhzjXW-idGcKFW-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-fkZUVj-status-default c-dhzjXW-idGcKFW-css"
         >
           2
         </button>
       </div>
       <div
-        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-iPHtVM-separator-default c-dhzjXW-ibJjasZ-css"
+        class="c-dhzjXW c-boNUgq c-boNUgq-fruqQw-direction-horizontal c-boNUgq-eoIvAE-separator-default c-dhzjXW-ibJjasZ-css"
         tabindex="0"
       >
         <button
           aria-label="step 3"
-          class="c-dhzjXW c-eqmUPO c-eqmUPO-gMtQgP-status-default c-dhzjXW-idGcKFW-css"
+          class="c-dhzjXW c-iXIhNm c-iXIhNm-fkZUVj-status-default c-dhzjXW-idGcKFW-css"
         >
           3
         </button>

--- a/lib/src/components/stepper/stepper-context/StepperContext.tsx
+++ b/lib/src/components/stepper/stepper-context/StepperContext.tsx
@@ -12,7 +12,8 @@ const StepperContext = React.createContext<Context>({
   allowSkip: false,
   direction: 'horizontal',
   hideLabels: false,
-  completedSteps: []
+  completedSteps: [],
+  showCompletedIcons: false
 })
 
 export const StepperProvider: React.FC<StepperProviderProps> = ({
@@ -23,7 +24,8 @@ export const StepperProvider: React.FC<StepperProviderProps> = ({
   onStepChange,
   direction,
   steps,
-  hideLabels
+  hideLabels,
+  showCompletedIcons
 }) => {
   const [activeStep, setActiveStep] = React.useState(0)
 
@@ -78,7 +80,8 @@ export const StepperProvider: React.FC<StepperProviderProps> = ({
         completedSteps,
         allowSkip,
         direction,
-        hideLabels
+        hideLabels,
+        showCompletedIcons
       }}
     >
       {children}

--- a/lib/src/components/stepper/types.ts
+++ b/lib/src/components/stepper/types.ts
@@ -26,6 +26,7 @@ export type Context = {
   allowSkip?: boolean
   direction?: Direction
   hideLabels: boolean
+  showCompletedIcons: boolean
 }
 
 export type StepperProviderProps = {
@@ -36,6 +37,7 @@ export type StepperProviderProps = {
   direction?: Direction
   steps: Step[]
   hideLabels: boolean
+  showCompletedIcons: boolean
 }
 
 export interface IStepperProps {
@@ -47,6 +49,7 @@ export interface IStepperProps {
   direction?: Direction
   steps?: Step[]
   hideLabels?: boolean
+  showCompletedIcons?: boolean
 }
 
 export interface IStepperNavigateProps {


### PR DESCRIPTION
### Description

https://atomlearningltd.atlassian.net/browse/DS-143
Note: part of that ticket requires a change on core once this work has been done and DS version on core updated

This fixes a number of issues with the stepper component and the various states that is has:

- The stepper track was not correctly showing as blue for completed items, this has been fixed
- Viewed (but not completed) items now show a darker than normal colour to separate them from default state
- Added a prop to allow showing tick icons for completed steps instead of their step number
- Changed the default state colour to be slightly darker so it shows up better on light backgrounds
- Moved the interaction states (hover, focus) to only appear when allow skip prop is present, this is because otherwise there would be no interaction so hover states were superfluous and confusing to the user
- Updated tests and snapshots

### Screenshots

![image](https://user-images.githubusercontent.com/66493855/199260737-aa7cd893-b713-4ba6-966a-8d23a50658fb.png)