### PR TITLE
Feat/purple badge theme

### DIFF
--- a/documentation/content/components.feedback.badge.md
+++ b/documentation/content/components.feedback.badge.md
@@ -17,7 +17,7 @@ tabs:
       ## Theme
 
 
-      These are the available `theme`s for this component: `success`, `warning`, `danger`, `neutral` and `info`. The default is `info`
+      These are the available `theme`s for this component: `success`, `warning`, `danger`, `neutral`, `info` and `purple`. The default is `info`
 
 
       <CodeBlock live={true} preview={true} code={`<Stack gap={3}>
@@ -26,6 +26,7 @@ tabs:
         <Badge theme="success">Success</Badge>
         <Badge theme="warning">Warning</Badge>
         <Badge theme="danger">Danger</Badge>
+        <Badge theme="purple">Purple</Badge>
       </Stack>`} language={"tsx"} />
 
 

--- a/lib/src/components/badge/Badge.tsx
+++ b/lib/src/components/badge/Badge.tsx
@@ -37,6 +37,10 @@ const StyledBadge = styled(Flex, {
       info: {
         bg: '$primaryLight',
         color: '$primaryMid'
+      },
+      purple: {
+        bg: '$purple200',
+        color: '$purple1000'
       }
     },
     size: {


### PR DESCRIPTION
Added purple badge theme variant to Badge component.

DS docs:

![Zrzut ekranu 2023-05-16 o 10 25 27](https://github.com/Atom-Learning/components/assets/20385360/8a0455b2-e049-467f-8830-6f6bb463198a)

Screenshot:

![Zrzut ekranu 2023-05-16 o 10 06 25](https://github.com/Atom-Learning/components/assets/20385360/575a67af-7110-457e-ab64-5771fd6aefee)
