### PR TITLE
fix: allow non-native fields used in react-hook-form to be controlled…

### DIFF
--- a/lib/src/components/checkbox-field/CheckboxField.tsx
+++ b/lib/src/components/checkbox-field/CheckboxField.tsx
@@ -22,7 +22,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   name,
   validation,
   description,
-  defaultChecked,
+  defaultChecked = false,
   checked,
   ...remainingProps
 }) => {

--- a/lib/src/components/checkbox-field/CheckboxField.tsx
+++ b/lib/src/components/checkbox-field/CheckboxField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { useController, useFormContext } from 'react-hook-form'
 
 import { Checkbox } from '~/components/checkbox'
 import {
@@ -18,43 +18,48 @@ enum CheckboxValue {
 
 export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   css,
-  defaultChecked = false,
   label,
   name,
   validation,
   description,
+  defaultChecked,
+  checked,
   ...remainingProps
 }) => {
   const { control } = useFormContext()
   const { error } = useFieldError(name)
+  const {
+    field: { ref, onChange, value: innerChecked, name: innerName }
+  } = useController({
+    name,
+    control,
+    rules: validation,
+    defaultValue: defaultChecked
+  })
+
+  React.useEffect(() => {
+    // Update the react-hook-form inner checked to match what is passed in.
+    if (typeof checked !== 'undefined') onChange(checked)
+  }, [checked])
 
   return (
-    <Controller
-      control={control}
-      name={name}
-      defaultValue={defaultChecked}
-      rules={validation}
-      render={({ onChange, value, name: innerName }) => (
-        <InlineFieldWrapper
-          css={css}
-          description={description}
-          error={error}
-          label={label}
-          required={Boolean(validation?.required)}
-        >
-          <Checkbox
-            defaultChecked={defaultChecked}
-            defaultValue={defaultChecked ? CheckboxValue.ON : CheckboxValue.OFF}
-            checked={value}
-            name={innerName}
-            onCheckedChange={onChange}
-            value={value ? CheckboxValue.ON : CheckboxValue.OFF}
-            {...(error && { state: 'error' })}
-            {...remainingProps}
-          />
-        </InlineFieldWrapper>
-      )}
-    />
+    <InlineFieldWrapper
+      css={css}
+      description={description}
+      error={error}
+      label={label}
+      required={Boolean(validation?.required)}
+    >
+      <Checkbox
+        ref={ref}
+        name={innerName}
+        {...remainingProps}
+        onCheckedChange={onChange}
+        value={innerChecked ? CheckboxValue.ON : CheckboxValue.OFF}
+        checked={innerChecked}
+        {...(error && { state: 'error' })}
+      />
+    </InlineFieldWrapper>
   )
 }
 

--- a/lib/src/components/radio-button-field/RadioButtonField.tsx
+++ b/lib/src/components/radio-button-field/RadioButtonField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { useController, useFormContext } from 'react-hook-form'
 
 import { FieldElementWrapperProps } from '~/components/field-wrapper'
 import { Description as FieldDescription } from '~/components/field-wrapper/FieldDescription'
@@ -25,6 +25,7 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
   css,
   direction = 'column',
   defaultValue,
+  value,
   description,
   label,
   name,
@@ -32,45 +33,53 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
   onValueChange,
   ...remainingProps
 }) => {
-    const { control } = useFormContext()
-    const { error } = useFieldError(name)
+  const { control } = useFormContext()
+  const {
+    field: { ref, onChange, value: innerValue, name: innerName }
+  } = useController({
+    name,
+    control,
+    rules: validation,
+    defaultValue
+  })
+  const { error } = useFieldError(name)
 
-    return (
-      <Fieldset css={css}>
-        <Label
-          as="legend"
-          css={{ p: 0, mb: '$3' }}
-          required={Boolean(validation?.required)}
-        >
-          {label}
-        </Label>
-        {description && (
-          <FieldDescription css={{ mb: '$3' }}>{description}</FieldDescription>
-        )}
-        <Controller
-          control={control}
-          name={name}
-          rules={validation}
-          defaultValue={defaultValue}
-          render={({ onChange, value }) => (
-            <RadioButtonGroup
-              direction={direction}
-              defaultValue={defaultValue}
-              onValueChange={(value) => {
-                onChange(value)
-                onValueChange?.(value)
-              }}
-              value={value}
-              {...remainingProps}
-            >
-              {children}
-            </RadioButtonGroup>
-          )}
-        />
-        {error && <InlineMessage css={{ mt: '$2' }}>{error}</InlineMessage>}
-      </Fieldset>
-    )
-  }
+  React.useEffect(() => {
+    // Update the react-hook-form inner value to match what is passed in.
+    if (typeof value !== 'undefined') onChange(value)
+  }, [value])
+
+  return (
+    <Fieldset css={css}>
+      <Label
+        as="legend"
+        css={{ p: 0, mb: '$3' }}
+        required={Boolean(validation?.required)}
+      >
+        {label}
+      </Label>
+      {description && (
+        <FieldDescription css={{ mb: '$3' }}>{description}</FieldDescription>
+      )}
+
+      <RadioButtonGroup
+        ref={ref}
+        direction={direction}
+        defaultValue={defaultValue}
+        onValueChange={(newValue) => {
+          onChange(newValue)
+          onValueChange?.(newValue)
+        }}
+        value={innerValue}
+        {...remainingProps}
+      >
+        {children}
+      </RadioButtonGroup>
+
+      {error && <InlineMessage css={{ mt: '$2' }}>{error}</InlineMessage>}
+    </Fieldset>
+  )
+}
 
 RadioButtonField.Item = RadioField
 

