### PR TITLE
Ds 350/aspect ratio documentation

### DIFF
--- a/documentation/components/admin/editor-component/AspectRatioTokenListEditorComponent.tsx
+++ b/documentation/components/admin/editor-component/AspectRatioTokenListEditorComponent.tsx
@@ -1,0 +1,32 @@
+export const AspectRatioTokenListEditorComponent = {
+  id: 'aspect-ratio-list',
+  label: 'Aspect Ratio List',
+  collapsed: true,
+  fields: [
+    {
+      name: 'ratios',
+      label: 'Ratios',
+      widget: 'list',
+      summary: '{{fields.token}}',
+      fields: [{ label: 'Token', name: 'token', widget: 'string' }]
+    }
+  ],
+  pattern: /^<AspectRatioTokenList ratios={(.*?)} \/>$/ms,
+  fromBlock: function (match) {
+    return {
+      ratios: match[1] && JSON.parse(match[1])
+    }
+  },
+  toBlock: function (data) {
+    const ratiosString = data?.ratios
+      ? JSON.stringify(data.ratios)
+      : JSON.stringify([])
+    return `<AspectRatioTokenList ratios={${ratiosString}} />`
+  },
+  toPreview: function (data) {
+    const ratiosString = data?.ratios?.length
+      ? JSON.stringify(data.ratios)
+      : 'ALL'
+    return `[AspectRatioTokenList ratios={${ratiosString}} /]`
+  }
+}

--- a/documentation/components/markdown/editor-component/AspectRatioTokenList.tsx
+++ b/documentation/components/markdown/editor-component/AspectRatioTokenList.tsx
@@ -1,0 +1,33 @@
+import type { Theme } from '@atom-learning/theme'
+import * as atomTheme from '@atom-learning/theme'
+import { TokenList } from './token-list'
+
+import { DemoBox } from './DemoBox'
+import * as React from 'react'
+
+const AspectRatioExample: typeof TokenList.Item = ({ token, value, ...rest }) => {
+  return (
+    <TokenList.Item token={token} value={value} {...rest}>
+      <DemoBox css={{ aspectRatio: value, width: 'auto' }} />
+    </TokenList.Item>
+  )
+}
+
+type AspectRatioTokenListProps = {
+  ratios?: { token: string; name: string }[]
+}
+
+export const AspectRatioTokenList: React.FC<AspectRatioTokenListProps> = ({
+  ratios: specificRatios,
+  ...rest
+}) => {
+  return (
+    <TokenList
+      direction="column"
+      allTokens={(atomTheme as Theme).ratios}
+      specificTokens={specificRatios}
+      ItemComponent={AspectRatioExample}
+      {...rest}
+    />
+  )
+}

--- a/documentation/components/markdown/index.tsx
+++ b/documentation/components/markdown/index.tsx
@@ -20,6 +20,7 @@ import { FontFamilyTokenList } from './editor-component/FontFamilyTokenList'
 import { FontSizeTokenList } from './editor-component/FontSizeTokenList'
 import { RadiusTokenList } from './editor-component/RadiusTokenList'
 import { ShadowTokenList } from './editor-component/ShadowTokenList'
+import { AspectRatioTokenList } from './editor-component/AspectRatioTokenList'
 import { DosAndDonts } from './editor-component/DosAndDonts'
 import { Cards } from './editor-component/Cards'
 
@@ -75,6 +76,7 @@ export const components = {
   FontSizeTokenList,
   RadiusTokenList,
   ShadowTokenList,
+  AspectRatioTokenList,
   DosAndDonts,
   Cards
 }

--- a/documentation/content/components.feedback.section-message.md
+++ b/documentation/content/components.feedback.section-message.md
@@ -9,8 +9,8 @@ tabs:
     content: >-
       A section message displays a contextual feedback message in a
       particular section of the page. They’re persistent and nonmodal. It can
