### PR TITLE
Feat/theme v1.2.0

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@atom-learning/components": "0.0.0-semantically-released",
     "@atom-learning/icons": "^1.14.0",
-    "@atom-learning/theme": "^1.1.0",
+    "@atom-learning/theme": "^1.2.0",
     "@lukeed/uuid": "^2.0.0",
     "netlify-cms-app": "^2.15.72",
     "next": "12.2.3",

--- a/lib/package.json
+++ b/lib/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@atom-learning/icons": "1.14.0",
     "@atom-learning/jest-stitches": "1.0.10",
-    "@atom-learning/theme": "1.1.1",
+    "@atom-learning/theme": "1.2.0",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@radix-ui/react-id": "0.1.5",
@@ -121,12 +121,12 @@
   },
   "peerDependencies": {
     "@atom-learning/icons": "^1.0.0",
-    "@atom-learning/theme": "^1.0.0",
+    "@atom-learning/theme": "^1.2.0",
     "react": "^17",
     "react-dom": "^17"
   },
   "dependencies": {
-    "@atom-learning/theme": "1.1.1",
+    "@atom-learning/theme": "1.2.0",
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/modifiers": "^6.0.0",
     "@dnd-kit/sortable": "^7.0.1",

--- a/lib/src/utilities/create-theme-variants/createThemeVariants.test.ts
+++ b/lib/src/utilities/create-theme-variants/createThemeVariants.test.ts
@@ -8,6 +8,7 @@ describe('createThemeVariants', () => {
       0: { p: '$space$0' },
       1: { p: '$space$1' },
       2: { p: '$space$2' },
+      24: { p: '$space$24' },
       3: { p: '$space$3' },
       4: { p: '$space$4' },
       5: { p: '$space$5' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,15 +28,10 @@
     chalk "^4.1.0"
     css "^3.0.0"
 
-"@atom-learning/theme@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-1.1.1.tgz#8944c731c6778d6881cf8c8a14dd76c3d1de219c"
-  integrity sha512-L3Fhd9rG+AWRqW6NFoVeriDcBjKpGpt1jwBMWt68kT7pnFBaOdAW/4cl5Kc5OJye9Z64mlR502XSBfMu2wCyCw==
-
-"@atom-learning/theme@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-1.1.0.tgz#dde9ea78393bba9b9fbce01107a9c36eedfa262f"
-  integrity sha512-Pz4VpmQy1OllkNpsT4bT7Fah7hANiooI/kkQJuIMTTHwwQ3JyNIadxpomGvz0Pqfjnk2RRZbjPFGkWhLymdOOg==
+"@atom-learning/theme@1.2.0", "@atom-learning/theme@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-1.2.0.tgz#311eb0246b7f4815d83e35f383590301498ecdb5"
+  integrity sha512-bkv+c5CRTWk9JhxPDzywpxAbsWZYcSbKFAxFHmkvBACG/A6Fy33yef823V75O7IQTzL5+1ssIFKXckbnNJ9Wzg==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"


### PR DESCRIPTION
Updates the `@atom-learning/theme` dependency to `v1.2.0`, which includes:
* New purple colour scale
* Updated internal naming for blue and grey scales
* Aliases to prevent the public API for the blue and grey scales from changing for now (this means no broken snapshots here!)
* Temporary `$24` space token to smooth the eventual process of adding a `24px` value in that scale