### PR TITLE
fix(actionicon): allow overriding the button type

### DIFF
--- a/lib/src/components/action-icon/ActionIcon.tsx
+++ b/lib/src/components/action-icon/ActionIcon.tsx
@@ -269,8 +269,8 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
         tooltipSide={tooltipSide}
       >
         <StyledButton
-          {...remainingProps}
           {...optionalLinkProps}
+          {...remainingProps}
           aria-label={label}
           theme={theme}
           appearance={appearance}


### PR DESCRIPTION
The current ActionIcon doesn't allow to have a `type=submit` when it is used as a button. By reversing the order it allows for a user to pass an override. This will make the component more flexible and allow us to use it in a form. (currently working on a field with a save action icon next to it)

**How the HTML looks like**
<img width="484" alt="image" src="https://github.com/Atom-Learning/components/assets/5703687/affa760e-1b37-4e1e-8320-2e75f25ffa45">
**Sandbox code**
<img width="394" alt="image" src="https://github.com/Atom-Learning/components/assets/5703687/7a6d6a41-6758-4b35-a2ee-fa14c85ef7a1">
