### PR TITLE
Feat/sp 1474 add metadata component to datatable

### DIFF
--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -697,7 +697,6 @@ describe('DataTable MetaData', () => {
         </DataTable>
       </Wrapper>
     )
-    screen.logTestingPlaygroundURL()
     expect(
       screen.getByText('18 items - Sorted by Name ascending')
     ).toBeInTheDocument()
@@ -715,5 +714,24 @@ describe('DataTable MetaData', () => {
     await waitFor(() => {
       expect(screen.findByText('6 items - Sorted by hobby ascending'))
     })
+  })
+
+  it('overwrites custom sorting label', async () => {
+    render(
+      <Wrapper>
+        <DataTable
+          columns={columns}
+          data={data}
+          defaultSort={{ column: 'name', direction: 'asc' }}
+        >
+          <DataTable.GlobalFilter />
+          <DataTable.MetaData sortLabel="Ordered by" />
+          <DataTable.Table sortable />
+        </DataTable>
+      </Wrapper>
+    )
+    expect(
+      screen.getByText('18 items - Ordered by Name ascending')
+    ).toBeInTheDocument()
   })
 })

--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -716,7 +716,7 @@ describe('DataTable MetaData', () => {
     })
   })
 
-  it('overwrites custom sorting label', async () => {
+  it('overwrites custom copy', async () => {
     render(
       <Wrapper>
         <DataTable
@@ -725,13 +725,15 @@ describe('DataTable MetaData', () => {
           defaultSort={{ column: 'name', direction: 'asc' }}
         >
           <DataTable.GlobalFilter />
-          <DataTable.MetaData sortLabel="Ordered by" />
+          <DataTable.MetaData
+            copy={{ sorted_by: 'Ordered by', ascending: 'going up' }}
+          />
           <DataTable.Table sortable />
         </DataTable>
       </Wrapper>
     )
     expect(
-      screen.getByText('18 items - Ordered by Name ascending')
+      screen.getByText('18 items - Ordered by Name going up')
     ).toBeInTheDocument()
   })
 })

--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -25,6 +25,8 @@ const columns = [
     cell: (info) => info.getValue()
   }),
   columnHelper.accessor('name', {
+    id: 'name',
+    header: 'Name',
     cell: (info) => info.getValue()
   }),
   columnHelper.accessor('hobby', {
@@ -110,7 +112,7 @@ describe('DataTable component', () => {
         </DataTable>
       </Wrapper>
     )
-    const nameHeader = screen.getByText('name')
+    const nameHeader = screen.getByText('Name')
 
     userEvent.click(nameHeader) // Sorts ascending
     expect(screen.getByText('agatha')).toBeVisible()
@@ -400,7 +402,7 @@ describe('DataTable server-side', () => {
     )
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'))
 
-    const nameHeader = screen.getByText('name')
+    const nameHeader = screen.getByText('Name')
 
     userEvent.click(nameHeader)
 
@@ -430,7 +432,7 @@ describe('DataTable server-side', () => {
     )
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'))
 
-    const nameHeader = screen.getByText('name')
+    const nameHeader = screen.getByText('Name')
 
     userEvent.click(nameHeader)
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'))
@@ -512,7 +514,7 @@ describe('DataTable server-side', () => {
 
     userEvent.click(screen.getByLabelText('Next page'))
     userEvent.click(screen.getByLabelText('Previous page'))
-    userEvent.click(screen.getByText('name'))
+    userEvent.click(screen.getByText('Name'))
 
     expect(screen.getByRole('combobox')).toBeDisabled()
     expect(getAsyncData).toHaveBeenCalledTimes(1)
@@ -677,5 +679,41 @@ describe('DataTable EmptyState', () => {
       </Wrapper>
     )
     expect(container).toMatchSnapshot()
+  })
+})
+
+describe('DataTable MetaData', () => {
+  it('renders row count and sorting', async () => {
+    render(
+      <Wrapper>
+        <DataTable
+          columns={columns}
+          data={data}
+          defaultSort={{ column: 'name', direction: 'asc' }}
+        >
+          <DataTable.GlobalFilter />
+          <DataTable.MetaData />
+          <DataTable.Table sortable />
+        </DataTable>
+      </Wrapper>
+    )
+    screen.logTestingPlaygroundURL()
+    expect(
+      screen.getByText('18 items - Sorted by Name ascending')
+    ).toBeInTheDocument()
+
+    const search = screen.getByRole('searchbox')
+    userEvent.clear(search)
+    userEvent.type(search, 'crossfit')
+    await waitFor(() => {
+      expect(screen.findByText('6 items - Sorted by Name ascending'))
+    })
+
+    const hobbyHeader = screen.getByText('hobby')
+
+    userEvent.click(hobbyHeader)
+    await waitFor(() => {
+      expect(screen.findByText('6 items - Sorted by hobby ascending'))
+    })
   })
 })

--- a/lib/src/components/data-table/DataTable.tsx
+++ b/lib/src/components/data-table/DataTable.tsx
@@ -9,6 +9,7 @@ import { DataTableGlobalFilter } from './DataTableGlobalFilter'
 import { DataTableHead } from './DataTableHead'
 import { DataTableHeaderCell } from './DataTableHeaderCell'
 import { DataTableLoading } from './DataTableLoading'
+import { DataTableMetaData } from './DataTableMetaData'
 import { DataTableRow } from './DataTableRow'
 import { DataTableTable } from './DataTableTable'
 import { DragAndDropTable } from './drag-and-drop'
@@ -56,6 +57,11 @@ type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
    *
    * Can navigate forward, backward, or to any specific page. If you need more customisation options,
    * you can build your own implementation with `useDataTable` and other UI components.
+   *
+   */
+
+  MetaData: typeof DataTableMetaData
+  /** Default display of amount of items and current sorting status for 'DataTable'
    *
    */
 
@@ -120,6 +126,7 @@ DataTable.DataCell = DataTableDataCell
 DataTable.DragAndDropTable = DragAndDropTable
 DataTable.Head = DataTableHead
 DataTable.HeaderCell = DataTableHeaderCell
+DataTable.MetaData = DataTableMetaData
 DataTable.Pagination = Pagination
 DataTable.Row = DataTableRow
 DataTable.GlobalFilter = DataTableGlobalFilter

--- a/lib/src/components/data-table/DataTable.types.ts
+++ b/lib/src/components/data-table/DataTable.types.ts
@@ -45,6 +45,7 @@ export type DataTableContextType<T = unknown> = Table<T> & {
   asyncDataState?: AsyncDataState
   runAsyncData?: (options: Partial<TAsyncDataOptions>) => Promise<void>
   data: TAsyncDataResult
+  columns: any
   /**
    * Directly update the data array that the table rows are built from.
    * This is useful when re-ordering rows, but is high-risk if you're not sure what you're doing!

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -147,6 +147,7 @@ export const DataTableProvider = ({
   const value: DataTableContextType = React.useMemo(() => {
     return {
       ...table,
+      columns,
       data,
       setData,
       setIsSortable,

--- a/lib/src/components/data-table/DataTableMetaData.tsx
+++ b/lib/src/components/data-table/DataTableMetaData.tsx
@@ -1,0 +1,36 @@
+import { CSS } from '@stitches/react'
+import * as React from 'react'
+
+import { Text } from '../text'
+import { useDataTable } from './index'
+
+interface IDataTableMetaDataProps {
+  css?: CSS
+}
+
+export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
+  css
+}) => {
+  const { getState, columns, getRowModel } = useDataTable()
+  const { sorting } = getState()
+  const isSorted = sorting.length > 0
+
+  const totalRows = getRowModel()?.rows?.length
+
+  const getColumnDisplayName = (id: string) => {
+    const sortedColumn = columns.find((col) => col.id === id)
+    return sortedColumn?.header
+  }
+
+  const getSortingString = (sorting) => {
+    return `- Sorted by ${getColumnDisplayName(sorting[0].id)} ${
+      sorting[0].desc ? 'descending' : 'ascending'
+    }`
+  }
+
+  return (
+    <Text css={{ fontWeight: 600, ...css }}>{`${totalRows} items ${
+      isSorted ? getSortingString(sorting) : ''
+    }`}</Text>
+  )
+}

--- a/lib/src/components/data-table/DataTableMetaData.tsx
+++ b/lib/src/components/data-table/DataTableMetaData.tsx
@@ -5,10 +5,12 @@ import { Text } from '../text'
 import { useDataTable } from './index'
 
 interface IDataTableMetaDataProps {
+  sortLabel?: string
   css?: CSS
 }
 
 export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
+  sortLabel,
   css
 }) => {
   const { getState, columns, getRowModel } = useDataTable()
@@ -23,9 +25,9 @@ export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
   }
 
   const getSortingString = (sorting) => {
-    return `- Sorted by ${getColumnDisplayName(sorting[0].id)} ${
-      sorting[0].desc ? 'descending' : 'ascending'
-    }`
+    return `- ${sortLabel || 'Sorted by'} ${getColumnDisplayName(
+      sorting[0].id
+    )} ${sorting[0].desc ? 'descending' : 'ascending'}`
   }
 
   return (

--- a/lib/src/components/data-table/DataTableMetaData.tsx
+++ b/lib/src/components/data-table/DataTableMetaData.tsx
@@ -19,7 +19,7 @@ export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
 
   const getColumnDisplayName = (id: string) => {
     const sortedColumn = columns.find((col) => col.id === id)
-    return sortedColumn?.header
+    return sortedColumn?.header || id
   }
 
   const getSortingString = (sorting) => {

--- a/lib/src/components/data-table/DataTableMetaData.tsx
+++ b/lib/src/components/data-table/DataTableMetaData.tsx
@@ -5,12 +5,25 @@ import { Text } from '../text'
 import { useDataTable } from './index'
 
 interface IDataTableMetaDataProps {
+  copy?: {
+    sorted_by?: string
+    ascending?: string
+    descending?: string
+    separator?: string
+  }
   sortLabel?: string
   css?: CSS
 }
 
+const defaultCopy = {
+  sorted_by: 'Sorted by',
+  ascending: 'ascending',
+  descending: 'descending',
+  separator: '-'
+}
+
 export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
-  sortLabel,
+  copy,
   css
 }) => {
   const { getState, columns, getRowModel } = useDataTable()
@@ -19,15 +32,19 @@ export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
 
   const totalRows = getRowModel()?.rows?.length
 
+  const copyMerged = { ...defaultCopy, ...copy }
+
   const getColumnDisplayName = (id: string) => {
     const sortedColumn = columns.find((col) => col.id === id)
     return sortedColumn?.header || id
   }
 
   const getSortingString = (sorting) => {
-    return `- ${sortLabel || 'Sorted by'} ${getColumnDisplayName(
-      sorting[0].id
-    )} ${sorting[0].desc ? 'descending' : 'ascending'}`
+    return `${copyMerged.separator} ${
+      copyMerged.sorted_by
+    } ${getColumnDisplayName(sorting[0].id)} ${
+      sorting[0].desc ? copyMerged.descending : copyMerged.ascending
+    }`
   }
 
   return (

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -1214,7 +1214,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
           >
-            name
+            Name
           </div>
         </th>
         <th
@@ -2646,7 +2646,7 @@ exports[`DataTable component renders 1`] = `
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
           >
-            name
+            Name
           </div>
         </th>
         <th
@@ -3611,7 +3611,7 @@ exports[`DataTable server-side renders 1`] = `
           <div
             class="c-dhzjXW c-dhzjXW-ijroWjL-css"
           >
-            name
+            Name
           </div>
         </th>
         <th
@@ -4560,7 +4560,7 @@ exports[`DataTable sticky columns renders 1`] = `
             <div
               class="c-dhzjXW c-dhzjXW-ijroWjL-css"
             >
-              name
+              Name
             </div>
           </th>
           <th


### PR DESCRIPTION
https://atomlearningltd.atlassian.net/jira/software/projects/SP/boards/8/backlog?selectedIssue=SP-1474
"Add a label component to DataTable that shows the number of items and the column that the sorting is based on. This should be added as a compound component, i.e. DataTable.MetaData."

***DEFAULT SORTING***
<img width="1878" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/77820a6e-8c2a-4647-bfb3-0b8719a12fe5">

***FILTERED WITH SEARCH***
<img width="1868" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/7711b11a-600c-4a2d-beb4-0055c4b9f82d">

***SORTED BY ANOTHER COLUMN***
<img width="1876" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/9a8857e4-c665-450c-a8aa-ce7711268e6d">

***UNSORTED***
<img width="1877" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/b74fd186-28da-4f99-83e4-b87ca82093f0">
