### PR TITLE
fix: positioning of tick icon on Checkbox

### DIFF
--- a/lib/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
+++ b/lib/src/components/checkbox-field/__snapshots__/CheckboxField.test.tsx.snap
@@ -8,15 +8,17 @@ exports[`CheckboxField component renders 1`] = `
     margin: 0;
   }
 
-  .c-eOfRZm {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  .c-jgUzPy {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
   }
 
-  .c-emNREM {
+  .c-lhbScT {
     -webkit-appearance: none;
     appearance: none;
+    position: relative;
     background-color: transparent;
     border: 1px solid var(--colors-tonal400);
     border-radius: 3px;
@@ -31,22 +33,22 @@ exports[`CheckboxField component renders 1`] = `
     transition: all 50ms ease-out;
   }
 
-  .c-emNREM[data-state="checked"] {
+  .c-lhbScT[data-state="checked"] {
     background-color: var(--colors-primary);
     border-color: var(--colors-primary);
   }
 
-  .c-emNREM[data-state="indeterminate"] {
+  .c-lhbScT[data-state="indeterminate"] {
     background-color: var(--colors-primary);
     border-color: var(--colors-primary);
   }
 
-  .c-emNREM:focus {
+  .c-lhbScT:focus {
     outline: 2px solid var(--colors-primary);
     outline-offset: 1px;
   }
 
-  .c-emNREM[disabled] {
+  .c-lhbScT[disabled] {
     background-color: var(--colors-tonal100);
     border-color: var(--colors-tonal400);
     cursor: not-allowed;
@@ -112,7 +114,7 @@ exports[`CheckboxField component renders 1`] = `
         >
           <button
             aria-checked="false"
-            class="c-emNREM"
+            class="c-lhbScT"
             data-state="unchecked"
             role="checkbox"
             type="button"

--- a/lib/src/components/checkbox/Checkbox.tsx
+++ b/lib/src/components/checkbox/Checkbox.tsx
@@ -7,13 +7,15 @@ import { styled } from '~/stitches'
 import { Icon } from '../icon'
 
 const StyledIndicator = styled(RadixCheckbox.Indicator, {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center'
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translateX(-50%) translateY(-50%)'
 })
 
 const StyledCheckbox = styled(RadixCheckbox.Root, {
   appearance: 'none',
+  position: 'relative',
   backgroundColor: 'transparent',
   border: '1px solid $colors$tonal400',
   borderRadius: '3px',
@@ -57,12 +59,10 @@ type CheckboxProps = React.ComponentProps<typeof StyledCheckbox>
 export const Checkbox: React.FC<CheckboxProps> = React.forwardRef(
   (props, ref) => (
     <StyledCheckbox {...props} ref={ref}>
-      <StyledIndicator>
+      <StyledIndicator asChild>
         <Icon
           is={props.checked === 'indeterminate' ? Minus : Ok}
           css={{
-            pointerEvents: 'none',
-            position: 'absolute',
             strokeWidth: '3',
             size: 14
           }}

--- a/lib/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/lib/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -2,15 +2,17 @@
 
 exports[`Checkbox component renders a checkbox 1`] = `
 @media  {
-  .c-eOfRZm {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  .c-jgUzPy {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
   }
 
-  .c-emNREM {
+  .c-lhbScT {
     -webkit-appearance: none;
     appearance: none;
+    position: relative;
     background-color: transparent;
     border: 1px solid var(--colors-tonal400);
     border-radius: 3px;
@@ -25,22 +27,22 @@ exports[`Checkbox component renders a checkbox 1`] = `
     transition: all 50ms ease-out;
   }
 
-  .c-emNREM[data-state="checked"] {
+  .c-lhbScT[data-state="checked"] {
     background-color: var(--colors-primary);
     border-color: var(--colors-primary);
   }
 
-  .c-emNREM[data-state="indeterminate"] {
+  .c-lhbScT[data-state="indeterminate"] {
     background-color: var(--colors-primary);
     border-color: var(--colors-primary);
   }
 
-  .c-emNREM:focus {
+  .c-lhbScT:focus {
     outline: 2px solid var(--colors-primary);
     outline-offset: 1px;
   }
 
-  .c-emNREM[disabled] {
+  .c-lhbScT[disabled] {
     background-color: var(--colors-tonal100);
     border-color: var(--colors-tonal400);
     cursor: not-allowed;
@@ -52,7 +54,7 @@ exports[`Checkbox component renders a checkbox 1`] = `
   <label>
     <button
       aria-checked="false"
-      class="c-emNREM"
+      class="c-lhbScT"
       data-state="unchecked"
       role="checkbox"
       title="test"


### PR DESCRIPTION
## The problem this is solving

Checkbox has no `position: relative` - so `position: absolute` Icon glitches when nested in scrollable parent.

https://user-images.githubusercontent.com/6905473/236504880-154ebfca-c44b-4e09-bdba-76ffd93eb729.mov


## Solution
add pos relative to checkbox; and since I'm there use a bit more solid css for positioning the icon and drop a div by using `asChild` for the indicator.

## Screenshots
**BOTH BEFORE AND AFTER (1 video - notice url change)**

https://user-images.githubusercontent.com/6905473/236507988-74752674-598e-4ad4-85d0-ad4b765b9660.mov


