### PR TITLE
feat: sidedrawer close customizable

### DIFF
--- a/lib/src/components/sidedrawer/SidedrawerClose.tsx
+++ b/lib/src/components/sidedrawer/SidedrawerClose.tsx
@@ -5,9 +5,24 @@ import React from 'react'
 import { Icon } from '../icon/Icon'
 import { ActionIcon } from '../action-icon/ActionIcon'
 
-export const SidedrawerClose: React.FC = () => (
+export const SidedrawerClose: React.FC<
+  React.ComponentProps<typeof ActionIcon>
+> = ({
+  appearance = 'simple',
+  label = 'close',
+  size = 'md',
+  theme = 'neutral',
+
+  ...remainingProps
+}) => (
   <DialogClose asChild>
-    <ActionIcon theme="neutral" appearance="simple" label="close" size="md">
+    <ActionIcon
+      theme={theme}
+      appearance={appearance}
+      size={size}
+      label={label}
+      {...remainingProps}
+    >
       <Icon is={Close} />
     </ActionIcon>
   </DialogClose>


### PR DESCRIPTION
`Sidedrawer.Close` customization

We found a need in Parent app to increase the size of `Sidedrawer.Close`.
Instead of changing the fixed `size` in design system, I made a solution with set of customisable props.
It's more flexible so other pods might align the Close for their needs.
It still keep the default values, so we have initial settings out of the box.

![Zrzut ekranu 2022-12-7 o 13 16 35](https://user-images.githubusercontent.com/23363033/206177358-f445d8ff-fcc4-4334-b905-705a591b4e2e.png)
