### PR TITLE
feat: add emptystate to DataTable

### DIFF
--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -12,6 +12,7 @@ import { Button } from '../button'
 import { Text } from '../text'
 import { Tooltip } from '../tooltip'
 import { DataTable } from '.'
+import { EmptyState } from '../empty-state'
 
 const columnHelper = createColumnHelper<{
   id: number
@@ -134,6 +135,24 @@ describe('DataTable component', () => {
 })
 
 describe('DataTable.Pagination component', () => {
+  it("doesn't render if table is empty", () => {
+    render(
+      <Wrapper>
+        <DataTable
+          columns={columns}
+          data={[]}
+          initialState={{ pagination: { pageIndex: 0, pageSize: 5 } }}
+        >
+          <DataTable.Table sortable />
+          <DataTable.Pagination />
+        </DataTable>
+      </Wrapper>
+    )
+
+    const nextPageButton = screen.queryByLabelText('Next page')
+    expect(nextPageButton).not.toBeInTheDocument()
+  })
+
   it('Displays the correct page number', async () => {
     render(
       <Wrapper>
@@ -221,7 +240,21 @@ describe('DataTable.Pagination component', () => {
   })
 })
 
-describe('DataTable Search component', () => {
+describe('DataTable GlobalFilter component', () => {
+  it("doesn't render if data is empty", () => {
+    render(
+      <Wrapper>
+        <DataTable columns={columns} data={[]}>
+          <DataTable.GlobalFilter label="Search" />
+          <DataTable.Table sortable />
+        </DataTable>
+      </Wrapper>
+    )
+
+    const nextPageButton = screen.queryByLabelText('Next page')
+    expect(nextPageButton).not.toBeInTheDocument()
+  })
+
   it('Filters table based on any column', async () => {
     render(
       <Wrapper>
@@ -620,6 +653,26 @@ describe('DataTable sticky columns', () => {
       <Wrapper>
         <DataTable columns={columns} data={data}>
           <DataTable.Table numberOfStickyColumns={1} />
+        </DataTable>
+      </Wrapper>
+    )
+    expect(container).toMatchSnapshot()
+  })
+})
+
+describe('DataTable EmptyState', () => {
+  it('renders custom empty state', () => {
+    const { container } = render(
+      <Wrapper>
+        <DataTable columns={columns} data={[]}>
+          <DataTable.GlobalFilter label="User search" css={{ mb: '$4' }} />
+          <DataTable.Table sortable css={{ mb: '$4' }} />
+          <DataTable.EmptyState>
+            <EmptyState.Title>No data available</EmptyState.Title>
+            <EmptyState.Body>Something is missing</EmptyState.Body>
+            <Button>Click here</Button>
+          </DataTable.EmptyState>
+          <DataTable.Pagination />
         </DataTable>
       </Wrapper>
     )

--- a/lib/src/components/data-table/DataTable.tsx
+++ b/lib/src/components/data-table/DataTable.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { DataTableBody } from './DataTableBody'
 import { DataTableProvider } from './DataTableContext'
 import { DataTableDataCell } from './DataTableDataCell'
+import { DataTableEmptyState } from './DataTableEmptyState'
 import { DataTableError } from './DataTableError'
 import { DataTableGlobalFilter } from './DataTableGlobalFilter'
 import { DataTableHead } from './DataTableHead'
@@ -99,6 +100,12 @@ type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
    *
    */
   Error: typeof DataTableError
+
+  /** Empty state implementation for `DataTable`.
+   *
+   * Extends the EmptyState component
+   */
+  EmptyState: typeof DataTableEmptyState
 }
 
 /** Context provider for DataTable state and logic.
@@ -119,3 +126,4 @@ DataTable.GlobalFilter = DataTableGlobalFilter
 DataTable.Table = DataTableTable
 DataTable.Loading = DataTableLoading
 DataTable.Error = DataTableError
+DataTable.EmptyState = DataTableEmptyState

--- a/lib/src/components/data-table/DataTableEmptyState.tsx
+++ b/lib/src/components/data-table/DataTableEmptyState.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+import { EmptyState } from '../empty-state'
+import { useDataTable } from './DataTableContext'
+type DataTableEmptyStateProps = React.ComponentProps<typeof EmptyState>
+
+export const DataTableEmptyState: React.FC<DataTableEmptyStateProps> = ({
+  children
+}) => {
+  const { getTotalRows } = useDataTable()
+
+  if (getTotalRows() !== 0) return null
+
+  return <EmptyState>
+    {children}
+  </EmptyState>
+}

--- a/lib/src/components/data-table/DataTableGlobalFilter.tsx
+++ b/lib/src/components/data-table/DataTableGlobalFilter.tsx
@@ -16,8 +16,11 @@ export const DataTableGlobalFilter: React.FC<DataTableSearchProps> = ({
   hideLabel = false,
   ...props
 }) => {
-  const { setGlobalFilter, getState, resetPagination } = useDataTable()
+  const { setGlobalFilter, getState, resetPagination, getTotalRows } =
+    useDataTable()
   const { globalFilter } = getState()
+
+  if (getTotalRows() === 0) return null
 
   const handleChange = debounce(250, (event) => {
     const {

--- a/lib/src/components/data-table/DataTableTable.tsx
+++ b/lib/src/components/data-table/DataTableTable.tsx
@@ -23,8 +23,10 @@ export const DataTableTable: React.FC<DataTableTableProps> = ({
   numberOfStickyColumns = 0,
   ...props
 }) => {
-  const { asyncDataState } = useDataTable()
+  const { asyncDataState, getTotalRows } = useDataTable()
   const isPending = asyncDataState === AsyncDataState.PENDING
+
+  if (getTotalRows() === 0 && !isPending) return null
 
   return (
     <>

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -1,5 +1,702 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataTable EmptyState renders custom empty state 1`] = `
+@media  {
+  .c-cVSpVL {
+    color: var(--colors-tonal500);
+    font-family: var(--fonts-body);
+    margin: 0;
+  }
+
+  .c-fZTBsJ {
+    -webkit-appearance: none;
+    appearance: none;
+    border: 1px solid var(--colors-tonal400);
+    border-radius: var(--radii-0);
+    box-shadow: none;
+    box-sizing: border-box;
+    color: var(--colors-tonal600);
+    cursor: text;
+    display: block;
+    font-family: var(--fonts-body);
+    padding-left: var(--space-3);
+    padding-right: var(--space-3);
+    transition: all 100ms ease-out;
+    width: 100%;
+  }
+
+  .c-fZTBsJ:focus {
+    border-color: var(--colors-primary);
+    outline: none;
+  }
+
+  .c-fZTBsJ[disabled] {
+    background-color: var(--colors-tonal100);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fZTBsJ::placeholder {
+    color: var(--colors-tonal300);
+    opacity: 1;
+  }
+
+  .c-cNcGUX::-webkit-search-decoration,
+  .c-cNcGUX::-webkit-search-cancel-button,
+  .c-cNcGUX::-webkit-search-results-button,
+  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+    display: none;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-hvMhuR {
+    color: var(--colors-tonal300);
+    position: absolute;
+    pointer-events: none;
+  }
+
+  .c-cwQMhQ {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-family: var(--fonts-sans);
+    font-size: var(--fontSizes-sm);
+    width: 100%;
+  }
+
+  .c-hjAYDb {
+    background: unset;
+  }
+
+  .c-jhJxGZ {
+    color: white;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    line-height: 1.5;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-ihQtuj {
+    border-bottom: 1px solid var(--colors-tonal100);
+    box-sizing: border-box;
+    color: var(--colors-tonal400);
+    font-family: var(--fonts-body);
+    line-height: 1.5;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  .c-ihQtuj:first-child {
+    font-weight: bold;
+  }
+
+  .c-eIXSIu {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .c-dyvMgW {
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    margin: 0;
+  }
+
+  .c-dyvMgW > .c-dyvMgW:before,
+  .c-dyvMgW > .c-dyvMgW:after {
+    display: none;
+  }
+
+  .c-beXZpM {
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: white;
+    background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22%23757575%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20color%3D%22%23757575%22%3E%3Cpolyline%20points%3D%226%2010%2012%2016%2018%2010%22%2F%3E%3C%2Fsvg%3E);
+    background-repeat: no-repeat, repeat;
+    border: 1px solid var(--colors-tonal300);
+    border-radius: var(--radii-0);
+    color: var(--colors-tonal600);
+    display: block;
+    font-family: var(--fonts-body);
+    font-weight: 400;
+    line-height: 1.4;
+    transition: all 75ms ease-out;
+    width: 100%;
+  }
+
+  .c-beXZpM:hover {
+    cursor: pointer;
+  }
+
+  .c-beXZpM:focus {
+    border-color: var(--colors-primary);
+    outline: none;
+  }
+
+  .c-beXZpM::-ms-expand {
+    display: none;
+  }
+
+  .c-beXZpM[disabled],
+  .c-beXZpM > option[disabled] {
+    background-color: var(--colors-tonal100);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-hVoQtf {
+    background-color: var(--colors-tonal500);
+    border-radius: var(--radii-0);
+    box-shadow: var(--shadows-0);
+    color: white;
+    font-family: var(--fonts-body);
+    font-size: var(--fontSizes-sm);
+    line-height: 1.5;
+    white-space: normal;
+    padding-left: var(--space-3);
+    padding-right: var(--space-3);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+    z-index: 10;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf {
+      animation-duration: 75ms;
+      animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+      will-change: transform, opacity;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
+      animation-name: k-ftcNPK;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
+      animation-name: k-hbaHED;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
+      animation-name: k-daNevH;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
+      animation-name: k-fvyGIa;
+    }
+}
+
+  .c-ecNzKx {
+    color: inherit !important;
+    fill: currentColor;
+  }
+
+  .c-ecNzKx[disabled] {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+
+  .c-ecNzKx[disabled] * {
+    pointer-events: none;
+  }
+
+  .c-jBOHFZ {
+    animation-name: k-gJNjLs;
+    animation-duration: 1s;
+    animation-fill-mode: both;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    background-color: currentColor;
+    border-radius: var(--radii-round);
+  }
+
+  .c-jBOHFZ:nth-child(1) {
+    animation-delay: -300ms;
+  }
+
+  .c-jBOHFZ:nth-child(2) {
+    animation-delay: -150ms;
+  }
+
+  .c-jBOHFZ:nth-child(3) {
+    animation-delay: 0;
+  }
+
+  .c-deGxWL {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+  }
+
+  .c-fkUJsw {
+    align-items: center;
+    background: unset;
+    border: unset;
+    border-radius: var(--radii-0);
+    cursor: pointer;
+    display: flex;
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    justify-content: center;
+    padding: unset;
+    text-decoration: none;
+    transition: all 100ms ease-out;
+    white-space: nowrap;
+    width: max-content;
+  }
+
+  .c-QtuIU {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .c-QtuIU > *:last-child {
+    margin-bottom: 0;
+  }
+
+  .c-eyOYLV {
+    color: var(--colors-tonal400);
+    font-family: var(--fonts-body);
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .c-cXdTNb {
+    color: var(--colors-tonal400);
+    font-weight: 400;
+  }
+}
+
+@media  {
+  .c-cVSpVL-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-cVSpVL-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-cVSpVL-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-cVSpVL-grKRUr-type-block {
+    display: block;
+    font-weight: 600;
+  }
+
+  .c-fZTBsJ-pHZal-size-md {
+    height: var(--sizes-4);
+    font-size: var(--fontSizes-md);
+  }
+
+  .c-dbrbZt-dMrjnF-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 1.75;
+  }
+
+  .c-hvMhuR-OveXb-size-md {
+    top: 10px;
+    right: 10px;
+    height: 20px;
+    width: 20px;
+  }
+
+  .c-cwQMhQ-urYIk-size-md .c-ihQtuj,
+  .c-cwQMhQ-urYIk-size-md .c-jhJxGZ,
+  .c-cwQMhQ-urYIk-size-md .c-jwhJBv {
+    height: var(--sizes-4);
+    padding: var(--space-1) var(--space-3);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:first-of-type {
+    border-top-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-jhJxGZ:last-of-type {
+    border-top-right-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:first-child {
+    border-bottom-left-radius: var(--radii-0);
+  }
+
+  .c-cwQMhQ-fplEaP-corners-round .c-hjAYDb:last-child .c-ihQtuj:last-child {
+    border-bottom-right-radius: var(--radii-0);
+  }
+
+  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
+    background: var(--colors-tonal50);
+    color: var(--colors-tonal600);
+  }
+
+  .c-PJLV-cevUCR-striped-false .c-hjAYDb {
+    background: white;
+  }
+
+  .c-dyvMgW-bndJoy-size-sm {
+    font-size: var(--fontSizes-sm);
+    line-height: 1.53;
+  }
+
+  .c-dyvMgW-bndJoy-size-sm::before {
+    content: '';
+    margin-bottom: -0.4056em;
+    display: table;
+  }
+
+  .c-dyvMgW-bndJoy-size-sm::after {
+    content: '';
+    margin-top: -0.4056em;
+    display: table;
+  }
+
+  .c-beXZpM-cGAtlD-size-sm {
+    background-position: right var(--space-2) top 50%, 0 0;
+    background-size: 18px auto, 100%;
+    font-size: var(--fontSizes-sm);
+    height: var(--sizes-3);
+    padding-left: var(--space-2);
+    padding-right: var(--space-5);
+  }
+
+  .c-fDzwZw-PrXKS-size-md {
+    height: var(--sizes-4);
+    width: var(--sizes-4);
+  }
+
+  .c-fDzwZw-rloUt-isRounded-true {
+    border-radius: var(--radii-round);
+  }
+
+  .c-hVoQtf-gWQnqe-size-md {
+    max-width: 250px;
+  }
+
+  .c-dbrbZt-cyeZeh-size-sm {
+    height: var(--sizes-1);
+    width: var(--sizes-1);
+    stroke-width: 1.5;
+  }
+
+  .c-fDzwZw-elrktp-size-sm {
+    height: var(--sizes-3);
+    width: var(--sizes-3);
+  }
+
+  .c-ecNzKx-kbKHjH-isDragging-false {
+    cursor: grab;
+  }
+
+  .c-jBOHFZ-jIYkAt-size-md {
+    height: 6px;
+    width: 6px;
+    margin-left: 2px;
+    margin-right: 2px;
+  }
+
+  .c-dyvMgW-gvmVBy-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+  }
+
+  .c-dyvMgW-gvmVBy-size-md::before {
+    content: '';
+    margin-bottom: -0.3864em;
+    display: table;
+  }
+
+  .c-dyvMgW-gvmVBy-size-md::after {
+    content: '';
+    margin-top: -0.3864em;
+    display: table;
+  }
+
+  .c-fkUJsw-elrwsr-size-md {
+    font-size: var(--fontSizes-md);
+    line-height: 1.5;
+    height: var(--sizes-4);
+    padding-left: var(--space-5);
+    padding-right: var(--space-5);
+  }
+
+  .c-QtuIU-gtyVWU-size-sm {
+    padding: var(--space-3);
+  }
+
+  .c-eyOYLV-gNjhJG-size-sm {
+    font-size: var(--fontSizes-md);
+    margin-bottom: var(--space-3);
+  }
+
+  .c-cXdTNb-kSBam-size-sm {
+    font-size: var(--fontSizes-sm);
+    margin-bottom: var(--space-4);
+  }
+}
+
+@media  {
+  .c-fDzwZw-jpgoGt-cv {
+    border: 1px solid;
+    border-color: currentColor;
+    color: var(--colors-primary);
+  }
+
+  .c-fDzwZw-jpgoGt-cv:not(:disabled):hover,
+  .c-fDzwZw-jpgoGt-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-jpgoGt-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-jpgoGt-cv[disabled] {
+    border-color: var(--colors-tonal400);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fDzwZw-cmVfvW-cv {
+    background: transparent;
+    color: var(--colors-primary);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):hover,
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-cmVfvW-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fDzwZw-otpKd-cv {
+    background: transparent;
+    color: var(--colors-tonal300);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):hover,
+  .c-fDzwZw-otpKd-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-otpKd-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-otpKd-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-gsycxF-cv {
+    background: var(--colors-primary);
+    color: white;
+  }
+
+  .c-fkUJsw-gsycxF-cv[disabled] {
+    background: var(--colors-tonal100);
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+
+  .c-fkUJsw-gsycxF-cv:not([disabled]):hover,
+  .c-fkUJsw-gsycxF-cv:not([disabled]):focus {
+    background: var(--colors-primaryMid);
+    color: white;
+  }
+
+  .c-fkUJsw-gsycxF-cv:not([disabled]):active {
+    background: var(--colors-primaryDark);
+  }
+}
+
+@media  {
+  .c-cVSpVL-ihbtntv-css {
+    margin-bottom: var(--space-3);
+  }
+
+  .c-PJLV-ieyRoAv-css {
+    position: relative;
+    margin-bottom: var(--space-4);
+  }
+
+  .c-cNcGUX-icRYcAH-css {
+    padding-right: var(--space-6);
+  }
+
+  .c-hvMhuR-ihFPSGE-css {
+    height: 20px;
+    width: 20px;
+  }
+
+  .c-cwQMhQ-illIiIE-css {
+    margin-bottom: var(--space-4);
+  }
+
+  .c-jhJxGZ-ifYtQLP-css {
+    cursor: initial;
+  }
+
+  .c-dhzjXW-ijroWjL-css {
+    align-items: center;
+  }
+
+  .c-beXZpM-ihbpiMz-css {
+    margin-right: var(--space-3);
+  }
+
+  .c-dyvMgW-igbZjeK-css {
+    flex: none;
+  }
+
+  .c-dhzjXW-ibZmKkd-css {
+    justify-content: flex-end;
+  }
+
+  .c-fDzwZw-illEebI-css {
+    margin-right: var(--space-4);
+  }
+
+  .c-jhJxGZ-igsmDXe-css {
+    cursor: pointer;
+  }
+
+  .c-dhzjXW-iczouOI-css {
+    position: relative;
+    align-items: center;
+  }
+
+  .c-dbrbZt-ifwENwN-css {
+    position: absolute;
+    left: var(--space-1);
+  }
+
+  .c-ecNzKx-iAsWAM-css {
+    display: inline-block;
+  }
+
+  .c-PJLV-icmpvrW-css {
+    position: relative;
+  }
+
+  .c-fDzwZw-ifWWfIb-css {
+    position: absolute;
+    top: 0;
+    right: var(--space-1);
+  }
+
+  .c-dhzjXW-ibICGYT-css {
+    justify-content: center;
+  }
+
+  .c-cwQMhQ-igyXmJO-css {
+    margin-bottom: var(--space-4);
+    opacity: 0.5;
+    pointer-events: none;
+    transition: opacity 250ms linear 150ms;
+  }
+
+  .c-PJLV-iiXkAWq-css {
+    overflow: auto;
+    max-width: 100%;
+  }
+
+  .c-PJLV-iiXkAWq-css td {
+    background: inherit;
+  }
+
+  .c-PJLV-igbAmsf-css {
+    overflow: auto;
+    max-width: 100%;
+  }
+
+  .c-PJLV-igbAmsf-css td:nth-of-type(1),
+  .c-PJLV-igbAmsf-css th:nth-of-type(1) {
+    position: sticky;
+    left: 0px;
+    min-width: 0px;
+    z-index: 2;
+  }
+
+  .c-PJLV-igbAmsf-css td {
+    background: inherit;
+  }
+}
+
+<div>
+  <div
+    class="c-dhzjXW c-QtuIU c-QtuIU-gtyVWU-size-sm"
+  >
+    <h2
+      class="c-eyOYLV c-eyOYLV-gNjhJG-size-sm"
+    >
+      No data available
+    </h2>
+    <p
+      class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-cXdTNb c-cXdTNb-kSBam-size-sm"
+    >
+      Something is missing
+    </p>
+    <button
+      class="c-fkUJsw c-fkUJsw-elrwsr-size-md c-fkUJsw-gsycxF-cv"
+      type="button"
+    >
+      Click here
+    </button>
+  </div>
+</div>
+`;
+
 exports[`DataTable component Renders drag handles for draggable table rows 1`] = `
 @media  {
   .c-cVSpVL {

--- a/lib/src/components/data-table/pagination/Pagination.tsx
+++ b/lib/src/components/data-table/pagination/Pagination.tsx
@@ -37,6 +37,8 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
 
   const { pagination: paginationState } = getState()
 
+  if (getTotalRows() === 0) return null
+
   const recordsCountFrom =
     paginationState.pageIndex * paginationState.pageSize + 1
   const recordsCountTo = recordsCountFrom + getRowModel().rows.length - 1


### PR DESCRIPTION
This adds the option to add an EmptyState to the DataTable. 
It requires the consumer to implement the state but at the moment this is all we need to unblock all the tickets for the table migrations as part of these 

The next iteration would be to implement a default empty state, however, this is blocked by the bigger discussion about how the DS handles generic illustrations so leaving this out of scope for this PR.

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/5703687/229134871-a3a99cc7-6a1e-44e3-af2f-86a926d1bc2f.png">


**Note: Under WIP to get feedback and I need some time to fix a few broken tests**