--- a/lib/src/components/slider-field/SliderField.tsx
+++ b/lib/src/components/slider-field/SliderField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { useController, useFormContext } from 'react-hook-form'
 
 import {
   FieldElementWrapperProps,
@@ -20,6 +20,8 @@ export const SliderField: React.FC<SliderFieldProps> = ({
   label,
   name,
   defaultValue,
+  value,
+  validation,
   outputLabel,
   min = 0,
   max = 100,
@@ -27,32 +29,35 @@ export const SliderField: React.FC<SliderFieldProps> = ({
   ...remainingProps
 }) => {
   const { control } = useFormContext()
+  const {
+    field: { ref, onChange, value: innerValue, name: innerName }
+  } = useController({
+    name,
+    control,
+    rules: validation,
+    defaultValue
+  })
+
+  React.useEffect(() => {
+    // Update the react-hook-form inner value to match what is passed in.
+    if (value?.length) onChange(value)
+  }, [JSON.stringify(value)])
 
   return (
     <FieldWrapper css={css} fieldId={name} label={label}>
-      <Controller
-        control={control}
-        name={name}
-        defaultValue={defaultValue}
-        render={({ onChange, value }) => (
-          <Slider
-            name={name}
-            defaultValue={defaultValue}
-            onValueChange={onChange}
-            value={value}
-            min={min}
-            max={max}
-            {...remainingProps}
-          >
-            <Slider.Steps min={min} max={max} steps={steps} />
+      <Slider
+        ref={ref}
+        name={innerName}
+        onValueChange={onChange}
+        value={innerValue}
+        min={min}
+        max={max}
+        {...remainingProps}
+      >
+        <Slider.Steps min={min} max={max} steps={steps} />
 
-            <Slider.Value
-              value={value || defaultValue}
-              outputLabel={outputLabel}
-            />
-          </Slider>
-        )}
-      />
+        <Slider.Value value={innerValue} outputLabel={outputLabel} />
+      </Slider>
     </FieldWrapper>
   )
 }

--- a/lib/src/components/slider/Slider.tsx
+++ b/lib/src/components/slider/Slider.tsx
@@ -67,40 +67,48 @@ const StyledThumb = styled(Thumb, {
 
 export type SliderProps = React.ComponentProps<typeof StyledSlider>
 
-export const Slider: React.FC<SliderProps> & {
+type SliderType = React.ForwardRefExoticComponent<SliderProps> & {
   Value: typeof SliderValue
   Steps: typeof SliderSteps
-} = ({
-  value,
-  defaultValue,
-  min = 0,
-  max = 100,
-  theme = 'tonal',
-  css,
-  children,
-  ...remainingProps
-}) => {
-  const values = value || defaultValue
-  return (
-    <CSSWrapper css={css}>
-      <StyledSlider
-        theme={theme}
-        defaultValue={defaultValue}
-        value={value}
-        min={min}
-        max={max}
-        {...remainingProps}
-      >
-        <StyledTrack>
-          <StyledRange />
-        </StyledTrack>
-        {values?.length &&
-          values.map((_, i) => <StyledThumb key={`thumb${i}`} />)}
-      </StyledSlider>
-      {children}
-    </CSSWrapper>
-  )
 }
+
+export const Slider: SliderType = React.forwardRef(
+  (
+    {
+      value,
+      defaultValue,
+      min = 0,
+      max = 100,
+      theme = 'tonal',
+      css,
+      children,
+      ...remainingProps
+    },
+    ref
+  ) => {
+    const values = value || defaultValue
+    return (
+      <CSSWrapper css={css}>
+        <StyledSlider
+          theme={theme}
+          defaultValue={defaultValue}
+          value={value}
+          min={min}
+          max={max}
+          ref={ref}
+          {...remainingProps}
+        >
+          <StyledTrack>
+            <StyledRange />
+          </StyledTrack>
+          {values?.length &&
+            values.map((_, i) => <StyledThumb key={`thumb${i}`} />)}
+        </StyledSlider>
+        {children}
+      </CSSWrapper>
+    )
+  }
+) as SliderType
 
 Slider.Value = SliderValue
 Slider.Steps = SliderSteps


### PR DESCRIPTION
… externally via props

**Follow up to this:** https://github.com/Atom-Learning/components/pull/462

The changes in the above PR were not enough. D: 

The component displayed as if it did have a controlled value set on it but the value was not _actually_ being registered in the form. 

This had to do with the fact these fields were non-native-html fields (radix) and had to be using the `Controller` from `react-hook-form` to register at all.  The `Controller` though seems to be handling anything relevant to value internally. For the value to register in the form the fields needed to be interacted with, manually, so that the `onChange` function would run internally in the `Controller`.

Which meant that when we were editing a form and not changing the field OR changing the values via something external the value was not updating in react-hook-form, validation wasn't passing and the form was not submitting.

To fix we need to tell the controller that the value has changed when it changes externally.

So, I did a bit of a refactor in the fields which use Controller to allow for this value to be controlled from outside as you'd expect. Hopefully bringing them to parity with the non-custom-component fields (which do not need to use `Controller`).

## Screenshots/Videos

**With this sandbox (notice highlight checked/value and NOT defaults):**
<img width="696" alt="Screenshot 2023-02-10 at 20 01 48" src="https://user-images.githubusercontent.com/6905473/218189080-1c24d430-2a64-4dfc-be6e-d349ea8027ab.png">

**before:**

https://user-images.githubusercontent.com/6905473/218189360-d98063f8-9070-4d30-b30c-41c816aa8cc6.mov



**after:**

https://user-images.githubusercontent.com/6905473/218189430-d6c0f977-49ad-47e5-9ef8-75972d727c94.mov




