### PR TITLE
fix(tooltip): override white-space style to make sure the text inside always wraps

### DIFF
--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event'
 import { createColumnHelper } from '@tanstack/react-table'
 import { DataTable } from '.'
 import { Tooltip } from '../tooltip'
-import { TooltipPortal } from '@radix-ui/react-tooltip'
 
 const columnHelper = createColumnHelper<{
   name: string

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`DataTable component renders 1`] = `
     transition: all 100ms ease-out;
   }
 
-  .c-hAXqx {
+  .c-hVoQtf {
     background-color: var(--colors-tonal500);
     border-radius: var(--radii-0);
     box-shadow: var(--shadows-0);
@@ -182,6 +182,7 @@ exports[`DataTable component renders 1`] = `
     font-family: var(--fonts-body);
     font-size: var(--fontSizes-sm);
     line-height: 1.5;
+    white-space: normal;
     padding-left: var(--space-3);
     padding-right: var(--space-3);
     padding-top: var(--space-2);
@@ -190,7 +191,7 @@ exports[`DataTable component renders 1`] = `
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx {
+    .c-hVoQtf {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -198,25 +199,25 @@ exports[`DataTable component renders 1`] = `
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="top"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="right"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="bottom"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="left"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -329,7 +330,7 @@ exports[`DataTable component renders 1`] = `
     border-radius: var(--radii-round);
   }
 
-  .c-hAXqx-gWQnqe-size-md {
+  .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
 }

--- a/lib/src/components/number-input-field/__snapshots__/NumberInputField.test.tsx.snap
+++ b/lib/src/components/number-input-field/__snapshots__/NumberInputField.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`NumberInputField component renders a field in error state - has no prog
     vertical-align: middle;
   }
 
