### PR TITLE
Fix: read DataTable custom idColumn correctly

### DIFF
--- a/lib/src/components/data-table/drag-and-drop/DragAndDropContainer.tsx
+++ b/lib/src/components/data-table/drag-and-drop/DragAndDropContainer.tsx
@@ -18,6 +18,20 @@ import {
 } from '@dnd-kit/sortable'
 import * as React from 'react'
 
+const DragAndDropTableContext = React.createContext<{ idColumn: string }>({
+  idColumn: 'id'
+})
+export const useDragAndDropTable = () => {
+  const context = React.useContext(DragAndDropTableContext)
+
+  if (!context)
+    throw new Error(
+      'useDragAndDropTable can only be called within a DragAndDropContainer'
+    )
+
+  return context
+}
+
 type DragAndDropContainerProps = {
   idColumn?: string
   onChange?: (oldIndex: number, newIndex: number, newData: TableData) => void
@@ -33,8 +47,8 @@ export const processDragEndEvent = (
   onChange?: (oldIndex: number, newIndex: number, newData: TableData) => void
 ) => {
   const { active, over } = event
-  const oldIndex = rowOrder.indexOf(active[idColumn])
-  const newIndex = rowOrder.indexOf(over?.[idColumn])
+  const oldIndex = rowOrder.indexOf(active.id)
+  const newIndex = rowOrder.indexOf(over?.id)
   const results = arrayMove(data.results, oldIndex, newIndex)
   onChange?.(oldIndex, newIndex, results)
   return { results, total: results.length }
@@ -89,7 +103,9 @@ export const DragAndDropContainer: React.FC<DragAndDropContainerProps> = ({
       modifiers={[restrictToVerticalAxis]}
     >
       <SortableContext items={rowOrder} strategy={verticalListSortingStrategy}>
-        {children}
+        <DragAndDropTableContext.Provider value={{ idColumn }}>
+          {children}
+        </DragAndDropTableContext.Provider>
       </SortableContext>
     </DndContext>
   )

--- a/lib/src/components/data-table/drag-and-drop/DraggableRow.tsx
+++ b/lib/src/components/data-table/drag-and-drop/DraggableRow.tsx
@@ -2,7 +2,7 @@ import type { Row } from '@tanstack/react-table'
 import * as React from 'react'
 import { Table } from '../../table'
 import { DataTableDataCell } from '../DataTableDataCell'
-import { Handle } from './'
+import { Handle, useDragAndDropTable } from './'
 import { CSS } from '@dnd-kit/utilities'
 import { useSortable } from '@dnd-kit/sortable'
 import type { UniqueIdentifier } from '@dnd-kit/core'
@@ -15,9 +15,11 @@ export type DataTableDraggableRowProps = React.ComponentProps<
 }
 
 export const DraggableRow: React.FC<DataTableDraggableRowProps> = ({ row }) => {
+  const { idColumn } = useDragAndDropTable()
+
   const { attributes, listeners, transform, setNodeRef, isDragging } =
     useSortable({
-      id: row.original.id as UniqueIdentifier
+      id: row.original[idColumn] as UniqueIdentifier
     })
 
   return (

--- a/lib/src/components/data-table/drag-and-drop/index.ts
+++ b/lib/src/components/data-table/drag-and-drop/index.ts
@@ -1,4 +1,7 @@
-export { DragAndDropContainer } from './DragAndDropContainer'
+export {
+  useDragAndDropTable,
+  DragAndDropContainer
+} from './DragAndDropContainer'
 export { DraggableRow } from './DraggableRow'
 export { Handle } from './Handle'
 export { DragAndDropTable } from './DragAndDropTable'


### PR DESCRIPTION
Fixes a problem where custom `idColumn` values didn't work correctly.

My original drag-and-drop row implementation had a bug where `DraggableRow` assumed the consumer was providing IDs for each row in an `id` property and `DragAndDropContainer` tried to read the id `@dnd-kit/sortable` provided dynamically using the `idColumn` value. This was the wrong way round!

Instead, `DraggableRow` now uses the provided `idColumn` find the value to provide as `@dnd-kit/sortable`'s `id` and `DragAndDropContainer` correctly reads the `id` from the objects that come out of `@dnd-kit/sortable`.