### PR TITLE
fix: navigation-menu mdx missing sign

### DIFF
--- a/lib/src/components/navigation/NavigationMenu.mdx
+++ b/lib/src/components/navigation/NavigationMenu.mdx
@@ -89,10 +89,8 @@ In the below example the styling of `NavigationMenu.DropdownContent` has been ch
         <NavigationMenu.DropdownItem href={`/theme/${item}`}>
           <NavigationMenu.DropdownItemTitle>
             {item}
-          </NavigationMenu.DropdownItemTitle
-          <Text>
-            This is some example text about {item}
-          </Text>
+          </NavigationMenu.DropdownItemTitle>
+          <Text>This is some example text about {item}</Text>
         </NavigationMenu.DropdownItem>
       ))}
     </NavigationMenu.DropdownContent>


### PR DESCRIPTION
We were missing `>` sing in mdx file.

![Zrzut ekranu 2022-11-10 o 12 30 46](https://user-images.githubusercontent.com/23363033/201079949-d0cd2c3d-ac8a-41a6-88d4-04372aa4c00f.png)