-  .c-hAXqx {
+  .c-hVoQtf {
     background-color: var(--colors-tonal500);
     border-radius: var(--radii-0);
     box-shadow: var(--shadows-0);
@@ -44,6 +44,7 @@ exports[`NumberInputField component renders a field in error state - has no prog
     font-family: var(--fonts-body);
     font-size: var(--fontSizes-sm);
     line-height: 1.5;
+    white-space: normal;
     padding-left: var(--space-3);
     padding-right: var(--space-3);
     padding-top: var(--space-2);
@@ -52,7 +53,7 @@ exports[`NumberInputField component renders a field in error state - has no prog
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx {
+    .c-hVoQtf {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -60,25 +61,25 @@ exports[`NumberInputField component renders a field in error state - has no prog
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="top"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="right"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="bottom"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="left"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -168,7 +169,7 @@ exports[`NumberInputField component renders a field in error state - has no prog
     stroke-width: 1.75;
   }
 
-  .c-hAXqx-gWQnqe-size-md {
+  .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
 
@@ -468,7 +469,7 @@ exports[`NumberInputField component renders a field with a disabled input - has 
     vertical-align: middle;
   }
 
-  .c-hAXqx {
+  .c-hVoQtf {
     background-color: var(--colors-tonal500);
     border-radius: var(--radii-0);
     box-shadow: var(--shadows-0);
@@ -476,6 +477,7 @@ exports[`NumberInputField component renders a field with a disabled input - has 
     font-family: var(--fonts-body);
     font-size: var(--fontSizes-sm);
     line-height: 1.5;
+    white-space: normal;
     padding-left: var(--space-3);
     padding-right: var(--space-3);
     padding-top: var(--space-2);
@@ -484,7 +486,7 @@ exports[`NumberInputField component renders a field with a disabled input - has 
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx {
+    .c-hVoQtf {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -492,25 +494,25 @@ exports[`NumberInputField component renders a field with a disabled input - has 
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="top"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="right"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="bottom"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="left"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -583,7 +585,7 @@ exports[`NumberInputField component renders a field with a disabled input - has 
     stroke-width: 1.75;
   }
 
-  .c-hAXqx-gWQnqe-size-md {
+  .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
 
@@ -814,7 +816,7 @@ exports[`NumberInputField component renders a field with a number input - has no
     vertical-align: middle;
   }
 
-  .c-hAXqx {
+  .c-hVoQtf {
     background-color: var(--colors-tonal500);
     border-radius: var(--radii-0);
     box-shadow: var(--shadows-0);
@@ -822,6 +824,7 @@ exports[`NumberInputField component renders a field with a number input - has no
     font-family: var(--fonts-body);
     font-size: var(--fontSizes-sm);
     line-height: 1.5;
+    white-space: normal;
     padding-left: var(--space-3);
     padding-right: var(--space-3);
     padding-top: var(--space-2);
@@ -830,7 +833,7 @@ exports[`NumberInputField component renders a field with a number input - has no
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx {
+    .c-hVoQtf {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -838,25 +841,25 @@ exports[`NumberInputField component renders a field with a number input - has no
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="top"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="right"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="bottom"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="left"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -929,7 +932,7 @@ exports[`NumberInputField component renders a field with a number input - has no
     stroke-width: 1.75;
   }
 
-  .c-hAXqx-gWQnqe-size-md {
+  .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
 

--- a/lib/src/components/number-input/__snapshots__/NumberInput.test.tsx.snap
+++ b/lib/src/components/number-input/__snapshots__/NumberInput.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`NumberInput component renders number input  1`] = `
     vertical-align: middle;
   }
 
-  .c-hAXqx {
+  .c-hVoQtf {
     background-color: var(--colors-tonal500);
     border-radius: var(--radii-0);
     box-shadow: var(--shadows-0);
@@ -38,6 +38,7 @@ exports[`NumberInput component renders number input  1`] = `
     font-family: var(--fonts-body);
     font-size: var(--fontSizes-sm);
     line-height: 1.5;
+    white-space: normal;
     padding-left: var(--space-3);
     padding-right: var(--space-3);
     padding-top: var(--space-2);
@@ -46,7 +47,7 @@ exports[`NumberInput component renders number input  1`] = `
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx {
+    .c-hVoQtf {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -54,25 +55,25 @@ exports[`NumberInput component renders number input  1`] = `
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="top"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="right"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="bottom"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="left"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -123,7 +124,7 @@ exports[`NumberInput component renders number input  1`] = `
     stroke-width: 1.75;
   }
 
-  .c-hAXqx-gWQnqe-size-md {
+  .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
 

--- a/lib/src/components/tooltip/TooltipContent.tsx
+++ b/lib/src/components/tooltip/TooltipContent.tsx
@@ -18,6 +18,7 @@ const StyledContent = styled(Content, {
   fontFamily: '$body',
   fontSize: '$sm',
   lineHeight: 1.5,
+  whiteSpace: 'normal',
   px: '$3',
   py: '$2',
   zIndex: TOOLTIP_Z_INDEX,

--- a/lib/src/components/tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/lib/src/components/tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip component renders a tooltip 1`] = `
 @media  {
-  .c-hAXqx {
+  .c-hVoQtf {
     background-color: var(--colors-tonal500);
     border-radius: var(--radii-0);
     box-shadow: var(--shadows-0);
@@ -10,6 +10,7 @@ exports[`Tooltip component renders a tooltip 1`] = `
     font-family: var(--fonts-body);
     font-size: var(--fontSizes-sm);
     line-height: 1.5;
+    white-space: normal;
     padding-left: var(--space-3);
     padding-right: var(--space-3);
     padding-top: var(--space-2);
@@ -18,7 +19,7 @@ exports[`Tooltip component renders a tooltip 1`] = `
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx {
+    .c-hVoQtf {
       animation-duration: 75ms;
       animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
       will-change: transform, opacity;
@@ -26,25 +27,25 @@ exports[`Tooltip component renders a tooltip 1`] = `
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="top"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
       animation-name: k-ftcNPK;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="right"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
       animation-name: k-hbaHED;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="bottom"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
       animation-name: k-daNevH;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hAXqx[data-state="delayed-open"][data-side="left"] {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
       animation-name: k-fvyGIa;
     }
 }
@@ -63,7 +64,7 @@ exports[`Tooltip component renders a tooltip 1`] = `
 }
 
 @media  {
-  .c-hAXqx-gWQnqe-size-md {
+  .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
 }
@@ -81,7 +82,7 @@ exports[`Tooltip component renders a tooltip 1`] = `
     style="position: fixed; left: 0px; top: 0px; transform: translate3d(0, -200%, 0); min-width: max-content;"
   >
     <div
-      class="c-hAXqx c-hAXqx-gWQnqe-size-md"
+      class="c-hVoQtf c-hVoQtf-gWQnqe-size-md"
       data-align="center"
       data-side="top"
       data-state="instant-open"


### PR DESCRIPTION
Before the fix, if the tooltip was used inside a table header with the style `white-space: nowrap` it would inherit that style for the tooltip content and would make the test be one line and overflow the tooltip if the text was larger than the tooltip width

[Jira Ticket](https://atomlearningltd.atlassian.net/browse/POG-286)

Screenshots broken and fixed:

![image](https://user-images.githubusercontent.com/4931116/199478708-8f12bcc9-eaf8-49a2-ab63-70e0dd8c4482.png)

![image](https://user-images.githubusercontent.com/4931116/199478667-2cbfe392-38be-4bc7-a2d2-12bdc0ab9b43.png)

