### PR TITLE
feat: do not open NavigationMenuDropdown via pointer events

### DIFF
--- a/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
@@ -1,5 +1,6 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import React from 'react'
+import { preventHover } from './preventHover'
 
 import { styled } from '~/stitches'
 
@@ -18,7 +19,10 @@ const StyledContent = styled(NavigationMenuPrimitive.Content, {
 })
 
 export const NavigationMenuDropdownContent: React.FC = ({ children }) => (
-  <StyledContent>
+  <StyledContent
+    onPointerMove={preventHover}
+    onPointerLeave={preventHover}
+  >
     <StyledList>{children}</StyledList>
   </StyledContent>
 )

--- a/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from '@atom-learning/icons'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import React from 'react'
+import { preventHover } from './preventHover'
 
 import { styled } from '~/stitches'
 
@@ -31,7 +32,12 @@ export const NavigationMenuDropdownTrigger = React.forwardRef<
   HTMLButtonElement,
   React.PropsWithChildren<{ active?: boolean }>
 >(({ children, active, ...props }, forwardedRef) => (
-  <StyledTrigger active={active} {...props} ref={forwardedRef}>
+  <StyledTrigger
+    active={active}
+    {...props}
+    ref={forwardedRef}
+    onPointerMove={preventHover}
+    onPointerLeave={preventHover}>
     {children}
     <Icon
       is={ChevronDown}

--- a/lib/src/components/navigation/preventHover.ts
+++ b/lib/src/components/navigation/preventHover.ts
@@ -1,0 +1,8 @@
+/*
+Used to block default radix hover to open menu behaviour
+Props: https://github.com/radix-ui/primitives/issues/1630
+*/
+export const preventHover = (event: any) => {
+  const e = event as Event
+  e.preventDefault()
+}


### PR DESCRIPTION
Jira: https://atomlearningltd.atlassian.net/browse/DS-165

Requirement: Have the navigation menu dropdown open only on click and not on hover.

Solution: https://github.com/radix-ui/primitives/issues/1630

### Videos

https://user-images.githubusercontent.com/6905473/214565843-ca1e4113-5b36-43df-a7d9-978fdaa572d2.mov

