### PR TITLE
feat: remove CSSWrapper from Stack so the elements its used as can be…

### DIFF
--- a/lib/src/components/stack/Stack.tsx
+++ b/lib/src/components/stack/Stack.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 
 import { CSS, styled } from '~/stitches'
 import { createThemeVariants } from '~/utilities'
-import { CSSWrapper } from '~/utilities/css-wrapper'
 
 const StyledStack = styled('div', {
   display: 'flex',
@@ -67,7 +66,6 @@ export const Stack: React.ForwardRefExoticComponent<StackPropsType> =
   React.forwardRef(
     (
       {
-        css,
         gap = 2,
         direction = 'row',
         wrap = 'wrap',
@@ -78,21 +76,19 @@ export const Stack: React.ForwardRefExoticComponent<StackPropsType> =
       ref
     ) => {
       return (
-        <CSSWrapper css={css}>
-          <StyledStack
-            ref={ref}
-            direction={direction}
-            gap={gap}
-            wrap={wrap}
-            justify={justify}
-            align={
-              typeof align === 'undefined' && direction !== 'column'
-                ? 'center'
-                : align
-            }
-            {...remainingProps}
-          />
-        </CSSWrapper>
+        <StyledStack
+          ref={ref}
+          direction={direction}
+          gap={gap}
+          wrap={wrap}
+          justify={justify}
+          align={
+            typeof align === 'undefined' && direction !== 'column'
+              ? 'center'
+              : align
+          }
+          {...remainingProps}
+        />
       )
     }
   )


### PR DESCRIPTION
… targetted with css


## Description

For the [CMS](https://github.com/Atom-Learning/components/pull/398) - I needed to use a `ul` for `Stack`. Because of how `Stack` is wrapped with a `CSSWrapper` the stack main element itself was becoming a `ul` as expected - but I could not target it with css to remove `ul` paddings.

I'm doubting the need for the `CSSWrapper` to exist in this component altogether so I've removed it. Now CSS gets passed directly onto `Stack`.