### PR TITLE
feat: enable editorial workflow

### DIFF
--- a/documentation/public/admin/config.yml
+++ b/documentation/public/admin/config.yml
@@ -14,6 +14,8 @@ backend:
     deleteMedia: "[NetlifyCMS] Delete “{{path}}”"
     openAuthoring: "[NetlifyCMS] {{message}}"
 
+publish_mode: editorial_workflow
+
 # local_backend: true
 
 media_folder: "documentation/public/admin/images" # Media files will be stored in the repo under images/uploads


### PR DESCRIPTION
Enables the `publish_mode: editorial_workflow` in the CMS, [as described here](https://decapcms.org/docs/add-to-your-site/#editorial-workflow).

Totally empty Jira ticket: https://atomlearningltd.atlassian.net/browse/DS-337

This allows us to draft content without publishing it. Draft content will be opened as a PR against the `documentation-content` branch. Approving a draft in the CMS will merge that PR. The existing GitHub Actions workflows should handle the rest, syncing `main` with the update to `documentation-content`, triggering a new deployment on Digital Ocean.

Note: as far as I can tell, there's no way to test this locally, since the CMS running on my machine can't authenticate with GitHub and if I switch to `local_backend` then there's nothing to PR against. So we'll have to test this in Prod. That said, I can confirm that enabling `editorial_workflow` doesn't affect the existing local dev experience.