### PR TITLE
Feat/control documentation via documentation content branch

### DIFF
--- a/.github/workflows/sync-from-documentation-to-main.yml
+++ b/.github/workflows/sync-from-documentation-to-main.yml
@@ -1,0 +1,49 @@
+name: Sync from documentation to main
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - documentation-content
+    paths:
+      - documentation/content/**
+      - documentation/public/admin/images/**
+
+jobs:
+  sync:
+    if: "startsWith(github.event.head_commit.message, '[NetlifyCMS]')"
+    name: Sync only the documentation content relevant folders from documentation-content into the main branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Get changed files excluding the docs
+        id: changed-files-excluded
+        uses: tj-actions/changed-files@v35
+        with:
+          base_sha: ${{ github.sha }}
+          files_ignore: |
+            documentation/content/**
+            documentation/public/admin/images/**
+
+      - name: Fail if files other than docs are changed
+        if: steps.changed-files-excluded.outputs.any_changed == 'true'
+        run: |
+          echo "Non-documentation files have been changed:"
+          for file in ${{ steps.changed-files-excluded.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
+          echo "This action is exiting as a safety feature! Revert files before trying again!"
+          exit 1
+
+      - uses: everlytic/branch-merge@1.1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_ref: "documentation-content"
+          target_branch: "main"
+          commit_message_template: "[Automated] Merged {source_ref} into target {target_branch}"

--- a/.github/workflows/sync-from-documentation-to-main.yml
+++ b/.github/workflows/sync-from-documentation-to-main.yml
@@ -1,7 +1,7 @@
 name: Sync from documentation to main
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -17,10 +17,9 @@ jobs:
     name: Sync only the documentation content relevant folders from documentation-content into the main branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           ref: main
-          fetch-depth: 0
 
       - name: Get changed files excluding the docs
         id: changed-files-excluded
@@ -41,7 +40,7 @@ jobs:
           echo "This action is exiting as a safety feature! Revert files before trying again!"
           exit 1
 
-      - uses: everlytic/branch-merge@1.1.2
+      - uses: everlytic/branch-merge@1.1.5
         with:
           github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
           source_ref: "documentation-content"

--- a/.github/workflows/sync-from-documentation-to-main.yml
+++ b/.github/workflows/sync-from-documentation-to-main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: everlytic/branch-merge@1.1.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
           source_ref: "documentation-content"
           target_branch: "main"
           commit_message_template: "[Automated] Merged {source_ref} into target {target_branch}"

--- a/.github/workflows/sync-from-main-to-documentation.yml
+++ b/.github/workflows/sync-from-main-to-documentation.yml
@@ -1,0 +1,22 @@
+name: Sync from main to documentation
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    name: Sync everything from main into the documentation-content branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: everlytic/branch-merge@1.1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_ref: "main"
+          target_branch: "documentation-content"
+          commit_message_template: "[Automated] Merged {source_ref} into target {target_branch}"

--- a/.github/workflows/sync-from-main-to-documentation.yml
+++ b/.github/workflows/sync-from-main-to-documentation.yml
@@ -1,7 +1,7 @@
 name: Sync from main to documentation
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -13,8 +13,8 @@ jobs:
     name: Sync everything from main into the documentation-content branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: everlytic/branch-merge@1.1.2
+      - uses: actions/checkout@v3
+      - uses: everlytic/branch-merge@1.1.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_ref: "main"

--- a/documentation/public/admin/config.yml
+++ b/documentation/public/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   repo: Atom-Learning/components
-  branch: main # Branch to update (optional; defaults to master)
+  branch: documentation-content # Branch to update (optional; defaults to master)
   base_url: https://atomlearning.design/ #Change to EXACT match for deployment url
   api_root: https://api.github.com # Shouldn't be necessary
   auth_endpoint: api/auth

--- a/documentation/public/admin/config.yml
+++ b/documentation/public/admin/config.yml
@@ -6,6 +6,14 @@ backend:
   api_root: https://api.github.com # Shouldn't be necessary
   auth_endpoint: api/auth
 
+  commit_messages:
+    create: "[NetlifyCMS] Create {{collection}} “{{slug}}”"
+    update: "[NetlifyCMS] Update {{collection}} “{{slug}}”"
+    delete: "[NetlifyCMS] Delete {{collection}} “{{slug}}”"
+    uploadMedia: "[NetlifyCMS] Upload “{{path}}”"
+    deleteMedia: "[NetlifyCMS] Delete “{{path}}”"
+    openAuthoring: "[NetlifyCMS] {{message}}"
+
 # local_backend: true
 
 media_folder: "documentation/public/admin/images" # Media files will be stored in the repo under images/uploads


### PR DESCRIPTION
## Problem:

Because now the CMS tries to commit changes to content directly to the main branch we get this error for users without direct write access to main (most of us).

![image](https://user-images.githubusercontent.com/6905473/220407756-a9eb58a3-1e61-4b8b-a425-16d42d81d93d.png)


## This PR attempts to fix this problem by:

1. Pointing NetlifyCMS to use another branch (`documentation-content`) to update documentation in. This other branch is not protected like `main` is so anything goes and anyone can directly commit to it.
2. When a commit is made to `documentation-content`  which matches the `[NetlifyCMS]` commit pattern and affects the 2 directories which I'd expect Netlify to be editing (content or admin uploaded images):
           * checkout main as bot
           * make sure there are no files changed outside the 2 documentation directories. IF THERE ARE: Stop action and throw error as this is unsafe to merge
           * If everything same, merge the branch back into main to update the documentation
1.  When a commit is made into `main`; merge main back into `documentation-content`.


**WARNING: The workflows have not been tested and AFAIK to test them we just need to do it live!** 
![image](https://media.tenor.com/qWlvQ17l6eIAAAAM/we-will-do-it-live-do-it-live.gif)


Any input very much appreciated as this is my first time writing github actions 👀 
