### PR TITLE
chore: updated divider colour

### DIFF
--- a/lib/src/components/divider/Divider.tsx
+++ b/lib/src/components/divider/Divider.tsx
@@ -4,7 +4,7 @@ import { styled } from '~/stitches'
 
 export const StyledDivider = styled('hr', {
   border: 0,
-  bg: '$tonal200',
+  bg: '$tonal100',
   variants: {
     orientation: {
       horizontal: { height: 1, width: '100%' },

--- a/lib/src/components/divider/__snapshots__/Divider.test.tsx.snap
+++ b/lib/src/components/divider/__snapshots__/Divider.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Divider component renders horizontal divider 1`] = `
 @media  {
-  .c-jpqjUq {
+  .c-fNKiiB {
     border: 0;
-    background: var(--colors-tonal200);
+    background: var(--colors-tonal100);
   }
 }
 
 @media  {
-  .c-jpqjUq-jokUAR-orientation-horizontal {
+  .c-fNKiiB-jokUAR-orientation-horizontal {
     height: 1px;
     width: 100%;
   }
@@ -17,26 +17,26 @@ exports[`Divider component renders horizontal divider 1`] = `
 
 <div>
   <hr
-    class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal"
+    class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal"
   />
 </div>
 `;
 
 exports[`Divider component renders vertical divider 1`] = `
 @media  {
-  .c-jpqjUq {
+  .c-fNKiiB {
     border: 0;
-    background: var(--colors-tonal200);
+    background: var(--colors-tonal100);
   }
 }
 
 @media  {
-  .c-jpqjUq-jokUAR-orientation-horizontal {
+  .c-fNKiiB-jokUAR-orientation-horizontal {
     height: 1px;
     width: 100%;
   }
 
-  .c-jpqjUq-fKZlxR-orientation-vertical {
+  .c-fNKiiB-fKZlxR-orientation-vertical {
     height: 100%;
     width: 1px;
     min-height: var(--sizes-3);
@@ -45,7 +45,7 @@ exports[`Divider component renders vertical divider 1`] = `
 
 <div>
   <hr
-    class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical"
+    class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical"
   />
 </div>
 `;

--- a/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -2,54 +2,54 @@
 
 exports[`MarkdownContent component renders 1`] = `
 @media  {
-  .c-dcjLby > .c-iSnHBU {
+  .c-cLTcXe > .c-iSnHBU {
     max-width: 65ch;
   }
 
-  .c-dcjLby > .c-iSnHBU:not(:first-child) {
+  .c-cLTcXe > .c-iSnHBU:not(:first-child) {
     margin-top: var(--space-5);
   }
 
-  .c-dcjLby > .c-iSnHBU:not(:last-child) {
+  .c-cLTcXe > .c-iSnHBU:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-fIXJvv {
+  .c-cLTcXe > .c-fIXJvv {
     max-width: 75ch;
   }
 
-  .c-dcjLby > .c-fIXJvv:not(:last-child) {
+  .c-cLTcXe > .c-fIXJvv:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-iQukjL {
+  .c-cLTcXe > .c-iQukjL {
     max-width: 75ch;
   }
 
-  .c-dcjLby > .c-iQukjL:not(:last-child) {
+  .c-cLTcXe > .c-iQukjL:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-jpqjUq {
+  .c-cLTcXe > .c-fNKiiB {
     margin-top: var(--space-5);
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-eWgOGC {
+  .c-cLTcXe > .c-eWgOGC {
     display: block;
   }
 
-  .c-dcjLby > .c-eWgOGC:not(:first-child) {
+  .c-cLTcXe > .c-eWgOGC:not(:first-child) {
     margin-top: var(--space-6);
   }
 
-  .c-dcjLby > .c-eWgOGC:not(:last-child) {
+  .c-cLTcXe > .c-eWgOGC:not(:last-child) {
     margin-bottom: var(--space-6);
   }
 
-  .c-jpqjUq {
+  .c-fNKiiB {
     border: 0;
-    background: var(--colors-tonal200);
+    background: var(--colors-tonal100);
   }
 
   .c-iSnHBU {
@@ -172,7 +172,7 @@ exports[`MarkdownContent component renders 1`] = `
 }
 
 @media  {
-  .c-jpqjUq-jokUAR-orientation-horizontal {
+  .c-fNKiiB-jokUAR-orientation-horizontal {
     height: 1px;
     width: 100%;
   }
@@ -349,7 +349,7 @@ exports[`MarkdownContent component renders 1`] = `
 }
 
 @media  {
-  .c-jpqjUq-ifGHEql-css {
+  .c-fNKiiB-ifGHEql-css {
     width: 100%;
   }
 
@@ -369,10 +369,10 @@ exports[`MarkdownContent component renders 1`] = `
 
 <div>
   <div
-    class="c-dcjLby"
+    class="c-cLTcXe"
   >
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -380,7 +380,7 @@ exports[`MarkdownContent component renders 1`] = `
       Headings
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h1
       class="c-iSnHBU c-iSnHBU-kYeJd-size-xl c-iSnHBU-ibHwuwj-css"
@@ -413,7 +413,7 @@ exports[`MarkdownContent component renders 1`] = `
       h6 Heading
     </h6>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -421,7 +421,7 @@ exports[`MarkdownContent component renders 1`] = `
       Emphasis
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <p
       class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
@@ -460,7 +460,7 @@ exports[`MarkdownContent component renders 1`] = `
       </em>
     </p>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -468,10 +468,10 @@ exports[`MarkdownContent component renders 1`] = `
       Blockquotes
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -479,7 +479,7 @@ exports[`MarkdownContent component renders 1`] = `
       Lists
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h3
       class="c-iSnHBU c-iSnHBU-fOoUdm-size-md c-iSnHBU-ibHwuwj-css"
@@ -646,7 +646,7 @@ exports[`MarkdownContent component renders 1`] = `
       </li>
     </ol>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -654,7 +654,7 @@ exports[`MarkdownContent component renders 1`] = `
       Code
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h3
       class="c-iSnHBU c-iSnHBU-fOoUdm-size-md c-iSnHBU-ibHwuwj-css"
@@ -695,7 +695,7 @@ line 3 of code
       Sample text here...
     </pre>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -703,7 +703,7 @@ line 3 of code
       Links
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <p
       class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"
@@ -727,7 +727,7 @@ line 3 of code
       </a>
     </p>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <h2
       class="c-iSnHBU c-iSnHBU-bSbzjX-size-lg c-iSnHBU-ibHwuwj-css"
@@ -735,7 +735,7 @@ line 3 of code
       Images
     </h2>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-ifGHEql-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-ifGHEql-css"
     />
     <p
       class="c-fIXJvv c-fIXJvv-gvmVBy-size-md c-fIXJvv-ibHwuwj-css"

--- a/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
+++ b/lib/src/components/stack-content/__snapshots__/StackContent.test.tsx.snap
@@ -2,48 +2,48 @@
 
 exports[`StackContent component renders a stack content 1`] = `
 @media  {
-  .c-dcjLby > .c-iSnHBU {
+  .c-cLTcXe > .c-iSnHBU {
     max-width: 65ch;
   }
 
-  .c-dcjLby > .c-iSnHBU:not(:first-child) {
+  .c-cLTcXe > .c-iSnHBU:not(:first-child) {
     margin-top: var(--space-5);
   }
 
-  .c-dcjLby > .c-iSnHBU:not(:last-child) {
+  .c-cLTcXe > .c-iSnHBU:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-fIXJvv {
+  .c-cLTcXe > .c-fIXJvv {
     max-width: 75ch;
   }
 
-  .c-dcjLby > .c-fIXJvv:not(:last-child) {
+  .c-cLTcXe > .c-fIXJvv:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-iQukjL {
+  .c-cLTcXe > .c-iQukjL {
     max-width: 75ch;
   }
 
-  .c-dcjLby > .c-iQukjL:not(:last-child) {
+  .c-cLTcXe > .c-iQukjL:not(:last-child) {
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-jpqjUq {
+  .c-cLTcXe > .c-fNKiiB {
     margin-top: var(--space-5);
     margin-bottom: var(--space-5);
   }
 
-  .c-dcjLby > .c-eWgOGC {
+  .c-cLTcXe > .c-eWgOGC {
     display: block;
   }
 
-  .c-dcjLby > .c-eWgOGC:not(:first-child) {
+  .c-cLTcXe > .c-eWgOGC:not(:first-child) {
     margin-top: var(--space-6);
   }
 
-  .c-dcjLby > .c-eWgOGC:not(:last-child) {
+  .c-cLTcXe > .c-eWgOGC:not(:last-child) {
     margin-bottom: var(--space-6);
   }
 
@@ -66,9 +66,9 @@ exports[`StackContent component renders a stack content 1`] = `
     display: none;
   }
 
-  .c-jpqjUq {
+  .c-fNKiiB {
     border: 0;
-    background: var(--colors-tonal200);
+    background: var(--colors-tonal100);
   }
 
   .c-iQukjL {
@@ -140,7 +140,7 @@ exports[`StackContent component renders a stack content 1`] = `
     display: table;
   }
 
-  .c-jpqjUq-jokUAR-orientation-horizontal {
+  .c-fNKiiB-jokUAR-orientation-horizontal {
     height: 1px;
     width: 100%;
   }
@@ -182,14 +182,14 @@ exports[`StackContent component renders a stack content 1`] = `
 }
 
 @media  {
-  .c-jpqjUq-igmqXFB-css {
+  .c-fNKiiB-igmqXFB-css {
     color: red;
   }
 }
 
 <div>
   <div
-    class="c-dcjLby"
+    class="c-cLTcXe"
   >
     <h2
       class="c-iSnHBU c-iSnHBU-fOoUdm-size-md"
@@ -202,7 +202,7 @@ exports[`StackContent component renders a stack content 1`] = `
       TEXT
     </p>
     <hr
-      class="c-jpqjUq c-jpqjUq-jokUAR-orientation-horizontal c-jpqjUq-igmqXFB-css"
+      class="c-fNKiiB c-fNKiiB-jokUAR-orientation-horizontal c-fNKiiB-igmqXFB-css"
     />
     <ul
       class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul"

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -85,9 +85,9 @@ exports[`TopBar component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-jpqjUq {
+  .c-fNKiiB {
     border: 0;
-    background: var(--colors-tonal200);
+    background: var(--colors-tonal100);
   }
 }
 
@@ -129,7 +129,7 @@ exports[`TopBar component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-jpqjUq-fKZlxR-orientation-vertical {
+  .c-fNKiiB-fKZlxR-orientation-vertical {
     height: 100%;
     width: 1px;
     min-height: var(--sizes-3);
@@ -158,7 +158,7 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-jpqjUq-ieFaPrQ-css {
+  .c-fNKiiB-ieFaPrQ-css {
     height: var(--sizes-2);
     background: var(--colors-tonal100);
   }
@@ -203,7 +203,7 @@ exports[`TopBar component renders 1`] = `
         </svg>
       </button>
       <hr
-        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ieFaPrQ-css"
+        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ieFaPrQ-css"
       />
       <button
         aria-label="Light/Dark mode"
@@ -316,9 +316,9 @@ exports[`TopBar component renders the lg variant 1`] = `
     vertical-align: middle;
   }
 
-  .c-jpqjUq {
+  .c-fNKiiB {
     border: 0;
-    background: var(--colors-tonal200);
+    background: var(--colors-tonal100);
   }
 }
 
@@ -360,7 +360,7 @@ exports[`TopBar component renders the lg variant 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-jpqjUq-fKZlxR-orientation-vertical {
+  .c-fNKiiB-fKZlxR-orientation-vertical {
     height: 100%;
     width: 1px;
     min-height: var(--sizes-3);
@@ -398,7 +398,7 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-jpqjUq-ieFaPrQ-css {
+  .c-fNKiiB-ieFaPrQ-css {
     height: var(--sizes-2);
     background: var(--colors-tonal100);
   }
@@ -443,7 +443,7 @@ exports[`TopBar component renders the lg variant 1`] = `
         </svg>
       </button>
       <hr
-        class="c-jpqjUq c-jpqjUq-fKZlxR-orientation-vertical c-jpqjUq-ieFaPrQ-css"
+        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ieFaPrQ-css"
       />
       <button
         aria-label="Light/Dark mode"


### PR DESCRIPTION
Ticket https://atomlearningltd.atlassian.net/browse/DS-145

## Implementation
- Updated background colour to `$tonal100` 

Old and new colours for comparison
<img width="658" alt="image" src="https://user-images.githubusercontent.com/44065175/203326507-420559aa-a216-42da-b3c2-5fc277d560e5.png">
