### PR TITLE
fix: show missing API references

### DIFF
--- a/lib/src/components/avatar/Avatar.mdx
+++ b/lib/src/components/avatar/Avatar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Avatar
-component: Avatar
+component: Avatar,Avatar.Image,Avatar.Initial,Avatar.Placeholder,Avatar.Icon
 description: Show a thumbnail representation of an individual or entity.
 category: Media
 ---

--- a/lib/src/components/chip-dismissible-group/ChipDismissibleGroup.mdx
+++ b/lib/src/components/chip-dismissible-group/ChipDismissibleGroup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chip Dismissible Group
-component: ChipDismissibleGroup
+component: ChipDismissibleGroupRoot,ChipDismissibleGroup.Item
 description: Combines the DismissibleGroup logic together with the Chip primitive styling
 category: Feedback
 ---

--- a/lib/src/components/chip-toggle-group/ChipToggleGroup.mdx
+++ b/lib/src/components/chip-toggle-group/ChipToggleGroup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chip Toggle Group
-component: ChipToggleGroup
+component: ChipToggleGroupRoot,ChipToggleGroup.Item
 description: Combines the Toggle Group radix component with the Chip primitive styling
 category: Feedback
 ---

--- a/lib/src/components/dismissible-group/DismissibleGroup.mdx
+++ b/lib/src/components/dismissible-group/DismissibleGroup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dismissible Group
-component: DismissibleGroup
+component: DismissibleGroupRoot,DismissibleGroup.Item,DismissibleGroup.Trigger
 description: A set of dismissible elements.
 category: Primitives
 ---

--- a/lib/src/components/dismissible/Dismissible.mdx
+++ b/lib/src/components/dismissible/Dismissible.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dismissible
-component: Dismissible
+component: DismissibleRoot,Dismissible.Trigger
 description: An element with a dismiss button which removes it from the view
 category: Primitives
 ---

--- a/lib/src/components/tabs/Tabs.mdx
+++ b/lib/src/components/tabs/Tabs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tabs
-component: Tabs
+component: Tabs,TriggerListWrapper,TabTrigger
 description: Tabs is a component that provides different sections of content that are displayed one at a time.
 category: Layout
 ---

--- a/lib/src/components/toast/Toast.mdx
+++ b/lib/src/components/toast/Toast.mdx
@@ -1,5 +1,6 @@
 ---
 title: Toast
+component: ToastProvider
 description: A toast notification that gives non-intrusive feedback to the user and times out automatically
 category: Feedback
 ---

--- a/lib/src/components/toggle-group/ToggleGroup.mdx
+++ b/lib/src/components/toggle-group/ToggleGroup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toggle Group
-component: ToggleGroup
+component: ToggleGroupRoot,ToggleGroup.Button,ToggleGroup.Item
 description: Extends functionality the Toggle Group radix component
 category: Content
 ---

--- a/site/src/components/PropsTable.tsx
+++ b/site/src/components/PropsTable.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  CSS,
   Flex,
   Heading,
   Icon,
@@ -14,6 +13,8 @@ import { pascalCase } from 'pascal-case'
 import * as React from 'react'
 import { ComponentDoc } from 'react-docgen-typescript'
 
+import type { CSS } from '~/stitches'
+
 import { Cell, InlineCode, Table } from '.'
 
 type PropsTableProps = {
@@ -25,7 +26,11 @@ const sizeOrder = ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl']
 const getComponentProps = (name): ComponentDoc =>
   docgen
     .filter(Boolean)
-    .find((component) => component.displayName === pascalCase(name))
+    .find(
+      (component) =>
+        component.displayName === name ||
+        component.displayName === pascalCase(name)
+    )
 
 const columns = ['Prop', 'Type', 'Default', 'Required']
 


### PR DESCRIPTION
## Context

Some components were not showing any API reference section
[Jira Ticket](https://atomlearningltd.atlassian.net/browse/FG-223)

## Implementation

`lib/scripts/generate-component-props.mjs` is responsible for generating a `docgen.json` file. This file is used by the component `<PropsTable.tsx>` to display the API reference. The components which API reference it will show are taken from the first section of the corresponding `.mdx` file.

For instance, in the `Avatar.mdx` file we have this:
```
---
title: Avatar
component: Avatar,Avatar.Image,Avatar.Initial,Avatar.Placeholder,Avatar.Icon
description: Show a thumbnail representation of an individual or entity.
category: Media
---
```

So `<PropsTable.tsx>` will try to show an API reference for each component of that list. But it actually, doesn't know to go into `Avatar.Image`; Instead, it uses the npm `pascal-case` package to transform the name into `AvatarImage`, and it only works, because the component passed to `Avatar.Image` is called `AvatarImage`

Due to some components' `.mdx` files not having all this into account, some were only displyaing the API reference for the root component (like `<Avatar>`) and others had it for none (like `<ToggleGroup>`).

Especial mention to `<CSSWrapper>` which was not showing for a different reason. `pascal-case` transforms `CSSWrapper` into `CssWrapper`, so in order to make it work, the function that checks the name matching, now it checks with the pascal-case transformation and without it, and if any of them match, it's a match.


## Screenshots
![localhost_3000_components_toggle-group](https://user-images.githubusercontent.com/4931116/209347777-3e3cc8e5-f5d1-4f62-8248-585ffbb65b5e.png)

