### PR TITLE
fix(fieldwrapper): allow prompt to have an onClick

### DIFF
--- a/lib/src/components/field-wrapper/FieldWrapper.test.tsx
+++ b/lib/src/components/field-wrapper/FieldWrapper.test.tsx
@@ -51,4 +51,26 @@ describe('FieldWrapper component', () => {
     expect(link).toHaveTextContent('Example prompt')
     expect(link).toHaveAttribute('href', 'https://example.com')
   })
+
+  it('links renders provided prompt with an onClick', async () => {
+    const promptClickMock = jest.fn()
+
+    render(
+      <FieldWrapper
+        label="Example Field"
+        fieldId="example"
+        error="Example error"
+        prompt={{ label: 'Example prompt', onClick: promptClickMock }}
+      >
+        <Input name="example" id="example" />
+      </FieldWrapper>
+    )
+    const button = await screen.findByRole('button')
+
+    expect(button).toHaveTextContent('Example prompt')
+
+    userEvent.click(button)
+
+    expect(promptClickMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/lib/src/components/field-wrapper/FieldWrapper.tsx
+++ b/lib/src/components/field-wrapper/FieldWrapper.tsx
@@ -16,7 +16,7 @@ export type FieldWrapperProps = {
   error?: string
   fieldId: string
   label: string
-  prompt?: { link: string; label: string }
+  prompt?: { link?: string; label: string; onClick?: () => void }
   description?: string
   required?: boolean
   hideLabel?: boolean
@@ -53,7 +53,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
           {label}
         </Label>
         {prompt && (
-          <Link href={prompt.link} size="sm">
+          <Link href={prompt.link} onClick={prompt.onClick} size="sm">
             {prompt.label}
           </Link>
         )}

--- a/lib/src/components/field-wrapper/FieldWrapper.tsx
+++ b/lib/src/components/field-wrapper/FieldWrapper.tsx
@@ -53,7 +53,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
           {label}
         </Label>
         {prompt && (
-          <Link href={prompt.link} onClick={prompt.onClick} size="sm">
+          <Link href={prompt?.link} onClick={prompt?.onClick} size="sm">
             {prompt.label}
           </Link>
         )}


### PR DESCRIPTION
This change allows the `FieldWrapper prompt` to have an `onClick` instead of just a link. This allows for the edge case where we need to trigger an action from the prompt that isn't a redirect.

The component looks exactly the same, and the prompt still will look like a link. 

This is needed to unblock https://atomlearningltd.atlassian.net/browse/FG-237.