### PR TITLE
fix: Set line height on time input type to fix alignment in Safari

### DIFF
--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -327,9 +327,10 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -955,9 +956,10 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -2422,9 +2424,10 @@ exports[`DataTable component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -2598,7 +2601,7 @@ exports[`DataTable component renders 1`] = `
     class="c-PJLV c-PJLV-ieyRoAv-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
       name="User search"
       type="search"
       value=""
@@ -3295,9 +3298,10 @@ exports[`DataTable server-side renders 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -3563,7 +3567,7 @@ exports[`DataTable server-side renders 1`] = `
     class="c-PJLV c-PJLV-icmpvrW-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
       type="search"
       value=""
     />
@@ -4276,9 +4280,10 @@ exports[`DataTable sticky columns renders 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {

--- a/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
+++ b/lib/src/components/date-field/__snapshots__/DateField.test.tsx.snap
@@ -115,9 +115,10 @@ exports[`DateField component renders a field in error state 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fDzwZw-PrXKS-size-md {
@@ -238,7 +239,7 @@ exports[`DateField component renders a field in error state 1`] = `
         class="c-PJLV c-PJLV-icmpvrW-css"
       >
         <input
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-bXVTjQ-state-error"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-bXVTjQ-state-error"
           id="DATE FIELD"
           name="DATE FIELD"
           type="text"
@@ -404,9 +405,10 @@ exports[`DateField component renders a field with a text input 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fDzwZw-PrXKS-size-md {
@@ -482,7 +484,7 @@ exports[`DateField component renders a field with a text input 1`] = `
         class="c-PJLV c-PJLV-icmpvrW-css"
       >
         <input
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md"
           id="DATE FIELD"
           name="DATE FIELD"
           placeholder="DATE FIELD"

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -61,9 +61,10 @@ exports[`DateInput component renders 1`] = `
 }
 
 @media  {
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fDzwZw-PrXKS-size-md {
@@ -117,7 +118,7 @@ exports[`DateInput component renders 1`] = `
   >
     <input
       aria-label="test"
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md"
       name="date"
       type="text"
       value=""

--- a/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
+++ b/lib/src/components/field-wrapper/__snapshots__/FieldWrapper.test.tsx.snap
@@ -150,9 +150,10 @@ exports[`FieldWrapper component renders 1`] = `
     display: table;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-PJLV-iymbh-theme-error {
@@ -220,7 +221,7 @@ exports[`FieldWrapper component renders 1`] = `
       </a>
     </div>
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md"
       id="example"
       name="example"
       type="text"

--- a/lib/src/components/input-field/__snapshots__/InputField.test.tsx.snap
+++ b/lib/src/components/input-field/__snapshots__/InputField.test.tsx.snap
@@ -100,9 +100,10 @@ exports[`InputField component renders a field in error state 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fZTBsJ-bXVTjQ-state-error {
@@ -184,7 +185,7 @@ exports[`InputField component renders a field in error state 1`] = `
         </label>
       </div>
       <input
-        class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-bXVTjQ-state-error"
+        class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-bXVTjQ-state-error"
         id="INPUT FIELD"
         name="INPUT FIELD"
         type="text"
@@ -298,9 +299,10 @@ exports[`InputField component renders a field with a number input 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -337,7 +339,7 @@ exports[`InputField component renders a field with a number input 1`] = `
         </label>
       </div>
       <input
-        class="c-fZTBsJ c-fZTBsJ-pHZal-size-md"
+        class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md"
         id="INPUT FIELD"
         inputmode="numeric"
         name="INPUT FIELD"
@@ -419,9 +421,10 @@ exports[`InputField component renders a field with a text input 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -458,7 +461,7 @@ exports[`InputField component renders a field with a text input 1`] = `
         </label>
       </div>
       <input
-        class="c-fZTBsJ c-fZTBsJ-pHZal-size-md"
+        class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md"
         id="INPUT FIELD"
         name="INPUT FIELD"
         placeholder="INPUT FIELD"

--- a/lib/src/components/input/Input.tsx
+++ b/lib/src/components/input/Input.tsx
@@ -33,11 +33,13 @@ const StyledInput = styled('input', {
     size: {
       sm: {
         height: '$3',
-        fontSize: '$sm'
+        fontSize: '$sm',
+        lineHeight: 1.7
       },
       md: {
         height: '$4',
-        fontSize: '$md'
+        fontSize: '$md',
+        lineHeight: 2
       }
     },
     state: {

--- a/lib/src/components/input/__snapshots__/Input.test.tsx.snap
+++ b/lib/src/components/input/__snapshots__/Input.test.tsx.snap
@@ -37,9 +37,10 @@ exports[`Input component renders a number input 1`] = `
 }
 
 @media  {
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -53,7 +54,7 @@ exports[`Input component renders a number input 1`] = `
 
 <div>
   <input
-    class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-ikLAKdM-css"
+    class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-ikLAKdM-css"
     inputmode="numeric"
     pattern="[0-9]*"
     placeholder="001"
@@ -99,9 +100,10 @@ exports[`Input component renders a text input 1`] = `
 }
 
 @media  {
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -115,7 +117,7 @@ exports[`Input component renders a text input 1`] = `
 
 <div>
   <input
-    class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-ikLAKdM-css"
+    class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-ikLAKdM-css"
     placeholder="INPUT"
     type="text"
   />

--- a/lib/src/components/number-input-field/__snapshots__/NumberInputField.test.tsx.snap
+++ b/lib/src/components/number-input-field/__snapshots__/NumberInputField.test.tsx.snap
@@ -206,9 +206,10 @@ exports[`NumberInputField component renders a field in error state - has no prog
     max-width: 250px;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fZTBsJ-bXVTjQ-state-error {
@@ -354,7 +355,7 @@ exports[`NumberInputField component renders a field in error state - has no prog
           aria-valuemax="9007199254740991"
           aria-valuemin="0"
           aria-valuenow="0"
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-bXVTjQ-state-error c-fZTBsJ-ibwGleD-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-bXVTjQ-state-error c-fZTBsJ-ibwGleD-css"
           id="numberInputField"
           inputmode="numeric"
           name="numberInputField"
@@ -617,9 +618,10 @@ exports[`NumberInputField component renders a field with a disabled input - has 
     max-width: 250px;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -725,7 +727,7 @@ exports[`NumberInputField component renders a field with a disabled input - has 
           aria-valuemax="9007199254740991"
           aria-valuemin="0"
           aria-valuenow="0"
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-ibwGleD-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-ibwGleD-css"
           disabled=""
           id="numberInputField"
           inputmode="numeric"
@@ -960,9 +962,10 @@ exports[`NumberInputField component renders a field with a number input - has no
     max-width: 250px;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -1068,7 +1071,7 @@ exports[`NumberInputField component renders a field with a number input - has no
           aria-valuemax="9007199254740991"
           aria-valuemin="0"
           aria-valuenow="0"
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-ibwGleD-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-ibwGleD-css"
           id="numberInputField"
           inputmode="numeric"
           name="numberInputField"

--- a/lib/src/components/number-input/__snapshots__/NumberInput.test.tsx.snap
+++ b/lib/src/components/number-input/__snapshots__/NumberInput.test.tsx.snap
@@ -162,9 +162,10 @@ exports[`NumberInput component renders number input  1`] = `
     max-width: 250px;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 }
 
@@ -248,7 +249,7 @@ exports[`NumberInput component renders number input  1`] = `
       aria-valuemax="9007199254740991"
       aria-valuemin="0"
       aria-valuenow="0"
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-ibwGleD-css"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-ibwGleD-css"
       inputmode="numeric"
       name="test"
       pattern="[0-9]*"

--- a/lib/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
+++ b/lib/src/components/password-field/__snapshots__/PasswordField.test.tsx.snap
@@ -141,9 +141,10 @@ exports[`PasswordField component renders a password field 1`] = `
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fDzwZw-PrXKS-size-md {
@@ -235,7 +236,7 @@ exports[`PasswordField component renders a password field 1`] = `
       >
         <input
           autocomplete="current-password"
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-icFLuKp-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-icFLuKp-css"
           id="password"
           name="password"
           type="password"

--- a/lib/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/lib/src/components/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -109,9 +109,10 @@ exports[`PasswordInput component renders 1`] = `
 }
 
 @media  {
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-fDzwZw-PrXKS-size-md {
@@ -172,7 +173,7 @@ exports[`PasswordInput component renders 1`] = `
     class="c-PJLV c-PJLV-icmpvrW-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-icFLuKp-css"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-icFLuKp-css"
       type="password"
     />
     <button

--- a/lib/src/components/search-field/__snapshots__/SearchField.test.tsx.snap
+++ b/lib/src/components/search-field/__snapshots__/SearchField.test.tsx.snap
@@ -113,9 +113,10 @@ exports[`SearchField component renders a field in error state - has no programma
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -219,7 +220,7 @@ exports[`SearchField component renders a field in error state - has no programma
         class="c-PJLV c-PJLV-icmpvrW-css"
       >
         <input
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-fZTBsJ-bXVTjQ-state-error c-cNcGUX c-cNcGUX-icRYcAH-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-fZTBsJ-bXVTjQ-state-error c-cNcGUX c-cNcGUX-icRYcAH-css"
           id="searchField"
           llabel="Search Field"
           name="searchField"
@@ -374,9 +375,10 @@ exports[`SearchField component renders a field with a disabled input - has no pr
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -436,7 +438,7 @@ exports[`SearchField component renders a field with a disabled input - has no pr
         class="c-PJLV c-PJLV-icmpvrW-css"
       >
         <input
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
           disabled=""
           id="searchField"
           name="searchField"
@@ -556,9 +558,10 @@ exports[`SearchField component renders a field with a search input - has no prog
     font-weight: 600;
   }
 
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -618,7 +621,7 @@ exports[`SearchField component renders a field with a search input - has no prog
         class="c-PJLV c-PJLV-icmpvrW-css"
       >
         <input
-          class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+          class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
           id="searchField"
           name="searchField"
           placeholder="Search Field"

--- a/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -59,9 +59,10 @@ exports[`SearchInput component renders 1`] = `
 }
 
 @media  {
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -98,7 +99,7 @@ exports[`SearchInput component renders 1`] = `
     class="c-PJLV c-PJLV-icmpvrW-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
       type="search"
       value=""
     />
@@ -243,9 +244,10 @@ exports[`SearchInput component renders clear button when non-empty defaultValue 
 }
 
 @media  {
-  .c-fZTBsJ-pHZal-size-md {
+  .c-fZTBsJ-fwoCmE-size-md {
     height: var(--sizes-4);
     font-size: var(--fontSizes-md);
+    line-height: 2;
   }
 
   .c-dbrbZt-dMrjnF-size-md {
@@ -318,7 +320,7 @@ exports[`SearchInput component renders clear button when non-empty defaultValue 
     class="c-PJLV c-PJLV-icmpvrW-css"
   >
     <input
-      class="c-fZTBsJ c-fZTBsJ-pHZal-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
+      class="c-fZTBsJ c-fZTBsJ-fwoCmE-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
       type="search"
       value="testingWhenDefaultValue"
     />


### PR DESCRIPTION
When input was set to time the text was misaligned in Safari.
To fix I've set a line height. I followed the other examples of line height and used a numerical value, 2 for `md` and 1.7 for `sm`

**BEFORE**:
<img width="650" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/02260f86-7036-4e68-b01a-56ab028989f7">

<img width="649" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/19d06581-4c77-46ae-8731-126eaa6b765b">

**AFTER**:
<img width="713" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/e3d7f70b-0627-41b5-a9d7-474712f6a10b">

<img width="687" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/dce011ad-21dd-44f4-a494-16639c45c3c3">

**Normal text input still works:**
<img width="647" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/b958eb8a-f31e-40dc-bb4d-ba359db27478">
