### PR TITLE
Ds 73/add table xl size

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -7,4 +7,4 @@ The documentation itself is added via a NetlifyCMS website. You will need to log
 ## Working with documentation locally.
 
 You can also work with the documentation locally by installing this repo as seen in [the main `README.md`](https://github.com/Atom-Learning/components/tree/main#readme)
-This will a faster way to work and see changes but it will require opening a PR in the end and is not recommended for users not comfortable with working with `git`.
+This is a faster way to work and see changes but requires opening a PR in the end and is not recommended for users not comfortable with working with `git`.

--- a/documentation/content/components.content.table.md
+++ b/documentation/content/components.content.table.md
@@ -6,8 +6,8 @@ links:
   showReportAnIssue: true
 tabs:
   - content: >-
-      The `Table` component displays a collection of data grouped into rows.
-      Its structure mirrors that of a regular HTML table, with the
+      The `Table` component displays a collection of data grouped into rows. Its
+      structure mirrors that of a regular HTML table, with the
       smaller `Table.Body`, `Table.Cell`, `Table.Footer`, `Table.Header`, `Table.HeaderCell` and `Table
       Row` components corresponding to
       the `<tbody>`, `<td>`, `<tfoot>`, `<thead>`, `<th>` and `<tr>` tags,
@@ -106,30 +106,54 @@ tabs:
       ## Variants
 
 
-      The `Table` component has 2 size variants that control the row height. The two available sizes are `md`(default) and `lg` which should be used when the table needs to show more than just text, ie: `Button(s)` and `ActionIcon(s)`. The increased height helps keep the elements clickable on smaller screensizes.
+      The `Table` component has 3 size variants that control the row height and cells padding. The three available sizes are `md`(default), `lg` and `xl`.
 
 
-      <CodeBlock live={true} preview={true} code={`<Table size="lg" css={{ width: '500px', mt: '100px', ml: '100px' }}>
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>First Name</Table.HeaderCell>
-            <Table.HeaderCell>Last Name</Table.HeaderCell>
-            <Table.HeaderCell>Age</Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>Rakim</Table.Cell>
-            <Table.Cell>Jackson</Table.Cell>
-            <Table.Cell>35</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Evelyn</Table.Cell>
-            <Table.Cell>Smith</Table.Cell>
-            <Table.Cell>27</Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table>`} language={"tsx"} />
+      <CodeBlock live={true} preview={true} code={`<>
+        <Table size="lg" css={{ width: '500px', mt: '100px', ml: '100px' }}>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>First Name</Table.HeaderCell>
+              <Table.HeaderCell>Last Name</Table.HeaderCell>
+              <Table.HeaderCell>Age</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Rakim</Table.Cell>
+              <Table.Cell>Jackson</Table.Cell>
+              <Table.Cell>35</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Evelyn</Table.Cell>
+              <Table.Cell>Smith</Table.Cell>
+              <Table.Cell>27</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+
+        <Table size="xl" css={{ width: '500px', mt: '100px', ml: '100px' }}>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>First Name</Table.HeaderCell>
+              <Table.HeaderCell>Last Name</Table.HeaderCell>
+              <Table.HeaderCell>Age</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Rakim</Table.Cell>
+              <Table.Cell>Jackson</Table.Cell>
+              <Table.Cell>35</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Evelyn</Table.Cell>
+              <Table.Cell>Smith</Table.Cell>
+              <Table.Cell>27</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </>`} language={"tsx"} />
 
 
       The `Table` component by default renders with a slight border radius. If you want to remove this, for example if you are rendering the `Table` inside another component that has border radius, you can remove this by setting `corners="square"`. The default is `corners="round"`.

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -75,12 +75,11 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
@@ -89,18 +88,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     display: flex;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 
@@ -278,29 +276,30 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     width: 20px;
   }
 
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gzzGYN-theme-light .c-GSaiK {
+  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
     color: var(--colors-tonal600);
   }
@@ -429,7 +428,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     margin-bottom: var(--space-4);
   }
 
-  .c-GSaiK-ifYtQLP-css {
+  .c-jhJxGZ-ifYtQLP-css {
     cursor: initial;
   }
 
@@ -453,7 +452,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     margin-right: var(--space-4);
   }
 
