### PR TITLE
fix: block inbuild wrap setting on Stack when direction is column

### DIFF
--- a/lib/src/components/stack/Stack.tsx
+++ b/lib/src/components/stack/Stack.tsx
@@ -83,7 +83,7 @@ export const Stack: React.ForwardRefExoticComponent<StackPropsType> =
             ref={ref}
             direction={direction}
             gap={gap}
-            wrap={wrap}
+            wrap={direction === 'column' ? 'no-wrap' : wrap}
             justify={justify}
             align={
               typeof align === 'undefined' && direction !== 'column'


### PR DESCRIPTION
`flex-direction: column` +  `flex-wrap: wrap` causes weird glitches to the stacked children. This change makes sure it's always set to no-wrap when the direction is column (set via Stack props).


Draft cause I'm not sure what the problem actually is.... D: