### PR TITLE
fix: allow numbers to be rendered when checking and wrapping type che…

### DIFF
--- a/lib/src/components/badge/Badge.mdx
+++ b/lib/src/components/badge/Badge.mdx
@@ -7,7 +7,7 @@ category: Feedback
 
 The `Badge` component can be used to highlight a short piece of information, like a status.
 
-```tsx preview
+```tsx preview live
 <Badge>New Data</Badge>
 ```
 

--- a/lib/src/components/badge/Badge.tsx
+++ b/lib/src/components/badge/Badge.tsx
@@ -70,7 +70,7 @@ export const Badge: React.FC<BadgeProps> = ({
   return (
     <StyledBadge role="status" theme={theme} size={size} {...rest}>
       {React.Children.map(children, (child) => {
-        if (typeof child === 'string') {
+        if (typeof child === 'string' || typeof child === 'number') {
           return (
             <Box
               css={{

--- a/lib/src/components/toggle-group/ToggleGroup.mdx
+++ b/lib/src/components/toggle-group/ToggleGroup.mdx
@@ -15,7 +15,7 @@ Extends visually by allowing for different sizing, vertical/horizontal display a
 
 `orientation="vertical | horizontal"`
 
-```jsx preview
+```jsx preview live
 <ToggleGroup.Root type="multiple" orientation="vertical">
   <ToggleGroup.Button value="a">A</ToggleGroup.Button>
   <ToggleGroup.Button value="b">B</ToggleGroup.Button>

--- a/lib/src/components/toggle-group/ToggleGroupButton.tsx
+++ b/lib/src/components/toggle-group/ToggleGroupButton.tsx
@@ -95,7 +95,7 @@ export const ToggleGroupButton: React.ForwardRefExoticComponent<
     <StyledButton ref={ref} size={size} isIconOnly={isIconOnly} {...rest}>
       {
         childrenArray.map((child) => {
-          if (!isSingleChild && typeof child === 'string')
+          if (!isSingleChild && (typeof child === 'string' || typeof child === 'number'))
             return <span key={child}>{child}</span>
           if (React.isValidElement(child)) {
             if (child?.type === Icon)


### PR DESCRIPTION
…cked children

**Jira:** https://atomlearningltd.atlassian.net/browse/DS-161

In a couple of components we check children type to wrap with an element (to do spacing between children via the parent).
We have been using `typeof child === 'string'` but sometimes the child would be a number which meant it would never render. For the ToggleGroup button it would render but it would not be space appropriately from the Icon.
This PR fixes this bit; **numbers are now treated the same way as string children**.

Additionally, when nesting multiple unwrapped children of varying types ie. `{1}/{3}` this is being read as 3 children and not 1, which means we get spacing between them - as you would get spacing between text and an icon. This is not being resolved in this PR.
I started coding to 'fix' this but it makes the children rendering crazy and it gets really complicated so I don't think it's worth as a requirement and implementation should make sure they are passing a string if they don't want random spaces. 

I kinda think that `string` casting in implementation for all use cases was probably good enough to begin with but at least with this change if a number is used directly it will appear instead of not even showing up and if it's not mixed with other types present in the same way as a string.

### Screenshots
**before**
![Screenshot 2023-01-26 at 13 52 11](https://user-images.githubusercontent.com/6905473/214852801-17127cf6-e02e-4cba-ae55-e6053b96852a.png)

**after**
![Screenshot 2023-01-26 at 13 51 09](https://user-images.githubusercontent.com/6905473/214852574-fc953e6b-4874-49ac-976e-81fd963a6a69.png)

**before**
![Screenshot 2023-01-26 at 13 54 23](https://user-images.githubusercontent.com/6905473/214853364-f821b43c-7856-4592-9858-6697346e3c64.png)

**after**
![Screenshot 2023-01-26 at 13 48 17](https://user-images.githubusercontent.com/6905473/214853020-c69aeed8-e8ec-4156-b443-70f21c228041.png)


### But this is still happening and I'm proposing to not fix but handle in implementation:

![Screenshot 2023-01-26 at 13 48 07](https://user-images.githubusercontent.com/6905473/214853612-8029f502-3bf6-456b-8686-732f43115785.png)

![Screenshot 2023-01-26 at 13 24 20](https://user-images.githubusercontent.com/6905473/214853728-2c0cc71e-1249-43cd-8499-cbafabe835e0.png)

**Just pass a string:**
![Screenshot 2023-01-26 at 13 24 33](https://user-images.githubusercontent.com/6905473/214853811-b8184f01-a4d4-4c15-b594-734b0fb6ee48.png)

