### PR TITLE
feat: pass onClick prop onto anchor links

### DIFF
--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -41,19 +41,15 @@ type LinkProps = Override<
 >
 
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ size = 'md', onClick, href, ...remainingProps }, ref) =>
-    href ? (
-      <StyledLink size={size} {...remainingProps} ref={ref} href={href} />
-    ) : (
-      <StyledLink
-        as="button"
-        size={size}
-        noCapsize // Safari cuts off overflowing text in <button /> elements
-        {...remainingProps}
-        ref={ref}
-        onClick={onClick}
-      />
-    )
+  ({ size = 'md', href, ...props }, ref) => (
+    <StyledLink
+      {...(!href && { as: 'button', noCapsize: true })}
+      size={size}
+      href={href}
+      {...props}
+      ref={ref}
+    />
+  )
 ) as React.FC<LinkProps>
 
 Link.displayName = 'Link'


### PR DESCRIPTION
## Issue
We were stripping the `onClick` prop when we rendered an `a` in `Link`.

In the main repo, we had several `Link` implementations with both an `href` and `onClick`. Because we had a wrapper component that rendered this `Link` component as a `react-router` `Link`, the `onClick` would still be fired (this component would render a `button` that would then be rendered as a `react-router` `Link` that rendered an `a`, retaining both the `href` and `onClick`.

_(kudos if you're still following me)_

To make sure `noCapsize` was only applied to `button` links, we had to make a change to this wrapper and make sure it rendered an `a` straight away when creating an internal link. This broke links with both `onClick` and `href` as we strip `onClick` in this `Link` component.

## Changes
- Pass on `onClick` to both `a` and `button` links