### PR TITLE
feat: sidedrawer - remaining props to allow custom styling. fix for c…

### DIFF
--- a/lib/src/components/sidedrawer/SidedrawerAccordion/SidedrawerAccordionContent.tsx
+++ b/lib/src/components/sidedrawer/SidedrawerAccordion/SidedrawerAccordionContent.tsx
@@ -22,8 +22,10 @@ const StyledContent = styled(Content, {
   }
 })
 
-export const SidedrawerAccordionContent: React.FC = ({ children }) => (
-  <StyledContent>
+export const SidedrawerAccordionContent: React.FC<
+  React.ComponentProps<typeof StyledContent>
+> = ({ children, ...remainingProps }) => (
+  <StyledContent {...remainingProps}>
     {React.Children.map(children, (child) => {
       return (
         <Box

--- a/lib/src/components/sidedrawer/SidedrawerAccordion/SidedrawerAccordionTrigger.tsx
+++ b/lib/src/components/sidedrawer/SidedrawerAccordion/SidedrawerAccordionTrigger.tsx
@@ -21,9 +21,11 @@ const StyledIcon = styled(Icon, {
   }
 })
 
-export const SidedrawerAccordionTrigger: React.FC = ({ children }) => (
+export const SidedrawerAccordionTrigger: React.FC<
+  React.ComponentProps<typeof StyledTrigger>
+> = ({ children, ...remainingProps }) => (
   <Header>
-    <StyledTrigger>
+    <StyledTrigger {...remainingProps}>
       <Flex
         css={{
           alignItems: 'center'

--- a/lib/src/components/sidedrawer/SidedrawerContent.tsx
+++ b/lib/src/components/sidedrawer/SidedrawerContent.tsx
@@ -15,7 +15,7 @@ const StyledContent = styled(Content, {
   position: 'fixed',
   top: 0,
   left: 0,
-  height: '100vh',
+  height: '100%',
   maxWidth: '304px',
   width: '100%',
   zIndex: MAX_Z_INDEX,
@@ -29,9 +29,13 @@ const StyledContent = styled(Content, {
   }
 })
 
-export const SidedrawerContent: React.FC = ({ children }) => (
+export const SidedrawerContent: React.FC<
+  React.ComponentProps<typeof StyledContent>
+> = ({ children, ...remainingProps }) => (
   <Portal>
     <SidedrawerOverlay data-testid="sidedrawer_overlay" />
-    <StyledContent role="navigation">{children}</StyledContent>
+    <StyledContent role="navigation" {...remainingProps}>
+      {children}
+    </StyledContent>
   </Portal>
 )

--- a/lib/src/components/sidedrawer/SidedrawerHeader.tsx
+++ b/lib/src/components/sidedrawer/SidedrawerHeader.tsx
@@ -10,8 +10,10 @@ const StyledHeader = styled('header', {
   }
 })
 
-export const SidedrawerHeader: React.FC = ({ children }) => (
-  <StyledHeader>
+export const SidedrawerHeader: React.FC<
+  React.ComponentProps<typeof StyledHeader>
+> = ({ children, ...remainingProps }) => (
+  <StyledHeader {...remainingProps}>
     <TopBar
       css={{
         mx: '$3'

--- a/lib/src/components/sidedrawer/__snapshots__/Sidedrawer.test.tsx.snap
+++ b/lib/src/components/sidedrawer/__snapshots__/Sidedrawer.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`Sidedrawer renders 1`] = `
     width: 100%;
   }
 
-  .c-hGKzaH {
+  .c-lnkIfg {
     background: white;
     box-shadow: var(--shadows-2);
     display: flex;
@@ -243,20 +243,20 @@ exports[`Sidedrawer renders 1`] = `
     position: fixed;
     top: 0;
     left: 0;
-    height: 100vh;
+    height: 100%;
     max-width: 304px;
     width: 100%;
     z-index: 2147483647;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hGKzaH[data-state="open"] {
+    .c-lnkIfg[data-state="open"] {
       animation: k-jLcgiN 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hGKzaH[data-state="closed"] {
+    .c-lnkIfg[data-state="closed"] {
       animation: k-kSYzSh 250ms ease-out;
     }
 }
@@ -392,7 +392,7 @@ exports[`Sidedrawer renders 1`] = `
 <div
   aria-describedby="radix-4"
   aria-labelledby="radix-3"
-  class="c-hGKzaH"
+  class="c-lnkIfg"
   data-state="open"
   id="radix-2"
   role="navigation"
@@ -739,7 +739,7 @@ exports[`Sidedrawer should expand an accordion by clicking on trigger and displa
     width: 100%;
   }
 
-  .c-hGKzaH {
+  .c-lnkIfg {
     background: white;
     box-shadow: var(--shadows-2);
     display: flex;
@@ -747,20 +747,20 @@ exports[`Sidedrawer should expand an accordion by clicking on trigger and displa
     position: fixed;
     top: 0;
     left: 0;
-    height: 100vh;
+    height: 100%;
     max-width: 304px;
     width: 100%;
     z-index: 2147483647;
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hGKzaH[data-state="open"] {
+    .c-lnkIfg[data-state="open"] {
       animation: k-jLcgiN 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hGKzaH[data-state="closed"] {
+    .c-lnkIfg[data-state="closed"] {
       animation: k-kSYzSh 250ms ease-out;
     }
 }
@@ -906,7 +906,7 @@ exports[`Sidedrawer should expand an accordion by clicking on trigger and displa
 <div
   aria-describedby="radix-24"
   aria-labelledby="radix-23"
-  class="c-hGKzaH"
+  class="c-lnkIfg"
   data-state="open"
   id="radix-22"
   role="navigation"


### PR DESCRIPTION
This PR contains 2 things
- `Remaining props` for `Sidedrawer` subcomponents to let us pass some custom styles or props if needed.
- Fix for `Sidedrawer.Content` height

The `100vh` `Sidedrawer.Content` height causes a lot of troubles on mobile devices. Basically when the mobile browser bar was visible, the content was cut-of.
The fix let navigation be always visible as a whole, not dependent of browser bar.

Missing `Footer` on image below
![Zrzut ekranu 2022-12-6 o 17 02 38](https://user-images.githubusercontent.com/23363033/206168655-ed6a33e2-38a7-4d3e-83df-b0373350738d.png)

This is correct:
![Zrzut ekranu 2022-12-7 o 09 55 17](https://user-images.githubusercontent.com/23363033/206168748-9622819c-9c90-44a2-abd6-e662a6546141.png)

BEFORE FIX POC:
https://user-images.githubusercontent.com/23363033/206168262-04068b80-9ada-4c96-b633-46896374ecc6.mp4

AFTER FIX POC:
https://user-images.githubusercontent.com/23363033/206168515-35089801-3793-4e94-80fe-160e101b1f96.mp4

