### PR TITLE
feat: simplify SectionMessage API by utilising pos absolute

### DIFF
--- a/documentation/content/components.feedback.section-message.md
+++ b/documentation/content/components.feedback.section-message.md
@@ -15,12 +15,10 @@ tabs:
       <CodeBlock live={true} preview={true} code={`<SectionMessage>
         <SectionMessage.Icon />
         <SectionMessage.Content>
-          <Box>
-            <SectionMessage.Title>Title message</SectionMessage.Title>
-            <SectionMessage.Description>
-              This is the description
-            </SectionMessage.Description>
-          </Box>
+          <SectionMessage.Title>Title message</SectionMessage.Title>
+          <SectionMessage.Description>
+            This is the description
+          </SectionMessage.Description>
         </SectionMessage.Content>
         <SectionMessage.Close />
       </SectionMessage>`} language={"tsx"} />
@@ -38,56 +36,56 @@ tabs:
           <Stack direction="column" css={{ width: 325 }} gap={3}>
             <SectionMessage theme="error">
               <SectionMessage.Icon />
-                <Box>
-                  <SectionMessage.Title>Title message</SectionMessage.Title>
-                  <SectionMessage.Description>
-                    This is the description
-                  </SectionMessage.Description>
-                </Box>
+              <SectionMessage.Content>
+                <SectionMessage.Title>Title message</SectionMessage.Title>
+                <SectionMessage.Description>
+                  This is the description
+                </SectionMessage.Description>
+              </SectionMessage.Content>
               <SectionMessage.Close />
             </SectionMessage>
 
             <SectionMessage theme="warning">
               <SectionMessage.Icon />
-                <Box>
-                  <SectionMessage.Title>Title message</SectionMessage.Title>
-                  <SectionMessage.Description>
-                    This is the description
-                  </SectionMessage.Description>
-                </Box>
+              <SectionMessage.Content>
+                <SectionMessage.Title>Title message</SectionMessage.Title>
+                <SectionMessage.Description>
+                  This is the description
+                </SectionMessage.Description>
+              </SectionMessage.Content>
               <SectionMessage.Close />
             </SectionMessage>
 
             <SectionMessage theme="success">
               <SectionMessage.Icon />
-                <Box>
-                  <SectionMessage.Title>Title message</SectionMessage.Title>
-                  <SectionMessage.Description>
-                    This is the description
-                  </SectionMessage.Description>
-                </Box>
+              <SectionMessage.Content>
+                <SectionMessage.Title>Title message</SectionMessage.Title>
+                <SectionMessage.Description>
+                  This is the description
+                </SectionMessage.Description>
+              </SectionMessage.Content>
               <SectionMessage.Close />
             </SectionMessage>
 
             <SectionMessage theme="info">
               <SectionMessage.Icon />
-                <Box>
-                  <SectionMessage.Title>Title message</SectionMessage.Title>
-                  <SectionMessage.Description>
-                    This is the description
-                  </SectionMessage.Description>
-                </Box>
+              <SectionMessage.Content>
+                <SectionMessage.Title>Title message</SectionMessage.Title>
+                <SectionMessage.Description>
+                  This is the description
+                </SectionMessage.Description>
+              </SectionMessage.Content>
               <SectionMessage.Close />
             </SectionMessage>
 
             <SectionMessage theme="neutral">
               <SectionMessage.Icon />
-                <Box>
-                  <SectionMessage.Title>Title message</SectionMessage.Title>
-                  <SectionMessage.Description>
-                    This is the description
-                  </SectionMessage.Description>
-                </Box>
+              <SectionMessage.Content>
+                <SectionMessage.Title>Title message</SectionMessage.Title>
+                <SectionMessage.Description>
+                  This is the description
+                </SectionMessage.Description>
+              </SectionMessage.Content>
               <SectionMessage.Close />
             </SectionMessage>
           </Stack>
@@ -129,19 +127,17 @@ tabs:
           <SectionMessage css={{ width: 500 }}>
             <SectionMessage.Icon />
             <SectionMessage.Content>
