### PR TITLE
Fix: broken list theme variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In the future, you only need to rerun `yarn build:docs` after you either delete 
 
 ### Running the sandbox
 
-The library offers sandbox capabilities to ease the development process. This run with the following command
+The library offers sandbox capabilities to ease the development process. This runs with the following command
 
 `yarn start:sandbox`
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ You can read more about the components included in `@atom-learning/components` a
 
 We can run the documentation site locally, with hot-reloading triggered by changes in the library. This offers a low-friction dev environment where we can see the effects of any local changes when applied to all existing components. (Note: hot reloading is currently only supported for changes to Typescript/.tsx files, not markdown files.)
 
-First, run `yarn build:docs && yarn dev:lib`. `yarn build:docs` collects the markdown documentation files for each component in `lib` into its `dist` directory, where the documentation site can find them. `yarn dev:lib` compiles the React component library and watches for changes.
+First, run `yarn build:lib && yarn build:docs`. `yarn build:docs` collects the markdown documentation files for each component in `lib` into its `dist` directory, where the documentation site can find them. `yarn build:docs` compiles the documentation and extract the component props.
 
 In another terminal, run `yarn dev:site` to run the documentation site at `http://localhost:3000`, taking the output as the previous commands as its input.
 
 In the future, you only need to rerun `yarn build:docs` after you either delete the content of `lib/dist` or you add/update some markdown files inside `lib`.
+
+### Running the sandbox
+
+The library offers sandbox capabilities to ease the development process. This run with the following command
+
+`yarn start:sandbox`
 
 ### Tests
 

--- a/lib/src/components/list/List.test.tsx
+++ b/lib/src/components/list/List.test.tsx
@@ -48,4 +48,15 @@ describe(`List component`, () => {
 
     expect(container.querySelector('ol')).toBeVisible()
   })
+
+  it('renders an unordered list with a primary theme', () => {
+    const { container } = render(
+      <List theme="primary">
+        <List.Item>Item 1</List.Item>
+        <List.Item>Item 2</List.Item>
+      </List>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
 })

--- a/lib/src/components/list/List.tsx
+++ b/lib/src/components/list/List.tsx
@@ -32,6 +32,13 @@ export const StyledList = styled('ul', {
           '&::marker': { content: '•', fontWeight: 'bold' }
         }
       }
+    },
+    theme: {
+      primary: {
+        [`& > ${StyledLi}`]: {
+          '&::marker': { color: '$primary' }
+        }
+      }
     }
   }
 })

--- a/lib/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/lib/src/components/list/__snapshots__/List.test.tsx.snap
@@ -71,3 +71,93 @@ exports[`List component renders a list 1`] = `
   </ul>
 </div>
 `;
+
+exports[`List component renders an unordered list with a primary theme 1`] = `
+@media  {
+  .c-iQukjL {
+    font-family: var(--fonts-body);
+    margin: unset;
+    padding: unset;
+  }
+
+  .c-iQukjL > .c-PJLV:not(:last-child) {
+    margin-bottom: var(--space-2);
+  }
+
+  .c-iQukjL > .c-PJLV:last-child {
+    margin-bottom: 0;
+  }
+}
+
+@media  {
+  .c-iQukjL-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-iQukjL-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-iQukjL-hUrFFO-noCapsize-true::before,
+  .c-iQukjL-hUrFFO-noCapsize-true::after {
+    display: none;
+  }
+
+  .c-iQukjL-DlQlZ-as-ul {
+    padding-left: var(--space-3);
+  }
+
+  .c-iQukjL-DlQlZ-as-ul > .c-PJLV {
+    padding-left: var(--space-2);
+  }
+
+  .c-iQukjL-DlQlZ-as-ul > .c-PJLV::marker {
+    content: "•";
+    font-weight: bold;
+  }
+
+  .c-iQukjL-jrjcGe-as-ol {
+    padding-left: var(--space-4);
+    list-style: decimal;
+  }
+
+  .c-iQukjL-jrjcGe-as-ol > .c-PJLV {
+    padding-left: var(--space-1);
+  }
+
+  .c-iQukjL-jrjcGe-as-ol > .c-PJLV::marker {
+    font-size: var(--fontSizes-sm);
+    font-weight: bold;
+  }
+
+  .c-iQukjL-gvBFgi-theme-primary > .c-PJLV::marker {
+    color: var(--colors-primary);
+  }
+}
+
+<div>
+  <ul
+    class="c-iQukjL c-iQukjL-gvmVBy-size-md c-iQukjL-hUrFFO-noCapsize-true c-iQukjL-DlQlZ-as-ul c-iQukjL-gvBFgi-theme-primary"
+  >
+    <li
+      class="c-PJLV"
+    >
+      Item 1
+    </li>
+    <li
+      class="c-PJLV"
+    >
+      Item 2
+    </li>
+  </ul>
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:site": "cd site && next build",
     "start:site": "cd site && next start",
     "lint-staged": "cd site && yarn run precommit && cd ../lib && yarn run precommit",
-    "build-all": "run-s build:*"
+    "build-all": "run-s build:*",
+    "start:sandbox": "cd lib && vite -c ./sandbox/vite.config.js"
   },
   "devDependencies": {
     "husky": "^4.3.8",


### PR DESCRIPTION
This PR re-introduces the theme variant for the list component, as we need it for the DS migration of the list https://atomlearningltd.atlassian.net/browse/FG-197. I have only added the primary variant since this is what we need only now.

<img width="245" alt="image" src="https://user-images.githubusercontent.com/5703687/212915997-e8c69341-d0dc-4c28-8b2a-fdb75c907de6.png">


https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-283