### PR TITLE
fix: workaround to only render first page of rows

### DIFF
--- a/lib/src/components/data-table/DataTable.mdx
+++ b/lib/src/components/data-table/DataTable.mdx
@@ -11,7 +11,7 @@ category: Content
 
 ## Anatomy
 
-The root `DataTable` component manages the table's state and exposes it via the React Context API. This state can be accessed by any child components by calling `useDataTable`.
+The root `DataTable` component manages the table's state and exposes it via the React Context API. This state can be accessed by any child components by calling `useDataTable`. You can pass an `initialState` prop to `DataTable` as described in the [`@tanstack/react-table` docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate).
 
 Other `DataTable` components call `useDataTable` and provide useful default implementations for common patterns. For example, `DataTable.Head` will render a header for every column defined in the parent `DataTable`. `DataTable.Body` will render a row for every data item. `DataTable.Table` combines both `DataTable.Head` and `DataTable.Body`.
 
@@ -153,4 +153,4 @@ If `DataTable`'s `isSortable` state is `true`, then `DataTable.Header` will be c
 
 ### Pagination
 
-`DataTable.Pagination` can be passed as a child to `DataTable` to render the pagination UI and configure the parent `DataTable` to paginate its data.
+`DataTable.Pagination` can be passed as a child to `DataTable` to render the pagination UI and configure the parent `DataTable` to paginate its data. Note: there is currently a bug where `DataTable` will render all rows on the initial render, even when paginated. There is no visible effect, but it can cause performance issues on large tables. The workaround for this is to pass an `initialState` prop to `DataTable`. E.g. `initialState={pagination: {pageSize: 5, pageIndex: 0}}`. This will force pagination to apply properly on the initial render. Make sure the `pagination` prop matches the config you use in `DataTable.Pagination`, as the latter will take precedence after the initial render.

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -23,7 +23,7 @@ type TableProviderProps = {
   data: Array<Record<string, unknown>>
   defaultSort?: { column: string; direction: 'asc' | 'desc' }
   children: React.ReactNode
-  pagination?: { pageIndex: 0; pageSize: number }
+  pagination?: { pageIndex: number; pageSize: number }
 }
 
 export const DataTableProvider = ({

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -23,15 +23,18 @@ type TableProviderProps = {
   data: Array<Record<string, unknown>>
   defaultSort?: { column: string; direction: 'asc' | 'desc' }
   children: React.ReactNode
+  pagination?: { pageIndex: 0; pageSize: number }
 }
 
 export const DataTableProvider = ({
   columns,
   data,
   defaultSort,
-  children
+  children,
+  pagination = undefined
 }: TableProviderProps): JSX.Element => {
-  const [isPaginated, setIsPaginated] = React.useState<boolean>(false)
+  const [isPaginated, setIsPaginated] = React.useState<boolean>(!!pagination)
+
   const [isSortable, setIsSortable] = React.useState<boolean>(false)
   const [sorting, setSorting] = React.useState<SortingState>(
     defaultSort
@@ -57,6 +60,11 @@ export const DataTableProvider = ({
     getPaginationRowModel: isPaginated ? getPaginationRowModel() : undefined,
     getSortedRowModel:
       isSortable || sorting.length ? getSortedRowModel() : undefined,
+    initialState: {
+      pagination: pagination
+        ? { pageSize: pagination.pageSize, pageIndex: pagination.pageIndex }
+        : undefined
+    },
     state: {
       sorting
     },

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -6,7 +6,20 @@ import {
   getSortedRowModel,
   getFilteredRowModel
 } from '@tanstack/react-table'
-import type { SortingState, Table } from '@tanstack/react-table'
+import type {
+  VisibilityTableState,
+  ColumnOrderTableState,
+  ColumnPinningTableState,
+  FiltersTableState,
+  SortingTableState,
+  ExpandedTableState,
+  GroupingTableState,
+  ColumnSizingTableState,
+  PaginationTableState,
+  RowSelectionTableState,
+  SortingState,
+  Table
+} from '@tanstack/react-table'
 
 type DataTableContextType<T = unknown> = Table<T> & {
   setIsSortable: React.Dispatch<React.SetStateAction<boolean>>
@@ -18,22 +31,37 @@ type DataTableContextType<T = unknown> = Table<T> & {
 const DataTableContext =
   React.createContext<DataTableContextType<unknown> | null>(null)
 
+type InitialState = Partial<
+  VisibilityTableState &
+    ColumnOrderTableState &
+    ColumnPinningTableState &
+    FiltersTableState &
+    SortingTableState &
+    ExpandedTableState &
+    GroupingTableState &
+    ColumnSizingTableState &
+    PaginationTableState &
+    RowSelectionTableState
+>
+
 type TableProviderProps = {
   columns
   data: Array<Record<string, unknown>>
   defaultSort?: { column: string; direction: 'asc' | 'desc' }
   children: React.ReactNode
-  pagination?: { pageIndex: number; pageSize: number }
+  initialState?: InitialState
 }
 
 export const DataTableProvider = ({
   columns,
   data,
   defaultSort,
-  children,
-  pagination = undefined
+  initialState = undefined,
+  children
 }: TableProviderProps): JSX.Element => {
-  const [isPaginated, setIsPaginated] = React.useState<boolean>(!!pagination)
+  const [isPaginated, setIsPaginated] = React.useState<boolean>(
+    !!initialState?.pagination
+  )
 
   const [isSortable, setIsSortable] = React.useState<boolean>(false)
   const [sorting, setSorting] = React.useState<SortingState>(
@@ -60,11 +88,7 @@ export const DataTableProvider = ({
     getPaginationRowModel: isPaginated ? getPaginationRowModel() : undefined,
     getSortedRowModel:
       isSortable || sorting.length ? getSortedRowModel() : undefined,
-    initialState: {
-      pagination: pagination
-        ? { pageSize: pagination.pageSize, pageIndex: pagination.pageIndex }
-        : undefined
-    },
+    initialState: initialState,
     state: {
       sorting
     },


### PR DESCRIPTION
Problem: paginated `DataTable`s render all of their rows on the initial render, not just the first page. So if any heavy-lifting happens in a row (e.g. API requests are made) then a big table can cause a browser crash.

Cause: `DataTable.Pagination` tells `DataTable` to paginate its data in a `useEffect`. `useEffect` fires after the render.

Short-term solution (this PR): Add an optional `pagination` prop to `DataTable` which will set pagination state for the first render

Long-term solution: overhaul the API