### PR TITLE
feat: added noCapsize prop to Text based components, added fix for ov…

### DIFF
--- a/lib/src/components/chip/Chip.tsx
+++ b/lib/src/components/chip/Chip.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Box } from '~/components/box'
 import { Flex } from '~/components/flex'
 import { Icon } from '~/components/icon'
-import { textVariantSize } from '~/components/text'
+import { getTextVariant } from '~/components/text'
 import { styled } from '~/stitches'
 import { overrideStitchesVariantValue } from '~/utilities/override-stitches-variant-value/overrideStitchesVariantValue'
 
@@ -76,9 +76,18 @@ export const StyledRoot = styled(Flex, {
   },
   variants: {
     size: {
-      sm: { height: '$2', ...textVariantSize({ applyCapsize: true }).sm },
-      md: { height: '$3', ...textVariantSize({ applyCapsize: true }).sm },
-      lg: { height: '$4', ...textVariantSize({ applyCapsize: true }).md }
+      sm: {
+        height: '$2',
+        ...getTextVariant({ size: 'sm' })
+      },
+      md: {
+        height: '$3',
+        ...getTextVariant({ size: 'sm' })
+      },
+      lg: {
+        height: '$4',
+        ...getTextVariant({ size: 'md' })
+      }
     }
   }
 })

--- a/lib/src/components/heading/Heading.tsx
+++ b/lib/src/components/heading/Heading.tsx
@@ -43,6 +43,11 @@ export const StyledHeading = styled('h2', {
         lineHeight: 1.06,
         ...capsize(0.1793, 0.1873)
       }
+    },
+    noCapsize: {
+      true: {
+        '&::before, &::after': { display: 'none' }
+      }
     }
   }
 })

--- a/lib/src/components/label/Label.tsx
+++ b/lib/src/components/label/Label.tsx
@@ -3,16 +3,17 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 import type { Override } from '~/utilities/types'
 
-import { textVariantSize } from '../text'
-
-const { sm, md } = textVariantSize()
+import { getTextVariant } from '../text'
 
 const StyledLabel = styled('label', {
   color: '$tonal500',
   fontFamily: '$body',
   m: 0,
   variants: {
-    size: { sm, md },
+    size: {
+      sm: getTextVariant({ size: 'sm' }),
+      md: getTextVariant({ size: 'md' })
+    },
     type: {
       block: {
         display: 'block',

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -63,7 +63,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
          *
          * https://stackoverflow.com/questions/41100273/overflowing-button-text-is-being-clipped-in-safari
          */}
-        <StyledSpan css={{ position: 'relative' }}>{children}</StyledSpan>
+        <StyledSpan>{children}</StyledSpan>
       </StyledLink>
     )
 ) as React.FC<LinkProps>

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -6,7 +6,9 @@ import { Override } from '~/utilities'
 
 import { StyledHeading } from '../heading/Heading'
 import { StyledLi } from '../list/List'
-import { StyledText, textVariantSize } from '../text/Text'
+import { StyledText, textVariants } from '../text/Text'
+
+const StyledSpan = styled('span', { position: 'relative' })
 
 export const StyledLink = styled('a', {
   bg: 'unset',
@@ -30,9 +32,7 @@ export const StyledLink = styled('a', {
       content: 'none'
     }
   },
-  variants: {
-    size: textVariantSize()
-  }
+  variants: textVariants
 })
 
 type LinkProps = Override<
@@ -43,9 +43,11 @@ type LinkProps = Override<
 >
 
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ size = 'md', onClick, href, ...remainingProps }, ref) =>
+  ({ children, size = 'md', onClick, href, ...remainingProps }, ref) =>
     href ? (
-      <StyledLink size={size} {...remainingProps} ref={ref} href={href} />
+      <StyledLink size={size} {...remainingProps} ref={ref} href={href}>
+        {children}
+      </StyledLink>
     ) : (
       <StyledLink
         as="button"
@@ -53,7 +55,16 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         {...remainingProps}
         ref={ref}
         onClick={onClick}
-      />
+      >
+        {/**
+         * Safari cuts off text that overflows in <button /> elements.
+         * When we apply capsize, this causes text to be cut-off.
+         * Adding an element with `position: relative` prevents this.
+         *
+         * https://stackoverflow.com/questions/41100273/overflowing-button-text-is-being-clipped-in-safari
+         */}
+        <StyledSpan css={{ position: 'relative' }}>{children}</StyledSpan>
+      </StyledLink>
     )
 ) as React.FC<LinkProps>
 

