### PR TITLE
Feat: Datatable FE pagination state

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -161,7 +161,8 @@
     "react-hot-toast": "^1.0.2",
     "react-player": "^2.9.0",
     "throttle-debounce": "^3.0.1",
-    "uid": "^2.0.0"
+    "uid": "^2.0.0",
+    "use-deep-compare-effect": "^1.8.1"
   },
   "husky": {
     "hooks": {

--- a/lib/src/components/data-table/DataTable.mdx
+++ b/lib/src/components/data-table/DataTable.mdx
@@ -77,6 +77,8 @@ If you need more flexibility than the default implementations provide, you can r
 
 Note also that `useDataTable` can only be called by a child component of `DataTable`. In a real example, you'll probably have a separate named component which makes the `useDataTable` call, because if you're not using the defaults as above then you probably have some complex logic involved. In this example we've got an inline child component for simplicity.
 
+Note that if you update the value of the `data` prop, it will reset the state of the table. This is useful if you are manipulating the data outside the context of the table.
+
 ```tsx
 <DataTable columns={columns} data={data}>
   {() => {

--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -63,11 +63,7 @@ describe('DataTable component', () => {
   it('renders', () => {
     const { container } = render(
       <Wrapper>
-        <DataTable
-          columns={columns}
-          data={data}
-          initialState={{ pagination: { pageIndex: 0, pageSize: 5 } }}
-        >
+        <DataTable columns={columns} data={data}>
           <DataTable.GlobalFilter label="User search" css={{ mb: '$4' }} />
           <DataTable.Table sortable css={{ mb: '$4' }} />
           <DataTable.Pagination />

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -21,7 +21,6 @@ import type {
   PaginationState,
   SortDirection
 } from '@tanstack/react-table'
-import { CSS } from '~/stitches'
 
 import {
   DataTableContextType,
@@ -50,7 +49,6 @@ type TableProviderProps = {
   defaultSort?: { column: string; direction: SortDirection }
   children: React.ReactNode
   initialState?: InitialState
-  css?: CSS
 } & (
   | { data: Array<Record<string, unknown>>; getAsyncData?: never }
   | { data?: never; getAsyncData: TGetAsyncData }
@@ -67,8 +65,7 @@ export const DataTableProvider = ({
   getAsyncData,
   defaultSort,
   initialState = undefined,
-  children,
-  css
+  children
 }: TableProviderProps): JSX.Element => {
   const [data, setData] = React.useState<TAsyncDataResult>({
     results: dataProp ?? [],

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -142,6 +142,12 @@ export const DataTableProvider = ({
     runAsyncData({})
   }, [runAsyncData])
 
+  React.useEffect(() => {
+    if (!dataProp) return
+
+    setData({ results: dataProp, total: dataProp.length })
+  }, [dataProp])
+
   const getTotalRows = () => data.total
 
   const table = useReactTable<unknown>({

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import useDeepCompareEffect from 'use-deep-compare-effect'
 import {
   useReactTable,
   getCoreRowModel,
@@ -61,7 +62,7 @@ const DataTableContext =
 
 export const DataTableProvider = ({
   columns,
-  data: dataProp,
+  data: dataProp = [],
   getAsyncData,
   defaultSort,
   initialState = undefined,
@@ -139,7 +140,7 @@ export const DataTableProvider = ({
     runAsyncData({})
   }, [runAsyncData])
 
-  React.useEffect(() => {
+  useDeepCompareEffect(() => {
     if (!dataProp) return
 
     setData({ results: dataProp, total: dataProp.length })

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -87,14 +87,10 @@ export const DataTableProvider = ({
 
   const [paginationState, setPagination] = React.useState<
     PaginationState | undefined
-  >(
-    getAsyncData
-      ? {
-          ...defaultPaginationState,
-          ...initialState?.pagination
-        }
-      : initialState?.pagination
-  )
+  >({
+    ...defaultPaginationState,
+    ...initialState?.pagination
+  })
 
   const [isSortable, setIsSortable] = React.useState<boolean>(false)
   const [sorting, setSorting] = React.useState<SortingState>(

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -588,6 +588,111 @@ exports[`DataTable component renders 1`] = `
           </button>
         </td>
       </tr>
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-cCZzXk"
+        >
+          xena
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          acting
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          <button>
+            do something
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-cCZzXk"
+        >
+          rick
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          bare-knuckle boxing
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          <button>
+            do something
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-cCZzXk"
+        >
+          phillip
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          crossfit
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          <button>
+            do something
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-cCZzXk"
+        >
+          maurice
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          acting
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          <button>
+            do something
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-cCZzXk"
+        >
+          peter
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          bare-knuckle boxing
+        </td>
+        <td
+          class="c-cCZzXk"
+        >
+          <button>
+            do something
+          </button>
+        </td>
+      </tr>
     </tbody>
   </table>
   <nav
@@ -596,7 +701,7 @@ exports[`DataTable component renders 1`] = `
     <p
       class="c-dyvMgW c-dyvMgW-bndJoy-size-sm"
     >
-      1 - 5 of 18 items
+      1 - 10 of 18 items
     </p>
     <div
       class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -614,21 +719,11 @@ exports[`DataTable component renders 1`] = `
         >
           2
         </option>
-        <option
-          value="2"
-        >
-          3
-        </option>
-        <option
-          value="3"
-        >
-          4
-        </option>
       </select>
       <p
         class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-igbZjeK-css"
       >
-        of 4 pages
+        of 2 pages
       </p>
     </div>
     <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -5017,6 +5017,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -12560,6 +12565,14 @@ use-callback-ref@^1.3.0:
   integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
   dependencies:
     tslib "^2.0.0"
+
+use-deep-compare-effect@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
+  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    dequal "^2.0.2"
 
 use-isomorphic-layout-effect@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
#### Description

There are two issues that this PR addresses:
- The internal data array is not updated when new data is passed in.
     - If the data is being manipulated outside of the table (such as filtering) the data is passed back into the component. I believe we need to maintain this flexibility.
- Unable to retrieve the pagination state using `useDataTable` from the FE implementation of DataTable
    - Since we provide a managed pagination state, onPaginationChange and a page count to`useReactTable` we need to ensure our `paginationState` is not undefined.

#### Implementation
- Adds a `useEffect` which will update the internal data state when the data prop changes
- Defaults the pagination state for both `getAsyncData` & `dataProp` implementations