### PR TITLE
fix: typescript errors to make build:docs happy again

### DIFF
--- a/documentation/components/markdown/editor-component/DosAndDonts.tsx
+++ b/documentation/components/markdown/editor-component/DosAndDonts.tsx
@@ -27,7 +27,7 @@ const DosAndDontsItem: React.FC<TDosAndDontsItemProps> = ({ image, type, descrip
         // Box-sizing can't be used as anything other than `border-box` as we need it to include paddings.
         aspectRatio: "332/192",
       }}>
-        <Image src={image} />
+        <Image src={image} alt="" />
       </Box>
       <Heading as="h3" size="xs" css={{ mb: '$3' }}>{typeText}</Heading>
       <Text>{description}</Text>
@@ -51,7 +51,7 @@ export const DosAndDonts: React.FC<DosAndDontsProps> = ({ items }) => {
         gridTemplateColumns: '1fr',
         '@sm': { gridTemplateColumns: '1fr 1fr' },
       }}>
-      {items.map((props) => <DosAndDontsItem {...props} />)}
+      {items.map((props) => <DosAndDontsItem key={props.description} {...props} />)}
     </Grid>
   )
 }

--- a/lib/src/components/grid/Grid.tsx
+++ b/lib/src/components/grid/Grid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { styled } from '~/stitches'
+import { CSS, styled } from '~/stitches'
 import { createThemeVariants } from '~/utilities'
 
 const GridContainer = styled('div', {
@@ -13,7 +13,10 @@ const GridContainer = styled('div', {
 type GridProps = React.ComponentProps<typeof GridContainer> & {
   minItemSize?: string
   maxItemSize?: string
-}
+} & {
+  css?: CSS
+  as?: any
+} // (!) `css` and `as` are both props that come from `stitches`. It would be better to figure out and export the appropriate type for them in stitches!
 
 export const Grid: React.FC<GridProps> = ({
   css,


### PR DESCRIPTION
Self explanatory.

Had to specify `as` for Grid as typescript was throwing - copied exactly how Stack does it.