--- a/lib/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/lib/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -132,12 +132,6 @@ exports[`Link component can be nested within Text and Heading 1`] = `
   }
 }
 
-@media  {
-  .c-cmpvrW-icmpvrW-css {
-    position: relative;
-  }
-}
-
 <div>
   <p
     class="c-fIXJvv c-fIXJvv-gvmVBy-size-md"
@@ -146,7 +140,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
       class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     >
       <span
-        class="c-cmpvrW c-cmpvrW-icmpvrW-css"
+        class="c-cmpvrW"
       >
         TEXT LINK
       </span>
@@ -159,7 +153,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
       class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     >
       <span
-        class="c-cmpvrW c-cmpvrW-icmpvrW-css"
+        class="c-cmpvrW"
       >
         HEADING LINK
       </span>

--- a/lib/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/lib/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -38,6 +38,10 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     content: none;
   }
 
+  .c-cmpvrW {
+    position: relative;
+  }
+
   .c-fIXJvv {
     color: var(--colors-tonal600);
     font-family: var(--fonts-body);
@@ -128,6 +132,12 @@ exports[`Link component can be nested within Text and Heading 1`] = `
   }
 }
 
+@media  {
+  .c-cmpvrW-icmpvrW-css {
+    position: relative;
+  }
+}
+
 <div>
   <p
     class="c-fIXJvv c-fIXJvv-gvmVBy-size-md"
@@ -135,7 +145,11 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     <button
       class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     >
-      TEXT LINK
+      <span
+        class="c-cmpvrW c-cmpvrW-icmpvrW-css"
+      >
+        TEXT LINK
+      </span>
     </button>
   </p>
   <h2
@@ -144,7 +158,11 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     <button
       class="c-kgcOue c-kgcOue-gvmVBy-size-md"
     >
-      HEADING LINK
+      <span
+        class="c-cmpvrW c-cmpvrW-icmpvrW-css"
+      >
+        HEADING LINK
+      </span>
     </button>
   </h2>
 </div>