-  .c-GSaiK-igsmDXe-css {
+  .c-jhJxGZ-igsmDXe-css {
     cursor: pointer;
   }
 
@@ -493,16 +492,16 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-iPJLV-css"
+    class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-iPJLV-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gzzGYN-theme-light"
+      class="c-PJLV c-PJLV-gJBDLb-theme-light"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -511,7 +510,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -520,7 +519,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -529,7 +528,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-ifYtQLP-css"
+          class="c-jhJxGZ c-jhJxGZ-ifYtQLP-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -547,7 +546,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -576,17 +575,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           1
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           chrissy
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -598,7 +597,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -627,17 +626,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           2
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           agatha
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -649,7 +648,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -678,17 +677,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           3
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           betty
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -700,7 +699,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -729,17 +728,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           4
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           denise
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -751,7 +750,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -780,17 +779,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           5
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           charlie
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -802,7 +801,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -831,17 +830,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           6
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           xena
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -853,7 +852,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -882,17 +881,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           7
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           rick
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -904,7 +903,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -933,17 +932,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           8
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           phillip
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -955,7 +954,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -984,17 +983,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           9
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           maurice
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1006,7 +1005,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1035,17 +1034,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           10
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           peter
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1057,7 +1056,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1086,17 +1085,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           11
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           velma
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1108,7 +1107,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1137,17 +1136,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           12
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           max
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1159,7 +1158,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1188,17 +1187,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           13
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           maxine
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1210,7 +1209,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1239,17 +1238,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           14
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           siobhan
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1261,7 +1260,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1290,17 +1289,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           15
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           nelly
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1312,7 +1311,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1341,17 +1340,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           16
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           kris
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1363,7 +1362,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1392,17 +1391,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           17
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           tony
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1414,7 +1413,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
         data-dragging="false"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button
             aria-describedby="DndDescribedBy-0"
@@ -1443,17 +1442,17 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           18
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           tina
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -1557,12 +1556,11 @@ exports[`DataTable component renders 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
@@ -1571,18 +1569,17 @@ exports[`DataTable component renders 1`] = `
     display: flex;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 
@@ -1746,29 +1743,30 @@ exports[`DataTable component renders 1`] = `
     width: 20px;
   }
 
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gzzGYN-theme-light .c-GSaiK {
+  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
     color: var(--colors-tonal600);
   }
@@ -1863,7 +1861,7 @@ exports[`DataTable component renders 1`] = `
     margin-bottom: var(--space-4);
   }
 
-  .c-GSaiK-ifYtQLP-css {
+  .c-jhJxGZ-ifYtQLP-css {
     cursor: initial;
   }
 
@@ -1887,7 +1885,7 @@ exports[`DataTable component renders 1`] = `
     margin-right: var(--space-4);
   }
 
-  .c-GSaiK-igsmDXe-css {
+  .c-jhJxGZ-igsmDXe-css {
     cursor: pointer;
   }
 }
@@ -1925,16 +1923,16 @@ exports[`DataTable component renders 1`] = `
     </svg>
   </div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-illIiIE-css"
+    class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-illIiIE-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gzzGYN-theme-light"
+      class="c-PJLV c-PJLV-gJBDLb-theme-light"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -1943,7 +1941,7 @@ exports[`DataTable component renders 1`] = `
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -1952,7 +1950,7 @@ exports[`DataTable component renders 1`] = `
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -1961,7 +1959,7 @@ exports[`DataTable component renders 1`] = `
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-ifYtQLP-css"
+          class="c-jhJxGZ c-jhJxGZ-ifYtQLP-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -1978,22 +1976,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           1
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           chrissy
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2004,22 +2002,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           2
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           agatha
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2030,22 +2028,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           3
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           betty
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2056,22 +2054,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           4
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           denise
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2082,22 +2080,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           5
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           charlie
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2108,22 +2106,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           6
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           xena
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2134,22 +2132,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           7
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           rick
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2160,22 +2158,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           8
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           phillip
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2186,22 +2184,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           9
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           maurice
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2212,22 +2210,22 @@ exports[`DataTable component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           10
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           peter
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2387,12 +2385,11 @@ exports[`DataTable server-side renders 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
@@ -2401,18 +2398,17 @@ exports[`DataTable server-side renders 1`] = `
     display: flex;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 
@@ -2620,29 +2616,30 @@ exports[`DataTable server-side renders 1`] = `
     width: 20px;
   }
 
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gzzGYN-theme-light .c-GSaiK {
+  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
     color: var(--colors-tonal600);
   }
@@ -2797,7 +2794,7 @@ exports[`DataTable server-side renders 1`] = `
     margin-bottom: var(--space-4);
   }
 
-  .c-GSaiK-ifYtQLP-css {
+  .c-jhJxGZ-ifYtQLP-css {
     cursor: initial;
   }
 
@@ -2821,7 +2818,7 @@ exports[`DataTable server-side renders 1`] = `
     margin-right: var(--space-4);
   }
 
-  .c-GSaiK-igsmDXe-css {
+  .c-jhJxGZ-igsmDXe-css {
     cursor: pointer;
   }
 
@@ -2890,16 +2887,16 @@ exports[`DataTable server-side renders 1`] = `
     </svg>
   </div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-illIiIE-css"
+    class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-illIiIE-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gzzGYN-theme-light"
+      class="c-PJLV c-PJLV-gJBDLb-theme-light"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -2908,7 +2905,7 @@ exports[`DataTable server-side renders 1`] = `
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -2917,7 +2914,7 @@ exports[`DataTable server-side renders 1`] = `
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-igsmDXe-css"
+          class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -2926,7 +2923,7 @@ exports[`DataTable server-side renders 1`] = `
           </div>
         </th>
         <th
-          class="c-GSaiK c-GSaiK-ifYtQLP-css"
+          class="c-jhJxGZ c-jhJxGZ-ifYtQLP-css"
         >
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -2943,22 +2940,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           1
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           chrissy
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2969,22 +2966,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           2
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           agatha
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -2995,22 +2992,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           3
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           betty
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3021,22 +3018,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           4
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           denise
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3047,22 +3044,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           5
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           charlie
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3073,22 +3070,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           6
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           xena
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3099,22 +3096,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           7
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           rick
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3125,22 +3122,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           8
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           phillip
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           crossfit
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3151,22 +3148,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           9
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           maurice
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           acting
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3177,22 +3174,22 @@ exports[`DataTable server-side renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           10
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           peter
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           bare-knuckle boxing
         </td>
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           <button>
             do something
@@ -3352,12 +3349,11 @@ exports[`DataTable sticky columns renders 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
@@ -3366,18 +3362,17 @@ exports[`DataTable sticky columns renders 1`] = `
     display: flex;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 
@@ -3602,29 +3597,30 @@ exports[`DataTable sticky columns renders 1`] = `
     width: 20px;
   }
 
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gzzGYN-theme-light .c-GSaiK {
+  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
     color: var(--colors-tonal600);
   }
@@ -3743,7 +3739,7 @@ exports[`DataTable sticky columns renders 1`] = `
     margin-bottom: var(--space-4);
   }
 
-  .c-GSaiK-ifYtQLP-css {
+  .c-jhJxGZ-ifYtQLP-css {
     cursor: initial;
   }
 
@@ -3767,7 +3763,7 @@ exports[`DataTable sticky columns renders 1`] = `
     margin-right: var(--space-4);
   }
 
-  .c-GSaiK-igsmDXe-css {
+  .c-jhJxGZ-igsmDXe-css {
     cursor: pointer;
   }
 
@@ -3839,16 +3835,16 @@ exports[`DataTable sticky columns renders 1`] = `
     role="scrollbar"
   >
     <table
-      class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-iPJLV-css"
+      class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-iPJLV-css"
     >
       <thead
-        class="c-PJLV c-PJLV-gzzGYN-theme-light"
+        class="c-PJLV c-PJLV-gJBDLb-theme-light"
       >
         <tr
           class="c-hjAYDb"
         >
           <th
-            class="c-GSaiK c-GSaiK-igsmDXe-css"
+            class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
           >
             <div
               class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -3857,7 +3853,7 @@ exports[`DataTable sticky columns renders 1`] = `
             </div>
           </th>
           <th
-            class="c-GSaiK c-GSaiK-igsmDXe-css"
+            class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
           >
             <div
               class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -3866,7 +3862,7 @@ exports[`DataTable sticky columns renders 1`] = `
             </div>
           </th>
           <th
-            class="c-GSaiK c-GSaiK-igsmDXe-css"
+            class="c-jhJxGZ c-jhJxGZ-igsmDXe-css"
           >
             <div
               class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -3875,7 +3871,7 @@ exports[`DataTable sticky columns renders 1`] = `
             </div>
           </th>
           <th
-            class="c-GSaiK c-GSaiK-ifYtQLP-css"
+            class="c-jhJxGZ c-jhJxGZ-ifYtQLP-css"
           >
             <div
               class="c-dhzjXW c-dhzjXW-ijroWjL-css"
@@ -3892,22 +3888,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             1
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             chrissy
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             bare-knuckle boxing
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -3918,22 +3914,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             2
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             agatha
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             crossfit
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -3944,22 +3940,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             3
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             betty
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             acting
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -3970,22 +3966,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             4
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             denise
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             bare-knuckle boxing
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -3996,22 +3992,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             5
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             charlie
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             crossfit
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4022,22 +4018,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             6
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             xena
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             acting
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4048,22 +4044,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             7
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             rick
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             bare-knuckle boxing
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4074,22 +4070,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             8
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             phillip
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             crossfit
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4100,22 +4096,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             9
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             maurice
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             acting
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4126,22 +4122,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             10
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             peter
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             bare-knuckle boxing
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4152,22 +4148,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             11
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             velma
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             crossfit
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4178,22 +4174,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             12
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             max
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             acting
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4204,22 +4200,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             13
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             maxine
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             bare-knuckle boxing
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4230,22 +4226,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             14
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             siobhan
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             crossfit
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4256,22 +4252,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             15
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             nelly
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             acting
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4282,22 +4278,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             16
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             kris
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             bare-knuckle boxing
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4308,22 +4304,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             17
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             tony
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             crossfit
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something
@@ -4334,22 +4330,22 @@ exports[`DataTable sticky columns renders 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             18
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             tina
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             acting
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             <button>
               do something

--- a/lib/src/components/table/Table.test.tsx
+++ b/lib/src/components/table/Table.test.tsx
@@ -51,29 +51,6 @@ describe(`Table component`, () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('renders with size set to xl', async () => {
-    const { container } = await render(
-      <Table size="xl" css={{ height: '100px', width: '400px' }}>
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>Column A</Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>This is text</Table.Cell>
-          </Table.Row>
-        </Table.Body>
-        <Table.Footer>
-          <Table.Row>
-            <Table.Cell>Footer 1</Table.Cell>
-          </Table.Row>
-        </Table.Footer>
-      </Table>
-    )
-    expect(container).toMatchSnapshot()
-  })
-
   it('renders with square corners', async () => {
     const { container } = await render(
       <Table corners="square" css={{ height: '100px', width: '400px' }}>

--- a/lib/src/components/table/Table.test.tsx
+++ b/lib/src/components/table/Table.test.tsx
@@ -51,6 +51,29 @@ describe(`Table component`, () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders with size set to xl', async () => {
+    const { container } = await render(
+      <Table size="xl" css={{ height: '100px', width: '400px' }}>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Column A</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>This is text</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer>
+          <Table.Row>
+            <Table.Cell>Footer 1</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
   it('renders with square corners', async () => {
     const { container } = await render(
       <Table corners="square" css={{ height: '100px', width: '400px' }}>

--- a/lib/src/components/table/Table.tsx
+++ b/lib/src/components/table/Table.tsx
@@ -32,12 +32,20 @@ const StyledTable = styled('table', {
     size: {
       md: {
         [`${TableCell}, ${TableHeaderCell}, ${TableFooterCell}`]: {
-          height: '$4'
+          height: '$4',
+          padding: '$1 $3'
         }
       },
       lg: {
         [`${TableCell}, ${TableHeaderCell}, ${TableFooterCell}`]: {
-          height: '$5'
+          height: '$5',
+          padding: '$2 $3'
+        }
+      },
+      xl: {
+        [`${TableCell}, ${TableHeaderCell}, ${TableFooterCell}`]: {
+          height: '$6',
+          padding: '$4 $3'
         }
       }
     },

--- a/lib/src/components/table/TableCell.tsx
+++ b/lib/src/components/table/TableCell.tsx
@@ -6,7 +6,6 @@ export const TableCell = styled('td', {
   color: '$tonal400',
   fontFamily: '$body',
   lineHeight: 1.5,
-  p: '$2 $3',
   textAlign: 'left',
   verticalAlign: 'middle',
   '&:first-child': { fontWeight: 'bold' }

--- a/lib/src/components/table/TableFooterCell.tsx
+++ b/lib/src/components/table/TableFooterCell.tsx
@@ -4,7 +4,6 @@ export const TableFooterCell = styled('td', {
   color: '$tonal400',
   fontFamily: '$body',
   fontWeight: 600,
-  p: '$2 $3',
   textAlign: 'left',
   verticalAlign: 'middle'
 })

--- a/lib/src/components/table/TableHeaderCell.tsx
+++ b/lib/src/components/table/TableHeaderCell.tsx
@@ -5,7 +5,6 @@ export const TableHeaderCell = styled('th', {
   fontFamily: '$body',
   fontWeight: 600,
   lineHeight: 1.5,
-  p: '$2 $3',
   textAlign: 'left',
   verticalAlign: 'middle'
 })

--- a/lib/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/lib/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -14,56 +14,55 @@ exports[`Table component renders 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 }
 
 @media  {
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
+  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
     background: var(--colors-primaryDark);
   }
 
@@ -85,16 +84,16 @@ exports[`Table component renders 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
+      class="c-PJLV c-PJLV-bzJeMb-theme-primaryDark"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK"
+          class="c-jhJxGZ"
         >
           Column A
         </th>
@@ -107,7 +106,7 @@ exports[`Table component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           This is text
         </td>
@@ -120,7 +119,7 @@ exports[`Table component renders 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           Footer 1
         </td>
@@ -144,56 +143,55 @@ exports[`Table component renders with a themed header 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 }
 
 @media  {
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
+  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
     background: var(--colors-primaryDark);
   }
 
@@ -205,13 +203,14 @@ exports[`Table component renders with a themed header 1`] = `
     background: var(--colors-tonal50);
   }
 
-  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
-  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
-  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
+  .c-cwQMhQ-jzCEki-size-lg .c-ihQtuj,
+  .c-cwQMhQ-jzCEki-size-lg .c-jhJxGZ,
+  .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
+    padding: var(--space-2) var(--space-3);
   }
 
-  .c-PJLV-gmYsCp-theme-primary .c-GSaiK {
+  .c-PJLV-jSYITb-theme-primary .c-jhJxGZ {
     background: var(--colors-primary);
   }
 }
@@ -225,16 +224,16 @@ exports[`Table component renders with a themed header 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gmYsCp-theme-primary"
+      class="c-PJLV c-PJLV-jSYITb-theme-primary"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK"
+          class="c-jhJxGZ"
         >
           Column A
         </th>
@@ -247,7 +246,7 @@ exports[`Table component renders with a themed header 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           This is text
         </td>
@@ -260,7 +259,7 @@ exports[`Table component renders with a themed header 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           Footer 1
         </td>
@@ -284,56 +283,55 @@ exports[`Table component renders with size set to lg 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 }
 
 @media  {
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
+  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
     background: var(--colors-primaryDark);
   }
 
@@ -345,10 +343,11 @@ exports[`Table component renders with size set to lg 1`] = `
     background: var(--colors-tonal50);
   }
 
-  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
-  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
-  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
+  .c-cwQMhQ-jzCEki-size-lg .c-ihQtuj,
+  .c-cwQMhQ-jzCEki-size-lg .c-jhJxGZ,
+  .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
+    padding: var(--space-2) var(--space-3);
   }
 }
 
@@ -361,16 +360,16 @@ exports[`Table component renders with size set to lg 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-goJwcl-size-lg c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-jzCEki-size-lg c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
+      class="c-PJLV c-PJLV-bzJeMb-theme-primaryDark"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK"
+          class="c-jhJxGZ"
         >
           Column A
         </th>
@@ -383,7 +382,7 @@ exports[`Table component renders with size set to lg 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           This is text
         </td>
@@ -396,7 +395,7 @@ exports[`Table component renders with size set to lg 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           Footer 1
         </td>
@@ -420,56 +419,55 @@ exports[`Table component renders with square corners 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 }
 
 @media  {
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
+  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
     background: var(--colors-primaryDark);
   }
 
@@ -481,10 +479,11 @@ exports[`Table component renders with square corners 1`] = `
     background: var(--colors-tonal50);
   }
 
-  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
-  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
-  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
+  .c-cwQMhQ-jzCEki-size-lg .c-ihQtuj,
+  .c-cwQMhQ-jzCEki-size-lg .c-jhJxGZ,
+  .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
+    padding: var(--space-2) var(--space-3);
   }
 }
 
@@ -497,16 +496,16 @@ exports[`Table component renders with square corners 1`] = `
 
 <div>
   <table
-    class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-icnGIKd-css"
+    class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-icnGIKd-css"
   >
     <thead
-      class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
+      class="c-PJLV c-PJLV-bzJeMb-theme-primaryDark"
     >
       <tr
         class="c-hjAYDb"
       >
         <th
-          class="c-GSaiK"
+          class="c-jhJxGZ"
         >
           Column A
         </th>
@@ -519,7 +518,7 @@ exports[`Table component renders with square corners 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           This is text
         </td>
@@ -532,7 +531,7 @@ exports[`Table component renders with square corners 1`] = `
         class="c-hjAYDb"
       >
         <td
-          class="c-cCZzXk"
+          class="c-ihQtuj"
         >
           Footer 1
         </td>
@@ -556,56 +555,55 @@ exports[`Table component renders with sticky columns 1`] = `
     background: unset;
   }
 
-  .c-GSaiK {
+  .c-jhJxGZ {
     color: white;
     font-family: var(--fonts-body);
     font-weight: 600;
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk {
+  .c-ihQtuj {
     border-bottom: 1px solid var(--colors-tonal100);
     box-sizing: border-box;
     color: var(--colors-tonal400);
     font-family: var(--fonts-body);
     line-height: 1.5;
-    padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: middle;
   }
 
-  .c-cCZzXk:first-child {
+  .c-ihQtuj:first-child {
     font-weight: bold;
   }
 }
 
 @media  {
-  .c-cwQMhQ-gWDrUk-size-md .c-cCZzXk,
-  .c-cwQMhQ-gWDrUk-size-md .c-GSaiK,
-  .c-cwQMhQ-gWDrUk-size-md .c-hYjVQ {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
     height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:first-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
     border-top-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-GSaiK:last-of-type {
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
     border-top-right-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:first-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
     border-bottom-left-radius: var(--radii-0);
   }
 
-  .c-cwQMhQ-fofZjp-corners-round .c-hjAYDb:last-child .c-cCZzXk:last-child {
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-jEDwTF-theme-primaryDark .c-GSaiK {
+  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
     background: var(--colors-primaryDark);
   }
 
@@ -617,13 +615,14 @@ exports[`Table component renders with sticky columns 1`] = `
     background: var(--colors-tonal50);
   }
 
-  .c-cwQMhQ-goJwcl-size-lg .c-cCZzXk,
-  .c-cwQMhQ-goJwcl-size-lg .c-GSaiK,
-  .c-cwQMhQ-goJwcl-size-lg .c-hYjVQ {
+  .c-cwQMhQ-jzCEki-size-lg .c-ihQtuj,
+  .c-cwQMhQ-jzCEki-size-lg .c-jhJxGZ,
+  .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
+    padding: var(--space-2) var(--space-3);
   }
 
-  .c-PJLV-gmYsCp-theme-primary .c-GSaiK {
+  .c-PJLV-jSYITb-theme-primary .c-jhJxGZ {
     background: var(--colors-primary);
   }
 }
@@ -672,27 +671,27 @@ exports[`Table component renders with sticky columns 1`] = `
     role="scrollbar"
   >
     <table
-      class="c-cwQMhQ c-cwQMhQ-gWDrUk-size-md c-cwQMhQ-fofZjp-corners-round c-cwQMhQ-idVpojG-css"
+      class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-idVpojG-css"
     >
       <thead
-        class="c-PJLV c-PJLV-jEDwTF-theme-primaryDark"
+        class="c-PJLV c-PJLV-bzJeMb-theme-primaryDark"
         numberofstickycolumns="1"
       >
         <tr
           class="c-hjAYDb"
         >
           <th
-            class="c-GSaiK"
+            class="c-jhJxGZ"
           >
             Column A
           </th>
           <th
-            class="c-GSaiK"
+            class="c-jhJxGZ"
           >
             Column B
           </th>
           <th
-            class="c-GSaiK"
+            class="c-jhJxGZ"
           >
             Column C
           </th>
@@ -706,17 +705,17 @@ exports[`Table component renders with sticky columns 1`] = `
           class="c-hjAYDb"
         >
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             This is text
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             This is text
           </td>
           <td
-            class="c-cCZzXk"
+            class="c-ihQtuj"
           >
             This is text
           </td>

--- a/lib/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/lib/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -210,13 +210,6 @@ exports[`Table component renders with a themed header 1`] = `
     padding: var(--space-2) var(--space-3);
   }
 
-  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
-    height: var(--sizes-6);
-    padding: var(--space-4) var(--space-3);
-  }
-
   .c-PJLV-jSYITb-theme-primary .c-jhJxGZ {
     background: var(--colors-primary);
   }
@@ -412,149 +405,6 @@ exports[`Table component renders with size set to lg 1`] = `
 </div>
 `;
 
-exports[`Table component renders with size set to xl 1`] = `
-@media  {
-  .c-cwQMhQ {
-    border-collapse: separate;
-    border-spacing: 0;
-    font-family: var(--fonts-sans);
-    font-size: var(--fontSizes-sm);
-    width: 100%;
-  }
-
-  .c-hjAYDb {
-    background: unset;
-  }
-
-  .c-jhJxGZ {
-    color: white;
-    font-family: var(--fonts-body);
-    font-weight: 600;
-    line-height: 1.5;
-    text-align: left;
-    vertical-align: middle;
-  }
-
-  .c-ihQtuj {
-    border-bottom: 1px solid var(--colors-tonal100);
-    box-sizing: border-box;
-    color: var(--colors-tonal400);
-    font-family: var(--fonts-body);
-    line-height: 1.5;
-    text-align: left;
-    vertical-align: middle;
-  }
-
-  .c-ihQtuj:first-child {
-    font-weight: bold;
-  }
-}
-
-@media  {
-  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
-  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
-  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
-    height: var(--sizes-4);
-    padding: var(--space-1) var(--space-3);
-  }
-
-  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
-    border-top-left-radius: var(--radii-0);
-  }
-
-  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
-    border-top-right-radius: var(--radii-0);
-  }
-
-  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
-    border-bottom-left-radius: var(--radii-0);
-  }
-
-  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
-    border-bottom-right-radius: var(--radii-0);
-  }
-
-  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
-    background: var(--colors-primaryDark);
-  }
-
-  .c-PJLV-gdcSSw-striped-true .c-hjAYDb:nth-child(odd) {
-    background: white;
-  }
-
-  .c-PJLV-gdcSSw-striped-true .c-hjAYDb:nth-child(even) {
-    background: var(--colors-tonal50);
-  }
-
-  .c-cwQMhQ-jzCEki-size-lg .c-ihQtuj,
-  .c-cwQMhQ-jzCEki-size-lg .c-jhJxGZ,
-  .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
-    height: var(--sizes-5);
-    padding: var(--space-2) var(--space-3);
-  }
-
-  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
-    height: var(--sizes-6);
-    padding: var(--space-4) var(--space-3);
-  }
-}
-
-@media  {
-  .c-cwQMhQ-icnGIKd-css {
-    height: 100px;
-    width: 400px;
-  }
-}
-
-<div>
-  <table
-    class="c-cwQMhQ c-cwQMhQ-dWxbfb-size-xl c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-icnGIKd-css"
-  >
-    <thead
-      class="c-PJLV c-PJLV-bzJeMb-theme-primaryDark"
-    >
-      <tr
-        class="c-hjAYDb"
-      >
-        <th
-          class="c-jhJxGZ"
-        >
-          Column A
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c-PJLV c-PJLV-gdcSSw-striped-true"
-    >
-      <tr
-        class="c-hjAYDb"
-      >
-        <td
-          class="c-ihQtuj"
-        >
-          This is text
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class="c-PJLV"
-    >
-      <tr
-        class="c-hjAYDb"
-      >
-        <td
-          class="c-ihQtuj"
-        >
-          Footer 1
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-</div>
-`;
-
 exports[`Table component renders with square corners 1`] = `
 @media  {
   .c-cwQMhQ {
@@ -634,13 +484,6 @@ exports[`Table component renders with square corners 1`] = `
   .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
     padding: var(--space-2) var(--space-3);
-  }
-
-  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
-    height: var(--sizes-6);
-    padding: var(--space-4) var(--space-3);
   }
 }
 
@@ -777,13 +620,6 @@ exports[`Table component renders with sticky columns 1`] = `
   .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
     padding: var(--space-2) var(--space-3);
-  }
-
-  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
-  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
-    height: var(--sizes-6);
-    padding: var(--space-4) var(--space-3);
   }
 
   .c-PJLV-jSYITb-theme-primary .c-jhJxGZ {

--- a/lib/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/lib/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -210,6 +210,13 @@ exports[`Table component renders with a themed header 1`] = `
     padding: var(--space-2) var(--space-3);
   }
 
+  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
+    height: var(--sizes-6);
+    padding: var(--space-4) var(--space-3);
+  }
+
   .c-PJLV-jSYITb-theme-primary .c-jhJxGZ {
     background: var(--colors-primary);
   }
@@ -405,6 +412,149 @@ exports[`Table component renders with size set to lg 1`] = `
 </div>
 `;
 
+exports[`Table component renders with size set to xl 1`] = `
+@media  {
+  .c-cwQMhQ {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-family: var(--fonts-sans);
+    font-size: var(--fontSizes-sm);
+    width: 100%;
+  }
+
+  .c-hjAYDb {
+    background: unset;
+  }
+
+  .c-jhJxGZ {
+    color: white;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    line-height: 1.5;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-ihQtuj {
+    border-bottom: 1px solid var(--colors-tonal100);
+    box-sizing: border-box;
+    color: var(--colors-tonal400);
+    font-family: var(--fonts-body);
+    line-height: 1.5;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-ihQtuj:first-child {
+    font-weight: bold;
+  }
+}
+
+@media  {
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
+    height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-PJLV-bzJeMb-theme-primaryDark .c-jhJxGZ {
+    background: var(--colors-primaryDark);
+  }
+
+  .c-PJLV-gdcSSw-striped-true .c-hjAYDb:nth-child(odd) {
+    background: white;
+  }
+
+  .c-PJLV-gdcSSw-striped-true .c-hjAYDb:nth-child(even) {
+    background: var(--colors-tonal50);
+  }
+
+  .c-cwQMhQ-jzCEki-size-lg .c-ihQtuj,
+  .c-cwQMhQ-jzCEki-size-lg .c-jhJxGZ,
+  .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
+    height: var(--sizes-5);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
+    height: var(--sizes-6);
+    padding: var(--space-4) var(--space-3);
+  }
+}
+
+@media  {
+  .c-cwQMhQ-icnGIKd-css {
+    height: 100px;
+    width: 400px;
+  }
+}
+
+<div>
+  <table
+    class="c-cwQMhQ c-cwQMhQ-dWxbfb-size-xl c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-icnGIKd-css"
+  >
+    <thead
+      class="c-PJLV c-PJLV-bzJeMb-theme-primaryDark"
+    >
+      <tr
+        class="c-hjAYDb"
+      >
+        <th
+          class="c-jhJxGZ"
+        >
+          Column A
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c-PJLV c-PJLV-gdcSSw-striped-true"
+    >
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-ihQtuj"
+        >
+          This is text
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class="c-PJLV"
+    >
+      <tr
+        class="c-hjAYDb"
+      >
+        <td
+          class="c-ihQtuj"
+        >
+          Footer 1
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;
+
 exports[`Table component renders with square corners 1`] = `
 @media  {
   .c-cwQMhQ {
@@ -484,6 +634,13 @@ exports[`Table component renders with square corners 1`] = `
   .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
     padding: var(--space-2) var(--space-3);
+  }
+
+  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
+    height: var(--sizes-6);
+    padding: var(--space-4) var(--space-3);
   }
 }
 
@@ -620,6 +777,13 @@ exports[`Table component renders with sticky columns 1`] = `
   .c-cwQMhQ-jzCEki-size-lg .c-jwhJBv {
     height: var(--sizes-5);
     padding: var(--space-2) var(--space-3);
+  }
+
+  .c-cwQMhQ-dWxbfb-size-xl .c-ihQtuj,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jhJxGZ,
+  .c-cwQMhQ-dWxbfb-size-xl .c-jwhJBv {
+    height: var(--sizes-6);
+    padding: var(--space-4) var(--space-3);
   }
 
   .c-PJLV-jSYITb-theme-primary .c-jhJxGZ {


### PR DESCRIPTION
JIRA ticket

The `xl` size is a bit bigger than the `lg`. Initially, we were going to call it `lg` and move the 2 existing sizes (`md` and `lg`) 1 level down. But we did it this way to be the least disruptive possible to the current usages.

This PR also makes the vertical padding depending on the `size`. Otherwise, tables with different sizes could actually look the same, as the row height which is the only thing the size was affecting is just a minimum, it can grow with taller content.

![image](https://user-images.githubusercontent.com/4931116/223771304-68713cba-6ba1-49cd-83c5-54924714921c.png)
