### PR TITLE
feat: allow SearchInput to be both controlled and uncontrolled

### DIFF
--- a/lib/src/components/data-table/DataTableGlobalFilter.tsx
+++ b/lib/src/components/data-table/DataTableGlobalFilter.tsx
@@ -38,7 +38,7 @@ export const DataTableGlobalFilter: React.FC<DataTableSearchProps> = ({
       </OptionallyVisuallyHiddenContainer>
       <SearchInput
         {...props}
-        value={globalFilter}
+        defaultValue={globalFilter}
         onChange={handleChange}
         name={label}
       />

--- a/lib/src/components/search-input/SearchInput.test.tsx
+++ b/lib/src/components/search-input/SearchInput.test.tsx
@@ -11,21 +11,46 @@ describe('SearchInput component', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('renders clear button', async () => {
-    const { container } = render(<SearchInput value="testing" />)
-
+  it('renders clear button when non-empty defaultValue', async () => {
+    const { container } = render(
+      <SearchInput
+        defaultValue="testingWhenDefaultValue"
+        clearText="clearWhenDefaultValue"
+      />
+    )
     expect(container).toMatchSnapshot()
+
+    expect(
+      await screen.queryByDisplayValue('testingWhenDefaultValue')
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('clearWhenDefaultValue')).toBeInTheDocument()
+  })
+
+  it('renders clear button when non-empty value', async () => {
+    render(<SearchInput value="testingWhenValue" clearText="clearWhenValue" />)
+    expect(
+      await screen.queryByDisplayValue('testingWhenValue')
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('clearWhenValue')).toBeInTheDocument()
   })
 
   it('calls onChange with user input', async () => {
     const mockOnChange = jest.fn()
+    const mockOnValueChange = jest.fn()
 
-    render(<SearchInput placeholder="Search" onChange={mockOnChange} />)
+    render(
+      <SearchInput
+        placeholder="Search"
+        onChange={mockOnChange}
+        onValueChange={mockOnValueChange}
+      />
+    )
 
     const input = screen.getByPlaceholderText('Search')
-    fireEvent.change(input, { target: { value: '1' } })
+    fireEvent.change(input, { target: { value: 'newValue' } })
 
     expect(mockOnChange.mock.calls.length).toBe(1)
+    expect(mockOnValueChange).toHaveBeenCalledWith('newValue')
   })
 
   it('clears text on button click', async () => {
@@ -35,7 +60,7 @@ describe('SearchInput component', () => {
       fireEvent.click(screen.getByRole('button'))
     })
 
-    expect(await screen.queryByText('testing')).not.toBeInTheDocument()
+    expect(await screen.queryByDisplayValue('testing')).not.toBeInTheDocument()
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -12,6 +12,8 @@ export type SearchInputProps = React.ComponentProps<typeof Input> & {
   size?: 'sm' | 'md'
   css?: CSS
   value?: string
+  defaultValue?: string
+  onValueChange?: (newValue: string) => void
   clearText?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
@@ -54,6 +56,8 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
       size = 'md',
       css,
       value,
+      defaultValue = '',
+      onValueChange,
       clearText = 'Clear',
       onChange,
       ...remainingProps
@@ -61,12 +65,13 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
     ref
   ) => {
     const [inputElRef, setInputElRef] = useCallbackRef()
-    const [inputValue, setInputValue] = React.useState<string | number>(
-      value || ''
-    )
     const [activeIcon, setActiveIcon] = React.useState<INPUT_ICON>(
-      value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
+      defaultValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
     )
+    React.useEffect(() => {
+      if (typeof value !== 'undefined')
+        setActiveIcon(value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
+    }, [value])
 
     React.useImperativeHandle(ref, () => inputElRef.current as HTMLInputElement)
 
@@ -85,12 +90,15 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
       })
       inputEl.dispatchEvent(ev2)
       inputEl.focus()
+      onValueChange?.('')
     }
 
     const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      setInputValue(event.target.value)
-      setActiveIcon(event.target.value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
       onChange?.(event)
+
+      const newValue = event.target.value
+      onValueChange?.(newValue)
+      setActiveIcon(newValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
     }
 
     const getIcon = () => {
@@ -123,7 +131,7 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
           size={size}
           type="search"
           {...remainingProps}
-          value={inputValue}
+          value={value}
           onChange={handleOnChange}
           css={{ pr: size === 'sm' ? '$5' : '$6' }}
         />

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -65,12 +65,14 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
     ref
   ) => {
     const [inputElRef, setInputElRef] = useCallbackRef()
+    const [innerValue, setInnerValue] = React.useState(defaultValue)
     const [activeIcon, setActiveIcon] = React.useState<INPUT_ICON>(
       defaultValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
     )
     React.useEffect(() => {
-      if (typeof value !== 'undefined')
-        setActiveIcon(value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
+      if (typeof value === 'undefined') return
+      setInnerValue(value)
+      setActiveIcon(value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
     }, [value])
 
     React.useImperativeHandle(ref, () => inputElRef.current as HTMLInputElement)
@@ -97,6 +99,7 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
       onChange?.(event)
 
       const newValue = event.target.value
+      setInnerValue(newValue)
       onValueChange?.(newValue)
       setActiveIcon(newValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
     }
@@ -131,7 +134,7 @@ export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
           size={size}
           type="search"
           {...remainingProps}
-          value={value}
+          value={innerValue}
           onChange={handleOnChange}
           css={{ pr: size === 'sm' ? '$5' : '$6' }}
         />

--- a/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`SearchInput component renders 1`] = `
 </div>
 `;
 
-exports[`SearchInput component renders clear button 1`] = `
+exports[`SearchInput component renders clear button when non-empty defaultValue 1`] = `
 @media  {
   .c-fZTBsJ {
     -webkit-appearance: none;
@@ -268,10 +268,10 @@ exports[`SearchInput component renders clear button 1`] = `
     <input
       class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
       type="search"
-      value="testing"
+      value="testingWhenDefaultValue"
     />
     <button
-      aria-label="Clear"
+      aria-label="clearWhenDefaultValue"
       class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-otpKd-cv c-fDzwZw-ifWWfIb-css"
       type="button"
     >


### PR DESCRIPTION
**BREAKING CHANGE: will need to change all uses of `value` to `defaultValue` in core or use controlled version**

> SearchInput component is uncontrolled. The value prop only acts as defaultValue setting the initial state of inner component state and not being used after that.

This PR allow for use both with a defaultValue (uncontrolled) and value (controlled).

JIRA: https://atomlearningltd.atlassian.net/browse/DS-308

## Screenshots

**With this sandbox:**
<img width="783" alt="Screenshot 2023-02-12 at 19 29 07" src="https://user-images.githubusercontent.com/6905473/218332738-78cdfc68-cb04-4380-9ea3-1df1d246a626.png">

**before:**

https://user-images.githubusercontent.com/6905473/218333054-9badc578-a598-4cf0-99b7-6b7cb3e465d1.mov


**after:**

https://user-images.githubusercontent.com/6905473/218332838-67fa72c4-8dd3-44e6-9c7b-91a92011862a.mov