--- a/lib/src/components/list/List.tsx
+++ b/lib/src/components/list/List.tsx
@@ -45,11 +45,12 @@ type ListType = React.ForwardRefExoticComponent<ListProps> & {
 }
 
 export const List = React.forwardRef(
-  ({ size = 'md', ordered, ...remainingProps }, ref) => (
+  ({ size = 'md', noCapsize = true, ordered, ...remainingProps }, ref) => (
     <StyledList
       ref={ref}
       as={ordered ? 'ol' : 'ul'}
       size={size}
+      noCapsize={noCapsize}
       {...remainingProps}
     />
   )

--- a/lib/src/components/list/List.tsx
+++ b/lib/src/components/list/List.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { styled } from '~/stitches'
 
-import { textVariantSize } from '../text'
+import { textVariants } from '../text'
 
 export const StyledLi = styled('li', {})
 
@@ -15,7 +15,7 @@ export const StyledList = styled('ul', {
     '&:last-child': { mb: 0 }
   },
   variants: {
-    size: textVariantSize({ applyCapsize: false }),
+    ...textVariants,
     as: {
       ol: {
         pl: '$4',

--- a/lib/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/lib/src/components/list/__snapshots__/List.test.tsx.snap
@@ -35,6 +35,11 @@ exports[`List component renders a list 1`] = `
     display: table;
   }
 
+  .c-iQukjL-hUrFFO-noCapsize-true::before,
+  .c-iQukjL-hUrFFO-noCapsize-true::after {
+    display: none;
+  }
+
   .c-iQukjL-DlQlZ-as-ul {
     padding-left: var(--space-3);
   }
@@ -51,7 +56,7 @@ exports[`List component renders a list 1`] = `
 
 <div>
   <ul
-    class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul"
+    class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul"
   >
     <li
       class="c-PJLV"

--- a/lib/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/lib/src/components/list/__snapshots__/List.test.tsx.snap
@@ -18,9 +18,21 @@ exports[`List component renders a list 1`] = `
 }
 
 @media  {
-  .c-iQukjL-bfiEAN-size-md {
+  .c-iQukjL-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
   }
 
   .c-iQukjL-DlQlZ-as-ul {
@@ -39,7 +51,7 @@ exports[`List component renders a list 1`] = `
 
 <div>
   <ul
-    class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul"
+    class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul"
   >
     <li
       class="c-PJLV"

--- a/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -298,6 +298,11 @@ exports[`MarkdownContent component renders 1`] = `
     display: table;
   }
 
+  .c-iQukjL-hUrFFO-noCapsize-true::before,
+  .c-iQukjL-hUrFFO-noCapsize-true::after {
+    display: none;
+  }
+
   .c-iQukjL-DlQlZ-as-ul {
     padding-left: var(--space-3);
   }
@@ -482,7 +487,7 @@ exports[`MarkdownContent component renders 1`] = `
       Unordered
     </h3>
     <ul
-      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
     >
       <li
         class="c-PJLV"
@@ -519,7 +524,7 @@ exports[`MarkdownContent component renders 1`] = `
           Sub-lists are made by indenting 2 spaces:
         </p>
         <ul
-          class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+          class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
         >
           <li
             class="c-PJLV"
@@ -530,7 +535,7 @@ exports[`MarkdownContent component renders 1`] = `
               Marker character change forces new list start:
             </p>
             <ul
-              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
             >
               <li
                 class="c-PJLV"
@@ -543,7 +548,7 @@ exports[`MarkdownContent component renders 1`] = `
               </li>
             </ul>
             <ul
-              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
             >
               <li
                 class="c-PJLV"
@@ -556,7 +561,7 @@ exports[`MarkdownContent component renders 1`] = `
               </li>
             </ul>
             <ul
-              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
             >
               <li
                 class="c-PJLV"
@@ -587,7 +592,7 @@ exports[`MarkdownContent component renders 1`] = `
       Ordered
     </h3>
     <ol
-      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-jrjcGe-as-ol c-iQukjL-igZTZYS-css"
+      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-jrjcGe-as-ol c-iQukjL-igZTZYS-css"
     >
       <li
         class="c-PJLV"

--- a/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -281,9 +281,21 @@ exports[`MarkdownContent component renders 1`] = `
     display: table;
   }
 
-  .c-iQukjL-bfiEAN-size-md {
+  .c-iQukjL-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
   }
 
   .c-iQukjL-DlQlZ-as-ul {
@@ -470,7 +482,7 @@ exports[`MarkdownContent component renders 1`] = `
       Unordered
     </h3>
     <ul
-      class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
     >
       <li
         class="c-PJLV"
@@ -507,7 +519,7 @@ exports[`MarkdownContent component renders 1`] = `
           Sub-lists are made by indenting 2 spaces:
         </p>
         <ul
-          class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+          class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
         >
           <li
             class="c-PJLV"
@@ -518,7 +530,7 @@ exports[`MarkdownContent component renders 1`] = `
               Marker character change forces new list start:
             </p>
             <ul
-              class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
             >
               <li
                 class="c-PJLV"
@@ -531,7 +543,7 @@ exports[`MarkdownContent component renders 1`] = `
               </li>
             </ul>
             <ul
-              class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
             >
               <li
                 class="c-PJLV"
@@ -544,7 +556,7 @@ exports[`MarkdownContent component renders 1`] = `
               </li>
             </ul>
             <ul
-              class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
+              class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul c-iQukjL-igZTZYS-css"
             >
               <li
                 class="c-PJLV"
@@ -575,7 +587,7 @@ exports[`MarkdownContent component renders 1`] = `
       Ordered
     </h3>
     <ol
-      class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-jrjcGe-as-ol c-iQukjL-igZTZYS-css"
+      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-jrjcGe-as-ol c-iQukjL-igZTZYS-css"
     >
       <li
         class="c-PJLV"

--- a/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
+++ b/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
@@ -162,6 +162,11 @@ exports[`StackContent component renders a stack content 1`] = `
     display: table;
   }
 
+  .c-iQukjL-hUrFFO-noCapsize-true::before,
+  .c-iQukjL-hUrFFO-noCapsize-true::after {
+    display: none;
+  }
+
   .c-iQukjL-DlQlZ-as-ul {
     padding-left: var(--space-3);
   }
@@ -200,7 +205,7 @@ exports[`StackContent component renders a stack content 1`] = `
       class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-igmqXFB-css"
     />
     <ul
-      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul"
+      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul"
     >
       <li
         class="c-PJLV"

--- a/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
+++ b/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
@@ -145,9 +145,21 @@ exports[`StackContent component renders a stack content 1`] = `
     width: 100%;
   }
 
-  .c-iQukjL-bfiEAN-size-md {
+  .c-iQukjL-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
   }
 
   .c-iQukjL-DlQlZ-as-ul {
@@ -188,7 +200,7 @@ exports[`StackContent component renders a stack content 1`] = `
       class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-igmqXFB-css"
     />
     <ul
-      class="c-iQukjL c-iQukjL-bfiEAN-size-md c-iQukjL-DlQlZ-as-ul"
+      class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-DlQlZ-as-ul"
     >
       <li
         class="c-PJLV"

--- a/lib/src/components/text/Text.tsx
+++ b/lib/src/components/text/Text.tsx
@@ -4,37 +4,46 @@ import { CSS, styled } from '~/stitches'
 import type { Override } from '~/utilities'
 import { capsize } from '~/utilities'
 
-type TextSizes = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+const defaultSize = 'md'
 
-export const textVariantSize = ({ applyCapsize = true } = {}): Record<
-  TextSizes,
-  CSS
-> => ({
-  xs: {
-    fontSize: '$xs',
-    lineHeight: 1.6,
-    ...(applyCapsize ? capsize(0.4364) : {})
+export const textVariants = {
+  size: {
+    xs: { fontSize: '$xs', lineHeight: 1.6, ...capsize(0.4364) },
+    sm: { fontSize: '$sm', lineHeight: 1.53, ...capsize(0.4056) },
+    md: { fontSize: '$md', lineHeight: 1.5, ...capsize(0.3864) },
+    lg: { fontSize: '$lg', lineHeight: 1.52, ...capsize(0.3983) },
+    xl: { fontSize: '$xl', lineHeight: 1.42, ...capsize(0.3506) }
   },
-  sm: {
-    fontSize: '$sm',
-    lineHeight: 1.53,
-    ...(applyCapsize ? capsize(0.4056) : {})
-  },
-  md: {
-    fontSize: '$md',
-    lineHeight: 1.5,
-    ...(applyCapsize ? capsize(0.3864) : {})
-  },
-  lg: {
-    fontSize: '$lg',
-    lineHeight: 1.52,
-    ...(applyCapsize ? capsize(0.3983) : {})
-  },
-  xl: {
-    fontSize: '$xl',
-    lineHeight: 1.42,
-    ...(applyCapsize ? capsize(0.3506) : {})
+  noCapsize: {
+    true: {
+      '&::before, &::after': { display: 'none' }
+    }
   }
+}
+
+// export const textCompoundVariants = (
+//   Object.keys(capSizes) as Array<keyof typeof capSizes>
+// ).flatMap((size) => [
+//   {
+//     size,
+//     noCapsize: false,
+//     css: capSizes[size]
+//   },
+//   {
+//     size,
+//     noCapsize: undefined,
+//     css: capSizes[size]
+//   }
+// ])
+
+export const getTextVariant: (
+  options: Partial<{
+    size: keyof typeof textVariants.size
+    noCapsize: boolean
+  }>
+) => CSS = ({ size = defaultSize, noCapsize }) => ({
+  ...textVariants.size[size],
+  ...textVariants.noCapsize[`${noCapsize}`]
 })
 
 export const StyledText = styled('p', {
@@ -46,9 +55,7 @@ export const StyledText = styled('p', {
   '& > &': {
     '&:before, &:after': { display: 'none' }
   },
-  variants: {
-    size: textVariantSize()
-  }
+  variants: textVariants
 })
 
 type TextProps = Override<
@@ -70,7 +77,7 @@ type TextProps = Override<
 >
 
 export const Text: React.ForwardRefExoticComponent<TextProps> =
-  React.forwardRef(({ size = 'md', ...remainingProps }, ref) => (
+  React.forwardRef(({ size = defaultSize, ...remainingProps }, ref) => (
     <StyledText size={size} {...remainingProps} ref={ref} />
   ))
 

--- a/lib/src/components/text/Text.tsx
+++ b/lib/src/components/text/Text.tsx
@@ -21,21 +21,6 @@ export const textVariants = {
   }
 }
 
-// export const textCompoundVariants = (
-//   Object.keys(capSizes) as Array<keyof typeof capSizes>
-// ).flatMap((size) => [
-//   {
-//     size,
-//     noCapsize: false,
-//     css: capSizes[size]
-//   },
-//   {
-//     size,
-//     noCapsize: undefined,
-//     css: capSizes[size]
-//   }
-// ])
-
 export const getTextVariant: (
   options: Partial<{
     size: keyof typeof textVariants.size

--- a/lib/src/components/text/Text.tsx
+++ b/lib/src/components/text/Text.tsx
@@ -21,12 +21,10 @@ export const textVariants = {
   }
 }
 
-export const getTextVariant: (
-  options: Partial<{
-    size: keyof typeof textVariants.size
-    noCapsize: boolean
-  }>
-) => CSS = ({ size = defaultSize, noCapsize }) => ({
+export const getTextVariant: (options: {
+  size: keyof typeof textVariants.size
+  noCapsize?: boolean
+}) => CSS = ({ size, noCapsize }) => ({
   ...textVariants.size[size],
   ...textVariants.noCapsize[`${noCapsize}`]
 })


### PR DESCRIPTION
## Description
There were two issues related to our `capsize` implementation:
- For some reason, Safari cuts off text that is overflowing in a `button` element. This caused text in a `<Link onClick={} />` to be cut-off.
- We implemented an `applyCapsize` setting in our `textVariantSize()` util function, but there was no way to disable `capsize` when using components because it was not set as a prop on components. Because of this text would be cut-off if we used `overflow: hidden` on elements with `capsize`.

- [DS-152: Possible Text component prop issue [Bug]](https://atomlearningltd.atlassian.net/browse/DS-152)

## Changes
- When the `Link` component renders a `button` it now wraps the `children` in a `span` with `position: relative` to prevent clipping.
- Added a `noCapsize` variant to the `Text` component, so that we can disable `capsize` in specific cases (for example when we set `overflow: hidden` on the element). This prop can also be used on `Link`, `Heading` and `List`.
- Created a new `getTextVariant()` util function to return the correct styles for a `size` and `noCapsize` combination.

## Screenshots
### Safari (before)
<img width="1521" alt="image" src="https://user-images.githubusercontent.com/2501587/200812269-dc6b2944-0505-4141-bca8-58944e9964f7.png">

### Safari (after)
<img width="1528" alt="image" src="https://user-images.githubusercontent.com/2501587/200812020-8a2c532e-9a40-4eb4-a503-1f7ee811e25a.png">

### Chrome (before)
<img width="1516" alt="image" src="https://user-images.githubusercontent.com/2501587/200812340-36055e54-3ab3-4d28-bf14-fcc2a01131c5.png">

### Chrome (after)
<img width="1528" alt="image" src="https://user-images.githubusercontent.com/2501587/200812143-6fffb9c1-4470-4f6f-a16a-e797ff02fdb2.png">