-              <Box>
-                <SectionMessage.Title>Title message</SectionMessage.Title>
-                <SectionMessage.Description>
-                  This is the description
-                </SectionMessage.Description>
-              </Box>
-              <SectionMessage.Actions>
+              <SectionMessage.Title>Title message</SectionMessage.Title>
+              <SectionMessage.Description>
+                This is the description
+              </SectionMessage.Description>
+            </SectionMessage.Content>
+            <SectionMessage.Actions>
                 <Button size="sm">Button</Button>
                 <Button size="sm" appearance="outline">
                   Button
                 </Button>
               </SectionMessage.Actions>
-            </SectionMessage.Content>
             <SectionMessage.Close />
           </SectionMessage>
         `} 

--- a/lib/src/components/section-message/SectionMessage.test.tsx
+++ b/lib/src/components/section-message/SectionMessage.test.tsx
@@ -2,7 +2,6 @@ import { render } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import React from 'react'
 
-import { Box } from '../box'
 import { SectionMessage } from '.'
 
 it('renders SectionMessage component and has no programmatically detectable a11y issues', async () => {
@@ -10,12 +9,10 @@ it('renders SectionMessage component and has no programmatically detectable a11y
     <SectionMessage theme="error">
       <SectionMessage.Icon />
       <SectionMessage.Content>
-        <Box>
-          <SectionMessage.Title>Title message</SectionMessage.Title>
-          <SectionMessage.Description>
-            This is the description
-          </SectionMessage.Description>
-        </Box>
+        <SectionMessage.Title>Title message</SectionMessage.Title>
+        <SectionMessage.Description>
+          This is the description
+        </SectionMessage.Description>
       </SectionMessage.Content>
       <SectionMessage.Close />
     </SectionMessage>

--- a/lib/src/components/section-message/SectionMessage.tsx
+++ b/lib/src/components/section-message/SectionMessage.tsx
@@ -1,13 +1,15 @@
-import { Danger, Error, Info, OkCircle } from '@atom-learning/icons'
 import { TooltipProvider } from '@radix-ui/react-tooltip'
 import React from 'react'
 
-import { CSS } from '~/stitches'
+import { styled } from '~/stitches'
 
 import { Stack } from '../stack'
 import { Dismissible } from '../dismissible'
 import { SectionMessageClose } from './SectionMessageClose'
-import { SectionMessageContext } from './SectionMessageContext'
+import {
+  SectionMessageProvider,
+  useSectionMessageContext
+} from './SectionMessageContext'
 import { SectionMessageIcon } from './SectionMessageIcon'
 import {
   SectionMessageActions,
@@ -18,80 +20,86 @@ import {
   SectionMessageTitle
 } from './SectionMessageText'
 
-export const THEMES = {
-  success: {
-    bg: '$successLight',
-    color: '$successDark',
-    icon: OkCircle
-  },
-  warning: {
-    bg: '$warningLight',
-    color: '$warningText',
-    icon: Danger
-  },
-  error: {
-    bg: '$dangerLight',
-    color: '$dangerDark',
-    icon: Error
-  },
-  neutral: {
-    bg: '$grey100',
-    color: '$grey1000',
-    icon: Info
-  },
-  info: {
-    bg: '$blue100',
-    color: '$blue1000',
-    icon: Info
+const StyledSectionMessage = styled(Dismissible, {
+  position: 'relative',
+  borderRadius: '$0',
+  display: 'flex',
+  p: '$4',
+  border: '1px solid white',
+  variants: {
+    theme: {
+      success: {
+        bg: '$successLight',
+        color: '$successDark'
+      },
+      warning: {
+        bg: '$warningLight',
+        color: '$warningText'
+      },
+      error: {
+        bg: '$dangerLight',
+        color: '$dangerDark'
+      },
+      neutral: {
+        bg: '$grey100',
+        color: '$grey1000'
+      },
+      info: {
+        bg: '$blue100',
+        color: '$blue1000'
+      }
+    },
+    hasIcon: {
+      true: {
+        pl: '$6'
+      }
+    },
+    hasDismiss: {
+      true: {
+        pr: '$7'
+      }
+    }
   }
+})
+
+const StyledStack = styled(Stack, {
+  flexGrow: 1,
+  justifyContent: 'space-between !important'
+})
+
+const SectionMessageRoot = ({
+  children,
+  ...rest
+}: React.ComponentProps<typeof StyledSectionMessage>): JSX.Element => {
+  const { theme, hasIcon, hasDismiss } = useSectionMessageContext()
+
+  return (
+    <StyledSectionMessage
+      {...rest}
+      theme={theme}
+      hasIcon={hasIcon}
+      hasDismiss={hasDismiss}
+    >
+      <StyledStack gap={3}>{children}</StyledStack>
+    </StyledSectionMessage>
+  )
 }
 
-export type SectionMessageTheme = keyof typeof THEMES
-
-interface SectionMessageProps
-  extends Omit<
-    Partial<React.ComponentProps<typeof Dismissible>>,
-    'asChild' | 'disabled'
-  > {
-  theme?: SectionMessageTheme
-  css?: CSS
+export type SectionMessageProps = React.ComponentProps<
+  typeof SectionMessageRoot
+> & {
+  theme: 'success' | 'warning' | 'error' | 'neutral' | 'info'
 }
 
 const SectionMessage = ({
   theme = 'info',
-  css,
-  onDismiss,
-  value = 'section-message',
-  children
+  ...rest
 }: SectionMessageProps): JSX.Element => {
   return (
     <TooltipProvider>
-      <SectionMessageContext.Provider value={{ theme }}>
-        <Dismissible value={value} onDismiss={onDismiss} asChild>
-          <Stack
-            gap={3}
-            css={{
-              position: 'relative',
-              fontFamily: '$body',
-              borderRadius: '$0',
-              fontSize: '$sm',
-              color: '$grey900',
-              display: 'flex',
-              p: '$4 $7 $4 $6',
-              border: '1px solid white',
-              bg: THEMES[theme].bg,
-              ['& > * ']: {
-                // Need to target direct children as there's an issue with Stack being 2 levels (CSSWrapper -> Actual Stack) and justify-content needed for the nested level
-                width: '100%',
-                justifyContent: 'space-between'
-              },
-              ...css
-            }}
-          >
-            {children}
-          </Stack>
-        </Dismissible>
-      </SectionMessageContext.Provider>
+      <SectionMessageProvider theme={theme}>
+        <SectionMessageRoot {...rest} />
+      </SectionMessageProvider>
     </TooltipProvider>
   )
 }

--- a/lib/src/components/section-message/SectionMessage.tsx
+++ b/lib/src/components/section-message/SectionMessage.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { CSS } from '~/stitches'
 
-import { Box } from '../box'
+import { Stack } from '../stack'
 import { Dismissible } from '../dismissible'
 import { SectionMessageClose } from './SectionMessageClose'
 import { SectionMessageContext } from './SectionMessageContext'
@@ -68,21 +68,28 @@ const SectionMessage = ({
     <TooltipProvider>
       <SectionMessageContext.Provider value={{ theme }}>
         <Dismissible value={value} onDismiss={onDismiss} asChild>
-          <Box
+          <Stack
+            gap={3}
             css={{
+              position: 'relative',
               fontFamily: '$body',
               borderRadius: '$0',
               fontSize: '$sm',
               color: '$grey900',
               display: 'flex',
-              p: '$4',
+              p: '$4 $7 $4 $6',
               border: '1px solid white',
               bg: THEMES[theme].bg,
+              ['& > * ']: {
+                // Need to target direct children as there's an issue with Stack being 2 levels (CSSWrapper -> Actual Stack) and justify-content needed for the nested level
+                width: '100%',
+                justifyContent: 'space-between'
+              },
               ...css
             }}
           >
             {children}
-          </Box>
+          </Stack>
         </Dismissible>
       </SectionMessageContext.Provider>
     </TooltipProvider>

--- a/lib/src/components/section-message/SectionMessageClose.tsx
+++ b/lib/src/components/section-message/SectionMessageClose.tsx
@@ -1,29 +1,41 @@
 import { Close } from '@atom-learning/icons'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { ActionIcon } from '../action-icon'
-import { Box } from '../box'
 import { Dismissible } from '../dismissible'
 import { Icon } from '../icon'
+import { useSectionMessageContext } from './SectionMessageContext'
 
 export const SectionMessageClose = ({
   label = 'Dismiss',
+  css,
   ...rest
 }: React.ComponentProps<typeof ActionIcon>): JSX.Element => {
+  const { setHasDismiss } = useSectionMessageContext()
+
+  useEffect(() => {
+    setHasDismiss(true)
+    return () => setHasDismiss(false)
+  }, [setHasDismiss])
+
   return (
     <Dismissible.Trigger asChild>
-      <Box css={{ m: 'auto', position: 'absolute', top: '$2', right: '$2' }}>
-        <ActionIcon
-          label={label}
-          css={{}}
-          size="sm"
-          appearance="simple"
-          theme="neutral"
-          {...rest}
-        >
-          <Icon is={Close} />
-        </ActionIcon>
-      </Box>
+      <ActionIcon
+        label={label}
+        css={{
+          m: 'auto',
+          position: 'absolute',
+          top: '$2',
+          right: '$2',
+          ...css
+        }}
+        size="sm"
+        appearance="simple"
+        theme="neutral"
+        {...rest}
+      >
+        <Icon is={Close} />
+      </ActionIcon>
     </Dismissible.Trigger>
   )
 }

--- a/lib/src/components/section-message/SectionMessageClose.tsx
+++ b/lib/src/components/section-message/SectionMessageClose.tsx
@@ -12,7 +12,7 @@ export const SectionMessageClose = ({
 }: React.ComponentProps<typeof ActionIcon>): JSX.Element => {
   return (
     <Dismissible.Trigger asChild>
-      <Box css={{ ml: 'auto', mt: '-$2', mr: '-$2', mb: '-$2', pl: '$4' }}>
+      <Box css={{ m: 'auto', position: 'absolute', top: '$2', right: '$2' }}>
         <ActionIcon
           label={label}
           css={{}}

--- a/lib/src/components/section-message/SectionMessageContext.tsx
+++ b/lib/src/components/section-message/SectionMessageContext.tsx
@@ -1,16 +1,39 @@
 import React from 'react'
 
-import { SectionMessageTheme } from './SectionMessage'
+import type { SectionMessageProps } from './SectionMessage'
 
-interface SectionMessageContextValue {
-  theme: SectionMessageTheme
+export type TSectionMessageContext = {
+  theme: SectionMessageProps['theme']
+  hasIcon: boolean
+  setHasIcon: React.Dispatch<React.SetStateAction<boolean>>
+  hasDismiss: boolean
+  setHasDismiss: React.Dispatch<React.SetStateAction<boolean>>
+}
+export type TSectionMessageProviderProps = {
+  theme: TSectionMessageContext['theme']
 }
 
-export const SectionMessageContext = React.createContext<
-  SectionMessageContextValue | undefined
->(undefined)
+export const SectionMessageContext =
+  React.createContext<TSectionMessageContext>({})
 
-export const useSectionMessageContext = (): SectionMessageContextValue => {
+export const SectionMessageProvider: React.FC<TSectionMessageProviderProps> = ({
+  theme = 'info',
+  children
+}) => {
+  const [hasIcon, setHasIcon] = React.useState(false)
+  const [hasDismiss, setHasDismiss] = React.useState(false)
+  const value = React.useMemo<TSectionMessageContext>(
+    () => ({ theme, hasIcon, setHasIcon, hasDismiss, setHasDismiss }),
+    [theme, hasIcon, setHasIcon, hasDismiss, setHasDismiss]
+  )
+  return (
+    <SectionMessageContext.Provider value={value}>
+      {children}
+    </SectionMessageContext.Provider>
+  )
+}
+
+export const useSectionMessageContext = (): TSectionMessageContext => {
   const context = React.useContext(SectionMessageContext)
 
   if (context === undefined) {

--- a/lib/src/components/section-message/SectionMessageIcon.tsx
+++ b/lib/src/components/section-message/SectionMessageIcon.tsx
@@ -8,15 +8,22 @@ import { useSectionMessageContext } from './SectionMessageContext'
 export const SectionMessageIcon = ({
   css,
   ...rest
-}: React.ComponentProps<typeof Box>): JSX.Element => {
+}: React.ComponentProps<typeof Icon>): JSX.Element => {
   const { theme } = useSectionMessageContext()
 
   return (
-    <Box
-      css={{ mr: '$2', mt: '-1px', color: THEMES[theme].color, ...css }}
+    <Icon
       {...rest}
-    >
-      <Icon is={THEMES[theme].icon} size="sm" />
-    </Box>
+      css={{
+        m: 'auto',
+        position: 'absolute',
+        left: '$4',
+        top: '$4',
+        color: THEMES[theme].color,
+        ...css
+      }}
+      is={THEMES[theme].icon}
+      size="sm"
+    />
   )
 }

--- a/lib/src/components/section-message/SectionMessageIcon.tsx
+++ b/lib/src/components/section-message/SectionMessageIcon.tsx
@@ -1,15 +1,24 @@
-import React from 'react'
-
-import { Box } from '../box'
+import React, { useEffect } from 'react'
+import { Danger, Error, Info, OkCircle } from '@atom-learning/icons'
 import { Icon } from '../icon'
-import { THEMES } from './SectionMessage'
 import { useSectionMessageContext } from './SectionMessageContext'
 
+const toIconSVG = {
+  success: OkCircle,
+  warning: Danger,
+  error: Error,
+  neutral: Info,
+  info: Info
+}
 export const SectionMessageIcon = ({
   css,
   ...rest
 }: React.ComponentProps<typeof Icon>): JSX.Element => {
-  const { theme } = useSectionMessageContext()
+  const { theme, setHasIcon } = useSectionMessageContext()
+  useEffect(() => {
+    setHasIcon(true)
+    return () => setHasIcon(false)
+  }, [setHasIcon])
 
   return (
     <Icon
@@ -19,10 +28,10 @@ export const SectionMessageIcon = ({
         position: 'absolute',
         left: '$4',
         top: '$4',
-        color: THEMES[theme].color,
+        color: 'currentColor',
         ...css
       }}
-      is={THEMES[theme].icon}
+      is={toIconSVG[theme]}
       size="sm"
     />
   )

--- a/lib/src/components/section-message/SectionMessageLayout.tsx
+++ b/lib/src/components/section-message/SectionMessageLayout.tsx
@@ -1,29 +1,22 @@
 import React from 'react'
 
-import { Flex } from '../flex'
+import { Box } from '../box'
+import { Stack } from '../stack'
 
 export const SectionMessageContent = ({
   css,
   ...rest
-}: React.ComponentProps<typeof Flex>): JSX.Element => {
-  return (
-    <Flex
-      css={{
-        columnGap: '$2',
-        rowGap: '$4',
-        flexWrap: 'wrap',
-        width: '100%',
-        alignItems: 'center',
-        justifyContent: 'space-between'
-      }}
-      {...rest}
-    />
-  )
+}: React.ComponentProps<typeof Box>): JSX.Element => {
+  return <Box css={{ maxWidth: '100%', flexShrink: 0, ...css }} {...rest} />
 }
 
 export const SectionMessageActions = ({
   css,
   ...rest
-}: React.ComponentProps<typeof Flex>): JSX.Element => {
-  return <Flex css={{ flexWrap: 'wrap', gap: '$3', ...css }} {...rest} />
+}: React.ComponentProps<typeof Stack>): JSX.Element => {
+  return (
+    <Box css={{ maxWidth: '100%', flexShrink: 0, ...css }}>
+      <Stack wrap="wrap" gap={3} {...rest} />
+    </Box>
+  )
 }

--- a/lib/src/components/section-message/SectionMessageText.tsx
+++ b/lib/src/components/section-message/SectionMessageText.tsx
@@ -1,22 +1,17 @@
 import React from 'react'
 
 import { Text } from '../text'
-import { THEMES } from './SectionMessage'
-import { useSectionMessageContext } from './SectionMessageContext'
 
 export const SectionMessageTitle = ({
   css,
   ...rest
 }: React.ComponentProps<typeof Text>): JSX.Element => {
-  const { theme } = useSectionMessageContext()
-
   return (
     <Text
       css={{
         fontWeight: 600,
         fontSize: '$md',
         mb: '$2',
-        color: THEMES[theme].color,
         ...css
       }}
       {...rest}

--- a/lib/src/components/section-message/SectionMessageText.tsx
+++ b/lib/src/components/section-message/SectionMessageText.tsx
@@ -16,7 +16,6 @@ export const SectionMessageTitle = ({
         fontWeight: 600,
         fontSize: '$md',
         mb: '$2',
-        pt: '1px',
         color: THEMES[theme].color,
         ...css
       }}

--- a/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
+++ b/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
@@ -2,6 +2,14 @@
 
 exports[`renders SectionMessage component and has no programmatically detectable a11y issues 1`] = `
 @media  {
+  .c-jgdwfn {
+    display: flex;
+  }
+
+  .c-jgdwfn > * {
+    margin: 0;
+  }
+
   .c-dbrbZt {
     display: inline-block;
     fill: none;
@@ -9,10 +17,6 @@ exports[`renders SectionMessage component and has no programmatically detectable
     stroke-linecap: round;
     stroke-linejoin: round;
     vertical-align: middle;
-  }
-
-  .c-dhzjXW {
-    display: flex;
   }
 
   .c-dyvMgW {
@@ -91,6 +95,32 @@ exports[`renders SectionMessage component and has no programmatically detectable
 }
 
 @media  {
+  .c-jgdwfn-ejCoEP-direction-row {
+    flex-direction: row;
+  }
+
+  .c-jgdwfn-XefLA-wrap-wrap {
+    flex-wrap: wrap;
+  }
+
+  .c-jgdwfn-awKDG-justify-start {
+    justify-content: flex-start;
+  }
+
+  .c-jgdwfn-jroWjL-align-center {
+    align-items: center;
+  }
+
+  .c-jgdwfn-dlytZv-gap-3 {
+    margin-top: calc(var(--space-3)*-1);
+    margin-left: calc(var(--space-3)*-1);
+  }
+
+  .c-jgdwfn-dlytZv-gap-3 > * {
+    margin-top: var(--space-3);
+    margin-left: var(--space-3);
+  }
+
   .c-dbrbZt-cyeZeh-size-sm {
     height: var(--sizes-1);
     width: var(--sizes-1);
@@ -146,37 +176,40 @@ exports[`renders SectionMessage component and has no programmatically detectable
 }
 
 @media  {
-  .c-PJLV-icCMPWT-css {
+  .c-PJLV-iboLTQx-css {
+    position: relative;
     font-family: var(--fonts-body);
     border-radius: var(--radii-0);
     font-size: var(--fontSizes-sm);
     color: var(--colors-grey900);
     display: flex;
-    padding: var(--space-4);
+    padding: var(--space-4) var(--space-7) var(--space-4) var(--space-6);
     border: 1px solid white;
     background: var(--colors-dangerLight);
   }
 
-  .c-PJLV-ijPPIYB-css {
-    margin-right: var(--space-2);
-    margin-top: -1px;
-    color: var(--colors-dangerDark);
-  }
-
-  .c-dhzjXW-ijwwQRy-css {
-    column-gap: var(--space-2);
-    row-gap: var(--space-4);
-    flex-wrap: wrap;
+  .c-PJLV-iboLTQx-css > * {
     width: 100%;
-    align-items: center;
     justify-content: space-between;
   }
 
-  .c-dyvMgW-ifbbGuT-css {
+  .c-dbrbZt-izgtgt-css {
+    margin: auto;
+    position: absolute;
+    left: var(--space-4);
+    top: var(--space-4);
+    color: var(--colors-dangerDark);
+  }
+
+  .c-PJLV-iduWbFV-css {
+    max-width: 100%;
+    flex-shrink: 0;
+  }
+
+  .c-dyvMgW-ijlNrJk-css {
     font-weight: 600;
     font-size: var(--fontSizes-md);
     margin-bottom: var(--space-2);
-    padding-top: 1px;
     color: var(--colors-dangerDark);
   }
 
@@ -186,25 +219,24 @@ exports[`renders SectionMessage component and has no programmatically detectable
     color: var(--colors-grey900);
   }
 
-  .c-PJLV-iMUsZT-css {
-    margin-left: auto;
-    margin-top: calc(var(--space-2)*-1);
-    margin-right: calc(var(--space-2)*-1);
-    margin-bottom: calc(var(--space-2)*-1);
-    padding-left: var(--space-4);
+  .c-PJLV-iefwZNm-css {
+    margin: auto;
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
   }
 }
 
 <div>
   <div
-    class="c-PJLV c-PJLV-icCMPWT-css"
+    class="c-PJLV c-PJLV-iboLTQx-css"
   >
     <div
-      class="c-PJLV c-PJLV-ijPPIYB-css"
+      class="c-jgdwfn c-jgdwfn-ejCoEP-direction-row c-jgdwfn-XefLA-wrap-wrap c-jgdwfn-awKDG-justify-start c-jgdwfn-jroWjL-align-center c-jgdwfn-dlytZv-gap-3"
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm"
+        class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-izgtgt-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -223,15 +255,11 @@ exports[`renders SectionMessage component and has no programmatically detectable
           r="10"
         />
       </svg>
-    </div>
-    <div
-      class="c-dhzjXW c-dhzjXW-ijwwQRy-css"
-    >
       <div
-        class="c-PJLV"
+        class="c-PJLV c-PJLV-iduWbFV-css"
       >
         <p
-          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dyvMgW-ifbbGuT-css"
+          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dyvMgW-ijlNrJk-css"
         >
           Title message
         </p>
@@ -241,27 +269,27 @@ exports[`renders SectionMessage component and has no programmatically detectable
           This is the description
         </p>
       </div>
-    </div>
-    <div
-      class="c-PJLV c-PJLV-iMUsZT-css"
-    >
-      <button
-        aria-label="Dismiss"
-        class="c-fDzwZw c-fDzwZw-elrktp-size-sm c-fDzwZw-otpKd-cv c-fDzwZw-iPJLV-css c-PJLV"
-        data-state="closed"
-        type="button"
+      <div
+        class="c-PJLV c-PJLV-iefwZNm-css"
       >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        <button
+          aria-label="Dismiss"
+          class="c-fDzwZw c-fDzwZw-elrktp-size-sm c-fDzwZw-otpKd-cv c-fDzwZw-iPJLV-css c-PJLV"
+          data-state="closed"
+          type="button"
         >
-          <path
-            d="m6.343 6.343 11.314 11.314m-11.314 0L17.657 6.343"
-          />
-        </svg>
-      </button>
+          <svg
+            aria-hidden="true"
+            class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-iPJLV-css"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m6.343 6.343 11.314 11.314m-11.314 0L17.657 6.343"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
+++ b/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
@@ -92,6 +92,19 @@ exports[`renders SectionMessage component and has no programmatically detectable
       animation-name: k-fvyGIa;
     }
 }
+
+  .c-flbHeh {
+    flex-grow: 1;
+    justify-content: space-between !important;
+  }
+
+  .c-iikTjs {
+    position: relative;
+    border-radius: var(--radii-0);
+    display: flex;
+    padding: var(--space-4);
+    border: 1px solid white;
+  }
 }
 
 @media  {
@@ -152,6 +165,19 @@ exports[`renders SectionMessage component and has no programmatically detectable
   .c-hVoQtf-gWQnqe-size-md {
     max-width: 250px;
   }
+
+  .c-iikTjs-jtgfr-theme-error {
+    background: var(--colors-dangerLight);
+    color: var(--colors-dangerDark);
+  }
+
+  .c-iikTjs-cSgxUp-hasIcon-true {
+    padding-left: var(--space-6);
+  }
+
+  .c-iikTjs-IFRSO-hasDismiss-true {
+    padding-right: var(--space-7);
+  }
 }
 
 @media  {
@@ -176,29 +202,12 @@ exports[`renders SectionMessage component and has no programmatically detectable
 }
 
 @media  {
-  .c-PJLV-iboLTQx-css {
-    position: relative;
-    font-family: var(--fonts-body);
-    border-radius: var(--radii-0);
-    font-size: var(--fontSizes-sm);
-    color: var(--colors-grey900);
-    display: flex;
-    padding: var(--space-4) var(--space-7) var(--space-4) var(--space-6);
-    border: 1px solid white;
-    background: var(--colors-dangerLight);
-  }
-
-  .c-PJLV-iboLTQx-css > * {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .c-dbrbZt-izgtgt-css {
+  .c-dbrbZt-ihCBfwK-css {
     margin: auto;
     position: absolute;
     left: var(--space-4);
     top: var(--space-4);
-    color: var(--colors-dangerDark);
+    color: currentColor;
   }
 
   .c-PJLV-iduWbFV-css {
@@ -206,11 +215,10 @@ exports[`renders SectionMessage component and has no programmatically detectable
     flex-shrink: 0;
   }
 
-  .c-dyvMgW-ijlNrJk-css {
+  .c-dyvMgW-ijgfvds-css {
     font-weight: 600;
     font-size: var(--fontSizes-md);
     margin-bottom: var(--space-2);
-    color: var(--colors-dangerDark);
   }
 
   .c-dyvMgW-ifUdxDN-css {
@@ -219,7 +227,7 @@ exports[`renders SectionMessage component and has no programmatically detectable
     color: var(--colors-grey900);
   }
 
-  .c-PJLV-iefwZNm-css {
+  .c-fDzwZw-iefwZNm-css {
     margin: auto;
     position: absolute;
     top: var(--space-2);
@@ -229,14 +237,14 @@ exports[`renders SectionMessage component and has no programmatically detectable
 
 <div>
   <div
-    class="c-PJLV c-PJLV-iboLTQx-css"
+    class="c-iikTjs c-iikTjs-jtgfr-theme-error c-iikTjs-cSgxUp-hasIcon-true c-iikTjs-IFRSO-hasDismiss-true"
   >
     <div
-      class="c-jgdwfn c-jgdwfn-ejCoEP-direction-row c-jgdwfn-XefLA-wrap-wrap c-jgdwfn-awKDG-justify-start c-jgdwfn-jroWjL-align-center c-jgdwfn-dlytZv-gap-3"
+      class="c-jgdwfn c-jgdwfn-ejCoEP-direction-row c-jgdwfn-XefLA-wrap-wrap c-jgdwfn-awKDG-justify-start c-jgdwfn-jroWjL-align-center c-jgdwfn-dlytZv-gap-3 c-flbHeh"
     >
       <svg
         aria-hidden="true"
-        class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-izgtgt-css"
+        class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-ihCBfwK-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -259,7 +267,7 @@ exports[`renders SectionMessage component and has no programmatically detectable
         class="c-PJLV c-PJLV-iduWbFV-css"
       >
         <p
-          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dyvMgW-ijlNrJk-css"
+          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dyvMgW-ijgfvds-css"
         >
           Title message
         </p>
@@ -269,27 +277,23 @@ exports[`renders SectionMessage component and has no programmatically detectable
           This is the description
         </p>
       </div>
-      <div
-        class="c-PJLV c-PJLV-iefwZNm-css"
+      <button
+        aria-label="Dismiss"
+        class="c-fDzwZw c-fDzwZw-elrktp-size-sm c-fDzwZw-otpKd-cv c-fDzwZw-iefwZNm-css c-PJLV"
+        data-state="closed"
+        type="button"
       >
-        <button
-          aria-label="Dismiss"
-          class="c-fDzwZw c-fDzwZw-elrktp-size-sm c-fDzwZw-otpKd-cv c-fDzwZw-iPJLV-css c-PJLV"
-          data-state="closed"
-          type="button"
+        <svg
+          aria-hidden="true"
+          class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-iPJLV-css"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="c-dbrbZt c-dbrbZt-cyeZeh-size-sm c-dbrbZt-iPJLV-css"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m6.343 6.343 11.314 11.314m-11.314 0L17.657 6.343"
-            />
-          </svg>
-        </button>
-      </div>
+          <path
+            d="m6.343 6.343 11.314 11.314m-11.314 0L17.657 6.343"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Used position absolute to place `x` and `Icon` - means we can simplify top level container, and don't need a `Box` anymore.

Also we no longer need negative margins as we just position absolute exactly where we want.

Oh it also fixes title and text overflow:
<img width="533" alt="Screenshot 2023-04-26 at 13 16 06" src="https://user-images.githubusercontent.com/6905473/234571717-4d5acd89-04f9-417e-b6a9-fb91f761cd25.png">