-      include a dismiss button, allowing the user to either
-      ignore them or interact with them at any time.
+      include a dismiss button, allowing the user to either ignore them or
+      interact with them at any time.
 
       <CodeBlock live={true} preview={true} code={`<SectionMessage>
         <SectionMessage.Icon />
@@ -125,13 +125,7 @@ tabs:
 
       ## API Reference
 
-      <ComponentProps component="SectionMessage" />
-      <ComponentProps component="SectionMessage.Icon" />
-      <ComponentProps component="SectionMessage.Content" />
-      <ComponentProps component="SectionMessage.Title" />
-      <ComponentProps component="SectionMessage.Description" />
-      <ComponentProps component="SectionMessage.Actions" />
-      <ComponentProps component="SectionMessage.Dismiss" />
+      <ComponentProps component="SectionMessage" /> <ComponentProps component="SectionMessage.Icon" /> <ComponentProps component="SectionMessage.Content" /> <ComponentProps component="SectionMessage.Title" /> <ComponentProps component="SectionMessage.Description" /> <ComponentProps component="SectionMessage.Actions" /> <ComponentProps component="SectionMessage.Dismiss" />
   - title: Visual
     content: >-
       ## Structure

--- a/documentation/content/components.surfaces.tile-interactive.md
+++ b/documentation/content/components.surfaces.tile-interactive.md
@@ -4,8 +4,8 @@ title: Tile Interactive
 tabs:
   - title: Code
     content: >-
-      <CodeBlock live={true} preview={true} code={`<TileGroup css={{background:
-      '$grey100', p: '$3', width: '100%'}} justify="center">
+      <CodeBlock live={true} preview={true} code={`<TileGroup
+      css={{background: '$grey100', p: '$3', width: '100%'}} justify="center">
         <TileInteractive onClick={() => alert('onClick')} css={{size: 100 }} borderRadius="md" />
         <TileInteractive href='/' css={{size: 100 }} borderRadius="md" border />
       </TileGroup>`} language={"tsx"} />

--- a/documentation/content/theme.overview.aspect-ratio.md
+++ b/documentation/content/theme.overview.aspect-ratio.md
@@ -22,10 +22,7 @@ tabs:
       The following aspect ratios are recommended for use across your UI: 16:9; 3:2; 4:3; 1:1; 3:4; 2:3.
 
 
-      The chip acts a container of different functions and elements such as an avatar, text, or an icon. They can also be closed or removed.
-
-
-      `*code preview goes here`
+      <AspectRatioTokenList ratios={[]} />
 
 
       ![Aspect ratio examples](/assets/images/aspect-ratios.svg "Aspect ratio examples")
@@ -80,4 +77,8 @@ tabs:
       <DosAndDonts items={[{"type":"do","description":"Use for an image or embedded video, and have it resize at a specific ratio.","image":"/assets/images/aspectratio-01-1-.png"},{"type":"dont","description":"Don’t use with fixed size (width & height) elements, as those will not adhere to the width-to-height ratio."},{"type":"do","description":"Use to embed a component or other HTML element."},{"type":"dont","description":"Don’t use without any child elements, because this is only a container element."},{"type":"do","description":"Choose an appropriate aspect ratio to keep information visible."},{"type":"avoid","description":"Cropping elements like images since it will change the original aspect ratio. "},{"type":"do","description":"Use our defined aspect ratios for standard components."},{"type":"avoid","description":"Using other aspect ratios for example in Card component. "}]} />
 parent: lfMACgjU6_Ee5Tw38zwzv
 uuid: 1cd8ca20-c883-4c87-aa31-efb5fa83e3d7
+nestedSlug:
+  - theme
+  - overview
+  - aspect-ratio
 ---

--- a/documentation/pages/admin.jsx
+++ b/documentation/pages/admin.jsx
@@ -10,6 +10,7 @@ import { FontFamilyTokenListEditorComponent } from "~/components/admin/editor-co
 import { FontSizeTokenListEditorComponent } from "~/components/admin/editor-component/FontSizeTokenListEditorComponent";
 import { RadiusTokenListEditorComponent } from "~/components/admin/editor-component/RadiusTokenListEditorComponent";
 import { ShadowTokenListEditorComponent } from "~/components/admin/editor-component/ShadowTokenListEditorComponent";
+import { AspectRatioTokenListEditorComponent } from "~/components/admin/editor-component/AspectRatioTokenListEditorComponent";
 import { DosAndDontsEditorComponent } from "~/components/admin/editor-component/DosAndDontsEditorComponent";
 import { CardsEditorComponent } from "~/components/admin/editor-component/CardsEditorComponent";
 import { UuidWidget } from "~/components/admin/widget/UuidWidget";
@@ -44,6 +45,8 @@ const Admin = () => {
       CMS.registerEditorComponent(RadiusTokenListEditorComponent);
 
       CMS.registerEditorComponent(ShadowTokenListEditorComponent);
+
+      CMS.registerEditorComponent(AspectRatioTokenListEditorComponent);
 
       CMS.registerEditorComponent(DosAndDontsEditorComponent);
 


### PR DESCRIPTION
[JIRA](https://atomlearningltd.atlassian.net/browse/DS-350)

## Description

The recently added aspectRatio tokens needed a component that shows the usage of the tokens in the normalised way we do the rest of the tokens that show the styling in blue boxes.

## Implementation

The components have been added (heavily inspired in the Shadow ones)
And they have been used in the aspect ratio page via the local CMS

## Screenshots

![image](https://github.com/Atom-Learning/components/assets/4931116/d5f84e16-3a57-4ded-9fab-f21f5358937b)

