### PR TITLE
Feat: Support markdown emphasis wrapping link without line break

### DIFF
--- a/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FieldWrapper component renders 1`] = `
     margin: 0;
   }
 
-  .c-dEwrHQ {
+  .c-fucOQC {
     background: unset;
     border: unset;
     padding: unset;
@@ -22,29 +22,32 @@ exports[`FieldWrapper component renders 1`] = `
     text-decoration: none;
   }
 
-  .c-dEwrHQ:focus,
-  .c-dEwrHQ:hover {
+  .c-fucOQC:focus,
+  .c-fucOQC:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-dEwrHQ:active {
+  .c-fucOQC:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dyvMgW > .c-dEwrHQ,
-  .c-jryFOR > .c-dEwrHQ,
-  .c-PJLV > .c-dEwrHQ {
+  .c-dyvMgW > .c-fucOQC,
+  .c-jryFOR > .c-fucOQC,
+  .c-PJLV > .c-fucOQC,
+  .c-bYNGXt > .c-fucOQC {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dyvMgW > .c-dEwrHQ::before,
-  .c-dyvMgW > .c-dEwrHQ::after,
-  .c-jryFOR > .c-dEwrHQ::before,
-  .c-jryFOR > .c-dEwrHQ::after,
-  .c-PJLV > .c-dEwrHQ::before,
-  .c-PJLV > .c-dEwrHQ::after {
+  .c-dyvMgW > .c-fucOQC::before,
+  .c-dyvMgW > .c-fucOQC::after,
+  .c-jryFOR > .c-fucOQC::before,
+  .c-jryFOR > .c-fucOQC::after,
+  .c-PJLV > .c-fucOQC::before,
+  .c-PJLV > .c-fucOQC::after,
+  .c-bYNGXt > .c-fucOQC::before,
+  .c-bYNGXt > .c-fucOQC::after {
     content: none;
   }
 
@@ -130,18 +133,18 @@ exports[`FieldWrapper component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-dEwrHQ-bndJoy-size-sm {
+  .c-fucOQC-bndJoy-size-sm {
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-dEwrHQ-bndJoy-size-sm::before {
+  .c-fucOQC-bndJoy-size-sm::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-dEwrHQ-bndJoy-size-sm::after {
+  .c-fucOQC-bndJoy-size-sm::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -210,7 +213,7 @@ exports[`FieldWrapper component renders 1`] = `
         Example Field
       </label>
       <a
-        class="c-dEwrHQ c-dEwrHQ-bndJoy-size-sm"
+        class="c-fucOQC c-fucOQC-bndJoy-size-sm"
         href="https://example.com"
       >
         Example prompt

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -6,6 +6,7 @@ import { Override } from '~/utilities'
 
 import { StyledHeading } from '../heading/Heading'
 import { StyledLi } from '../list/List'
+import { StyledMarkdownEmphasis } from '../markdown-content/components'
 import { StyledText, textVariants } from '../text/Text'
 
 export const StyledLink = styled('a', {
@@ -23,13 +24,14 @@ export const StyledLink = styled('a', {
   '&:active': {
     color: '$primaryDark'
   },
-  [`${StyledText} > &, ${StyledHeading} > &, ${StyledLi} > &`]: {
-    fontSize: '100%',
-    lineHeight: 1,
-    '&::before, &::after': {
-      content: 'none'
-    }
-  },
+  [`${StyledText} > &, ${StyledHeading} > &, ${StyledLi} > &, ${StyledMarkdownEmphasis} > &`]:
+    {
+      fontSize: '100%',
+      lineHeight: 1,
+      '&::before, &::after': {
+        content: 'none'
+      }
+    },
   variants: textVariants
 })
 

--- a/lib/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/lib/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Link component can be nested within Text and Heading 1`] = `
 @media  {
-  .c-dEwrHQ {
+  .c-fucOQC {
     background: unset;
     border: unset;
     padding: unset;
@@ -12,29 +12,32 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     text-decoration: none;
   }
 
-  .c-dEwrHQ:focus,
-  .c-dEwrHQ:hover {
+  .c-fucOQC:focus,
+  .c-fucOQC:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-dEwrHQ:active {
+  .c-fucOQC:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dyvMgW > .c-dEwrHQ,
-  .c-jryFOR > .c-dEwrHQ,
-  .c-PJLV > .c-dEwrHQ {
+  .c-dyvMgW > .c-fucOQC,
+  .c-jryFOR > .c-fucOQC,
+  .c-PJLV > .c-fucOQC,
+  .c-bYNGXt > .c-fucOQC {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dyvMgW > .c-dEwrHQ::before,
-  .c-dyvMgW > .c-dEwrHQ::after,
-  .c-jryFOR > .c-dEwrHQ::before,
-  .c-jryFOR > .c-dEwrHQ::after,
-  .c-PJLV > .c-dEwrHQ::before,
-  .c-PJLV > .c-dEwrHQ::after {
+  .c-dyvMgW > .c-fucOQC::before,
+  .c-dyvMgW > .c-fucOQC::after,
+  .c-jryFOR > .c-fucOQC::before,
+  .c-jryFOR > .c-fucOQC::after,
+  .c-PJLV > .c-fucOQC::before,
+  .c-PJLV > .c-fucOQC::after,
+  .c-bYNGXt > .c-fucOQC::before,
+  .c-bYNGXt > .c-fucOQC::after {
     content: none;
   }
 
@@ -57,42 +60,42 @@ exports[`Link component can be nested within Text and Heading 1`] = `
 }
 
 @media  {
-  .c-dEwrHQ-gvmVBy-size-md {
+  .c-fucOQC-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::before {
+  .c-fucOQC-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::after {
+  .c-fucOQC-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
   }
 
-  .c-dEwrHQ-jvTRJO-size-lg {
+  .c-fucOQC-jvTRJO-size-lg {
     font-size: var(--fontSizes-lg);
     line-height: 1.52;
   }
 
-  .c-dEwrHQ-jvTRJO-size-lg::before {
+  .c-fucOQC-jvTRJO-size-lg::before {
     content: '';
     margin-bottom: -0.3983em;
     display: table;
   }
 
-  .c-dEwrHQ-jvTRJO-size-lg::after {
+  .c-fucOQC-jvTRJO-size-lg::after {
     content: '';
     margin-top: -0.3983em;
     display: table;
   }
 
-  .c-dEwrHQ-hUrFFO-noCapsize-true::before,
-  .c-dEwrHQ-hUrFFO-noCapsize-true::after {
+  .c-fucOQC-hUrFFO-noCapsize-true::before,
+  .c-fucOQC-hUrFFO-noCapsize-true::after {
     display: none;
   }
 
@@ -136,7 +139,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     class="c-dyvMgW c-dyvMgW-gvmVBy-size-md"
   >
     <button
-      class="c-dEwrHQ c-dEwrHQ-gvmVBy-size-md c-dEwrHQ-hUrFFO-noCapsize-true"
+      class="c-fucOQC c-fucOQC-gvmVBy-size-md c-fucOQC-hUrFFO-noCapsize-true"
     >
       TEXT LINK
     </button>
@@ -145,7 +148,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
     class="c-jryFOR c-jryFOR-fOoUdm-size-md"
   >
     <button
-      class="c-dEwrHQ c-dEwrHQ-gvmVBy-size-md c-dEwrHQ-hUrFFO-noCapsize-true"
+      class="c-fucOQC c-fucOQC-gvmVBy-size-md c-fucOQC-hUrFFO-noCapsize-true"
     >
       HEADING LINK
     </button>
@@ -155,7 +158,7 @@ exports[`Link component can be nested within Text and Heading 1`] = `
 
 exports[`Link component renders an anchor 1`] = `
 @media  {
-  .c-dEwrHQ {
+  .c-fucOQC {
     background: unset;
     border: unset;
     padding: unset;
@@ -165,46 +168,49 @@ exports[`Link component renders an anchor 1`] = `
     text-decoration: none;
   }
 
-  .c-dEwrHQ:focus,
-  .c-dEwrHQ:hover {
+  .c-fucOQC:focus,
+  .c-fucOQC:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-dEwrHQ:active {
+  .c-fucOQC:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dyvMgW > .c-dEwrHQ,
-  .c-jryFOR > .c-dEwrHQ,
-  .c-PJLV > .c-dEwrHQ {
+  .c-dyvMgW > .c-fucOQC,
+  .c-jryFOR > .c-fucOQC,
+  .c-PJLV > .c-fucOQC,
+  .c-bYNGXt > .c-fucOQC {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dyvMgW > .c-dEwrHQ::before,
-  .c-dyvMgW > .c-dEwrHQ::after,
-  .c-jryFOR > .c-dEwrHQ::before,
-  .c-jryFOR > .c-dEwrHQ::after,
-  .c-PJLV > .c-dEwrHQ::before,
-  .c-PJLV > .c-dEwrHQ::after {
+  .c-dyvMgW > .c-fucOQC::before,
+  .c-dyvMgW > .c-fucOQC::after,
+  .c-jryFOR > .c-fucOQC::before,
+  .c-jryFOR > .c-fucOQC::after,
+  .c-PJLV > .c-fucOQC::before,
+  .c-PJLV > .c-fucOQC::after,
+  .c-bYNGXt > .c-fucOQC::before,
+  .c-bYNGXt > .c-fucOQC::after {
     content: none;
   }
 }
 
 @media  {
-  .c-dEwrHQ-gvmVBy-size-md {
+  .c-fucOQC-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::before {
+  .c-fucOQC-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::after {
+  .c-fucOQC-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -213,7 +219,7 @@ exports[`Link component renders an anchor 1`] = `
 
 <div>
   <a
-    class="c-dEwrHQ c-dEwrHQ-gvmVBy-size-md"
+    class="c-fucOQC c-fucOQC-gvmVBy-size-md"
     href="https://google.com/"
   >
     GOOGLE
@@ -223,7 +229,7 @@ exports[`Link component renders an anchor 1`] = `
 
 exports[`Link component renders an large anchor 1`] = `
 @media  {
-  .c-dEwrHQ {
+  .c-fucOQC {
     background: unset;
     border: unset;
     padding: unset;
@@ -233,63 +239,66 @@ exports[`Link component renders an large anchor 1`] = `
     text-decoration: none;
   }
 
-  .c-dEwrHQ:focus,
-  .c-dEwrHQ:hover {
+  .c-fucOQC:focus,
+  .c-fucOQC:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-dEwrHQ:active {
+  .c-fucOQC:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dyvMgW > .c-dEwrHQ,
-  .c-jryFOR > .c-dEwrHQ,
-  .c-PJLV > .c-dEwrHQ {
+  .c-dyvMgW > .c-fucOQC,
+  .c-jryFOR > .c-fucOQC,
+  .c-PJLV > .c-fucOQC,
+  .c-bYNGXt > .c-fucOQC {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dyvMgW > .c-dEwrHQ::before,
-  .c-dyvMgW > .c-dEwrHQ::after,
-  .c-jryFOR > .c-dEwrHQ::before,
-  .c-jryFOR > .c-dEwrHQ::after,
-  .c-PJLV > .c-dEwrHQ::before,
-  .c-PJLV > .c-dEwrHQ::after {
+  .c-dyvMgW > .c-fucOQC::before,
+  .c-dyvMgW > .c-fucOQC::after,
+  .c-jryFOR > .c-fucOQC::before,
+  .c-jryFOR > .c-fucOQC::after,
+  .c-PJLV > .c-fucOQC::before,
+  .c-PJLV > .c-fucOQC::after,
+  .c-bYNGXt > .c-fucOQC::before,
+  .c-bYNGXt > .c-fucOQC::after {
     content: none;
   }
 }
 
 @media  {
-  .c-dEwrHQ-gvmVBy-size-md {
+  .c-fucOQC-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::before {
+  .c-fucOQC-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::after {
+  .c-fucOQC-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
   }
 
-  .c-dEwrHQ-jvTRJO-size-lg {
+  .c-fucOQC-jvTRJO-size-lg {
     font-size: var(--fontSizes-lg);
     line-height: 1.52;
   }
 
-  .c-dEwrHQ-jvTRJO-size-lg::before {
+  .c-fucOQC-jvTRJO-size-lg::before {
     content: '';
     margin-bottom: -0.3983em;
     display: table;
   }
 
-  .c-dEwrHQ-jvTRJO-size-lg::after {
+  .c-fucOQC-jvTRJO-size-lg::after {
     content: '';
     margin-top: -0.3983em;
     display: table;
@@ -298,7 +307,7 @@ exports[`Link component renders an large anchor 1`] = `
 
 <div>
   <a
-    class="c-dEwrHQ c-dEwrHQ-jvTRJO-size-lg"
+    class="c-fucOQC c-fucOQC-jvTRJO-size-lg"
     href="https://google.com/"
   >
     GOOGLE

--- a/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`MarkdownContent component renders 1`] = `
     padding: var(--space-3);
   }
 
-  .c-dEwrHQ {
+  .c-fucOQC {
     background: unset;
     border: unset;
     padding: unset;
@@ -115,29 +115,32 @@ exports[`MarkdownContent component renders 1`] = `
     text-decoration: none;
   }
 
-  .c-dEwrHQ:focus,
-  .c-dEwrHQ:hover {
+  .c-fucOQC:focus,
+  .c-fucOQC:hover {
     color: var(--colors-primaryMid);
     text-decoration: underline;
   }
 
-  .c-dEwrHQ:active {
+  .c-fucOQC:active {
     color: var(--colors-primaryDark);
   }
 
-  .c-dyvMgW > .c-dEwrHQ,
-  .c-jryFOR > .c-dEwrHQ,
-  .c-PJLV > .c-dEwrHQ {
+  .c-dyvMgW > .c-fucOQC,
+  .c-jryFOR > .c-fucOQC,
+  .c-PJLV > .c-fucOQC,
+  .c-bYNGXt > .c-fucOQC {
     font-size: 100%;
     line-height: 1;
   }
 
-  .c-dyvMgW > .c-dEwrHQ::before,
-  .c-dyvMgW > .c-dEwrHQ::after,
-  .c-jryFOR > .c-dEwrHQ::before,
-  .c-jryFOR > .c-dEwrHQ::after,
-  .c-PJLV > .c-dEwrHQ::before,
-  .c-PJLV > .c-dEwrHQ::after {
+  .c-dyvMgW > .c-fucOQC::before,
+  .c-dyvMgW > .c-fucOQC::after,
+  .c-jryFOR > .c-fucOQC::before,
+  .c-jryFOR > .c-fucOQC::after,
+  .c-PJLV > .c-fucOQC::before,
+  .c-PJLV > .c-fucOQC::after,
+  .c-bYNGXt > .c-fucOQC::before,
+  .c-bYNGXt > .c-fucOQC::after {
     content: none;
   }
 
@@ -320,18 +323,18 @@ exports[`MarkdownContent component renders 1`] = `
     font-weight: bold;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md {
+  .c-fucOQC-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::before {
+  .c-fucOQC-gvmVBy-size-md::before {
     content: '';
     margin-bottom: -0.3864em;
     display: table;
   }
 
-  .c-dEwrHQ-gvmVBy-size-md::after {
+  .c-fucOQC-gvmVBy-size-md::after {
     content: '';
     margin-top: -0.3864em;
     display: table;
@@ -691,7 +694,7 @@ line 3 of code
       class="c-dyvMgW c-dyvMgW-gvmVBy-size-md"
     >
       <a
-        class="c-dEwrHQ c-dEwrHQ-gvmVBy-size-md"
+        class="c-fucOQC c-fucOQC-gvmVBy-size-md"
         href="http://dev.nodeca.com"
       >
         link text
@@ -701,7 +704,7 @@ line 3 of code
       class="c-dyvMgW c-dyvMgW-gvmVBy-size-md"
     >
       <a
-        class="c-dEwrHQ c-dEwrHQ-gvmVBy-size-md"
+        class="c-fucOQC c-fucOQC-gvmVBy-size-md"
         href="http://nodeca.github.io/pica/demo/"
         title="title text!"
       >

--- a/lib/src/components/markdown-content/components/MarkdownEmphasis.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownEmphasis.tsx
@@ -8,7 +8,7 @@ type MarkdownEmphasisProps = {
   handleNode: (node: Content) => React.ReactElement
 }
 
-const StyledMarkdownEmphasis = styled('em', { fontStyle: 'italic' })
+export const StyledMarkdownEmphasis = styled('em', { fontStyle: 'italic' })
 
 export const MarkdownEmphasis: React.FC<MarkdownEmphasisProps> = ({
   node,

--- a/lib/src/components/markdown-content/components/index.ts
+++ b/lib/src/components/markdown-content/components/index.ts
@@ -1,5 +1,5 @@
 export { MarkdownCode } from './MarkdownCode'
-export { MarkdownEmphasis } from './MarkdownEmphasis'
+export { MarkdownEmphasis, StyledMarkdownEmphasis } from './MarkdownEmphasis'
 export { MarkdownHeading } from './MarkdownHeading'
 export { MarkdownInlineCode } from './MarkdownInlineCode'
 export { MarkdownImage } from './MarkdownImage'


### PR DESCRIPTION
### Description

When adding the italic markdown to content containing a link, it adds the `::before` and `::after` pseudo styling, creating a new line.

```
  this italic _[link text](http://google.com)_ should be in one line

  _this italic [link text](http://google.com) should be in one line_
```

<img width="507" alt="image" src="https://user-images.githubusercontent.com/11061661/207876718-566e8c7a-5944-4be7-8830-84647feb0eb7.png">


#### Before
<img width="269" alt="image" src="https://user-images.githubusercontent.com/11061661/207876006-9882fa98-ba6a-4a3b-a054-ee96a553acf8.png">

#### After
<img width="380" alt="image" src="https://user-images.githubusercontent.com/11061661/207876074-5ff73892-6fe2-414c-8ba3-1a0050293d7a.png">

