### PR TITLE
fix: navigation-menu list rendering issue

### DIFF
--- a/lib/src/components/navigation/NavigationMenuItem.tsx
+++ b/lib/src/components/navigation/NavigationMenuItem.tsx
@@ -118,7 +118,7 @@ export const NavigationMenuDropdownTrigger = React.forwardRef<
 export const NavigationMenuDropdownContent = styled('ul', {
   all: 'unset'
 })
-const ListItem = styled('li', { all: 'unset' })
+const ListItem = styled('li', { listStyle: 'none' })
 const DisabledButton = styled('button', { ...itemStyles, ...disabledStyles })
 
 type NavigationMenuLinkProps = {

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Nav component renders 1`] = `
 @media  {
-  .c-leHWbT {
-    all: unset;
+  .c-hdHRLY {
+    list-style: none;
   }
 
   .c-dIYQCX {
@@ -170,7 +170,7 @@ exports[`Nav component renders 1`] = `
         dir="ltr"
       >
         <li
-          class="c-leHWbT"
+          class="c-hdHRLY"
         >
           <a
             class="c-dIYQCX c-govTNd c-govTNd-ctVDrw-elementType-link"


### PR DESCRIPTION
I found really weird issue with elements not fitting in the dropdown content area.
I played with it and noticed that `unset: all` makes this problem.

![Zrzut ekranu 2022-11-9 o 15 05 31](https://user-images.githubusercontent.com/23363033/201041453-8cddfa79-0c09-488b-b4e3-d35ab6c7356a.png)


https://user-images.githubusercontent.com/23363033/201041512-f2a63f84-3e1d-40dd-9086-0aa2ec10d439.mov

