### PR TITLE
Chore: Update `@stitches/react`

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -149,7 +149,7 @@
     "@radix-ui/react-tooltip": "^1.0.0",
     "@radix-ui/react-visually-hidden": "^1.0.0",
     "@reach/combobox": "^0.16.1",
-    "@stitches/react": "^1.2.8",
+    "@stitches/react": "1.3.1-1",
     "@tanstack/react-table": "^8.5.11",
     "@types/react": "^17.0.30",
     "color2k": "^2.0.0",

--- a/lib/src/components/alert-dialog/AlertDialogContent.tsx
+++ b/lib/src/components/alert-dialog/AlertDialogContent.tsx
@@ -19,7 +19,10 @@ const slideOut = keyframes({
 
 const StyledAlertDialogOverlay = styled(Overlay, {
   backgroundColor: '$alpha600',
-  inset: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
   position: 'fixed',
   zIndex: DIALOG_Z_INDEX,
   '@allowMotion': {

--- a/lib/src/components/dialog/DialogContent.tsx
+++ b/lib/src/components/dialog/DialogContent.tsx
@@ -25,7 +25,10 @@ const slideOut = keyframes({
 
 const StyledDialogOverlay = styled(Overlay, {
   backgroundColor: '$alpha600',
-  inset: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
   position: 'fixed',
   overflowY: 'auto',
   zIndex: DIALOG_Z_INDEX,

--- a/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/lib/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
     }
 }
 
-  .c-hImYEd {
+  .c-fYlVmN {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
@@ -70,13 +70,13 @@ exports[`Dialog component opens the popover once trigger is clicked 1`] = `
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hImYEd[data-state="open"] {
+    .c-fYlVmN[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hImYEd[data-state="closed"] {
+    .c-fYlVmN[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
@@ -231,7 +231,7 @@ exports[`Dialog component with custom background renders 1`] = `
     }
 }
 
-  .c-hImYEd {
+  .c-fYlVmN {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
@@ -243,13 +243,13 @@ exports[`Dialog component with custom background renders 1`] = `
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hImYEd[data-state="open"] {
+    .c-fYlVmN[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hImYEd[data-state="closed"] {
+    .c-fYlVmN[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }
@@ -307,7 +307,7 @@ exports[`Dialog component with custom background renders 1`] = `
 }
 
 <div
-  class="c-hImYEd"
+  class="c-fYlVmN"
   data-state="open"
   id="modal_overlay"
   style="pointer-events: auto;"
@@ -409,7 +409,7 @@ exports[`Dialog component without close button renders 1`] = `
     }
 }
 
-  .c-hImYEd {
+  .c-fYlVmN {
     background-color: var(--colors-alpha600);
     top: 0;
     right: 0;
@@ -421,13 +421,13 @@ exports[`Dialog component without close button renders 1`] = `
   }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hImYEd[data-state="open"] {
+    .c-fYlVmN[data-state="open"] {
       animation: k-eyOShd 250ms ease-out;
     }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    .c-hImYEd[data-state="closed"] {
+    .c-fYlVmN[data-state="closed"] {
       animation: k-bHbNKp 550ms ease-out;
     }
 }

--- a/lib/src/stitches.ts
+++ b/lib/src/stitches.ts
@@ -12,13 +12,6 @@ export const utils = {
     background: value
   }),
 
-  inset: (value: ScaleValue<'space'> | number | string) => ({
-    top: value,
-    right: value,
-    bottom: value,
-    left: value
-  }),
-
   size: (value: ScaleValue<'size'> | number | string) => ({
     height: value,
     width: value

--- a/site/package.json
+++ b/site/package.json
@@ -26,7 +26,7 @@
     "@atom-learning/icons": "1.14.0",
     "@atom-learning/theme": "1.1.1",
     "@next/mdx": "^10.0.6",
-    "@stitches/react": "^1.2.5",
+    "@stitches/react": "1.3.1-1",
     "capital-case": "^1.0.4",
     "next": "^10.0.6",
     "next-images": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,10 +2786,10 @@
     "@size-limit/esbuild" "7.0.8"
     "@size-limit/file" "7.0.8"
 
-"@stitches/react@^1.2.5", "@stitches/react@^1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.2.8.tgz#954f8008be8d9c65c4e58efa0937f32388ce3a38"
-  integrity sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==
+"@stitches/react@1.3.1-1":
+  version "1.3.1-1"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.3.1-1.tgz#d8fcbadd4ea06506117ddfcd5a583a598acc18d8"
+  integrity sha512-ErptbQehV25Da6LtZuM/51kGNK/UvlRY2da9IhhfXQ9h4bmf2f+lYFiJQ9j43O1kwYr6iYJIBRM47FEbsUWffw==
 
 "@tanstack/react-table@^8.5.11":
   version "8.5.11"


### PR DESCRIPTION
Updating `@stitches/react` to fix a number of issues with the library with later versions of Typescript.

@Mhoog and I have been through the wringer over the past few weeks trying to resolve some type issues with `@atom-learning/components` and `@stitches` in particular, resulting in this need to update `@stitches` to the latest published version (a beta).

I've written some of the steps that we went through to provide a bit of context, but it included a fair amount of trial and error testing, patching local versions of the packages, whilst also trying to resolve local TS issues with our codebase, so please let me know if you want any more detail on why we did certain things, but hopefully, we concluded with a relatively simple fix.

The initial issue we hit was with how `@stitches` accessed types from modules that weren't exported from the module

```
Exported variable "Variable" has or is using name 'Stitches' from external module
```

This was flagged sporadically across `styled()` and standard `Box`, `Flex`, etc. components, and we've also had this a couple of times in our own codebase. @Mhoog fixed this in https://github.com/Atom-Learning/components/pull/454

The next issue was types missing altogether from `@atom-learning/components` & `@stitches`, which required a change to TS module resolution `"node16"` to `"node"`, alongside an upgrade to TS itself. There are a whole heap of weird compatibility issues with the various ways that TS resolves modules and the requirements that it has with each condition to return the correct files. So TS needed an update and the type imports needed to include the relevant extension. This was fixed in this PR to `@stitches` https://github.com/stitchesjs/stitches/issues/1084

The final issue, now we'd upgraded to TS 4.9 was with `@stitches/react`s use of symbols. https://github.com/stitchesjs/stitches/pull/1082

```
TS4118: The type of this node cannot be serialized because its property '[$$PropertyValue]' cannot be serialized.
```

Thankfully that fix went into the beta release, so the only remaining issue was our use of `inset` as a key in our `@stitches` `utils` 🤷 

```
Type 'CSS | undefined' is not assignable to type 'CSS<{ sm: string; md: string; lg: string; xl: string; reducedMotion: string; allowMotion: string; hover: string; }, { col...
```

_For some reason_, in this updated version of `@stitches`, the key `inset` produced this TS error. I can only assume that somewhere in the update they've changed how custom utils and standard CSS properties overlap, and produce an error if any key in `utils` matches a standard CSS property. https://developer.mozilla.org/en-US/docs/Web/CSS/inset

We don't use `inset` too much in the codebase, and unfortunately, we can't use it natively until we drop Safari 12/13, so I have just removed the custom util and replaced it inline with `top: 0; right: 0; bottom: 0; left: 0`.

I've probably forgotten a few things to mention, but that's broadly how we got here.