### PR TITLE
fix: empty page when navigating from a tab that is not the first

### DIFF
--- a/documentation/components/page/Layout.tsx
+++ b/documentation/components/page/Layout.tsx
@@ -3,30 +3,43 @@ import { Heading, Tabs, Box, StackContent } from '@atom-learning/components'
 import Head from 'next/head'
 import { Container, Header, Footer, Links, Pagination } from '.'
 import { components } from '~/components/markdown/index'
-import { MDXRemote } from "next-mdx-remote";
+import { MDXRemote } from 'next-mdx-remote'
 import { TDynamicPage } from '~/lib/types/DynamicPage'
+import { useState, useEffect } from 'react'
 
 export const Layout: React.FC<TDynamicPage> = (props) => {
-  const { links, slug, tabs, title } = props;
-
+  const { links, slug, tabs, title } = props
   const tabsLength = tabs?.length
-  const hasContent = !!tabsLength;
+  const hasContent = !!tabsLength
+
+  const [activeTab, setactiveTab] = useState('tab0')
+
+  useEffect(() => {
+    setactiveTab('tab0')
+  }, [slug])
 
   return (
-    <Tabs defaultValue="tab0">
+    <Tabs value={activeTab} onValueChange={setactiveTab}>
       <Head>
-        <title>
-          {title ? `${title} | ` : ''}Atom Learning Design System
-        </title>
+        <title>{title ? `${title} | ` : ''}Atom Learning Design System</title>
       </Head>
-      <Box as="article" css={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Box
+        as="article"
+        css={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}
+      >
         <Header>
           <StackContent>
-            <Heading as="h1" size="lg">{title}</Heading>
+            <Heading as="h1" size="lg">
+              {title}
+            </Heading>
             <Links {...links} />
             {tabsLength > 1 && (
               <Tabs.TriggerList css={{ position: 'absolute', bottom: 0 }}>
-                {tabs.map((tab, i) => <Tabs.Trigger key={tab.title} value={`tab${i}`}>{tab.title}</Tabs.Trigger>)}
+                {tabs.map((tab, i) => (
+                  <Tabs.Trigger key={tab.title} value={`tab${i}`}>
+                    {tab.title}
+                  </Tabs.Trigger>
+                ))}
               </Tabs.TriggerList>
             )}
           </StackContent>
@@ -40,8 +53,7 @@ export const Layout: React.FC<TDynamicPage> = (props) => {
                   <MDXRemote {...tab.content} components={components} />
                 </StackContent>
               </Tabs.Content>
-            ))
-            }
+            ))}
           </Container>
         )}
 

--- a/documentation/components/page/Layout.tsx
+++ b/documentation/components/page/Layout.tsx
@@ -5,7 +5,7 @@ import { Container, Header, Footer, Links, Pagination } from '.'
 import { components } from '~/components/markdown/index'
 import { MDXRemote } from 'next-mdx-remote'
 import { TDynamicPage } from '~/lib/types/DynamicPage'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 export const Layout: React.FC<TDynamicPage> = (props) => {
   const { links, slug, tabs, title } = props
@@ -13,10 +13,6 @@ export const Layout: React.FC<TDynamicPage> = (props) => {
   const hasContent = !!tabsLength
 
   const [activeTab, setactiveTab] = useState('tab0')
-
-  useEffect(() => {
-    setactiveTab('tab0')
-  }, [slug])
 
   return (
     <Tabs value={activeTab} onValueChange={setactiveTab}>

--- a/documentation/components/page/Layout.tsx
+++ b/documentation/components/page/Layout.tsx
@@ -5,17 +5,14 @@ import { Container, Header, Footer, Links, Pagination } from '.'
 import { components } from '~/components/markdown/index'
 import { MDXRemote } from 'next-mdx-remote'
 import { TDynamicPage } from '~/lib/types/DynamicPage'
-import { useState } from 'react'
 
 export const Layout: React.FC<TDynamicPage> = (props) => {
   const { links, slug, tabs, title } = props
   const tabsLength = tabs?.length
   const hasContent = !!tabsLength
 
-  const [activeTab, setactiveTab] = useState('tab0')
-
   return (
-    <Tabs value={activeTab} onValueChange={setactiveTab}>
+    <Tabs defaultValue="tab0">
       <Head>
         <title>{title ? `${title} | ` : ''}Atom Learning Design System</title>
       </Head>

--- a/documentation/pages/[...slug].tsx
+++ b/documentation/pages/[...slug].tsx
@@ -5,7 +5,7 @@ const { getPageByFilename, getAllPages } = require('~/lib/api.cjs')
 import { TDynamicPage } from '~/lib/types/DynamicPage'
 import remarkGfm from 'remark-gfm'
 
-import { serialize } from "next-mdx-remote/serialize";
+import { serialize } from 'next-mdx-remote/serialize'
 
 import { Layout as PageLayout } from '~/components/page/Layout'
 
@@ -15,7 +15,7 @@ type Props = {
 }
 
 export default function Page({ Page, preview }: Props) {
-  const { slug } = Page;
+  const { slug } = Page
 
   const router = useRouter()
 
@@ -23,9 +23,8 @@ export default function Page({ Page, preview }: Props) {
 
   if (router.isFallback) return <div>Loading…</div>
 
-  if (preview) return null;
-  return <PageLayout {...Page} />
-
+  if (preview) return null
+  return <PageLayout key={slug} {...Page} />
 }
 
 type Params = {
@@ -43,10 +42,16 @@ export const getStaticProps = async ({ params }: Params) => {
     'tabs'
   ])
 
-  const tabs = Page?.tabs ? await Promise.all(Page.tabs.map(async ({ content, ...rest }) => {
-    const serializedContent = await serialize(content || '', { mdxOptions: { remarkPlugins: [remarkGfm] } })
-    return { content: serializedContent, ...rest }
-  })) : []
+  const tabs = Page?.tabs
+    ? await Promise.all(
+        Page.tabs.map(async ({ content, ...rest }) => {
+          const serializedContent = await serialize(content || '', {
+            mdxOptions: { remarkPlugins: [remarkGfm] }
+          })
+          return { content: serializedContent, ...rest }
+        })
+      )
+    : []
 
   return {
     props: {
@@ -54,8 +59,8 @@ export const getStaticProps = async ({ params }: Params) => {
         ...Page,
         tabs,
         nestedSlug: nestedSlug
-      },
-    },
+      }
+    }
   }
 }
 
@@ -67,9 +72,9 @@ export const getStaticPaths = async () => {
       return {
         params: {
           slug: Page.nestedSlug
-        },
+        }
       }
     }),
-    fallback: false,
+    fallback: false
   }
 }


### PR DESCRIPTION
[JIRA](https://atomlearningltd.atlassian.net/browse/DS-346)

## Description
When navigating from a component tab that was not the first tab to a component that only has one tab an empty screen was shown. This has been fixed

## Implementation
The problem is that the current tab was stored in the tab provider, and was not reset when navigating from one component to other.

~Going from un uncontrolled approach to a controlled approach for the tabs and resetting it when the `slug` changes did the trick.~

After some review comments, I tried usin `key={slug}` so the tabs re-render. It doesn't work in the `<Tab>` component directly, so I did it in the parent component.

## Screenshots
### Before

https://user-images.githubusercontent.com/4931116/231988038-dff1abd6-3d19-4f08-981d-023c63d68d91.mov


### After

https://user-images.githubusercontent.com/4931116/231988085-3bf3e9b9-0c8a-4eb2-a3aa-da5fbe06c98f.mov


