### PR TITLE
docs: fix Slider examples

### DIFF
--- a/documentation/content/components.form.fields.slider-field.md
+++ b/documentation/content/components.form.fields.slider-field.md
@@ -18,7 +18,7 @@ tabs:
 
 
       <CodeBlock live={true} preview={true} code={`<Form>
-        <SliderField name="slider" label="Select a value" defaultValue={[50]} />
+        <SliderField name="slider" label="Select a value" defaultValue={[50]} css={{ width: '260px' }} />
       </Form>`} language={"tsx"} />
 
 

--- a/documentation/content/components.form.primitives.slider.md
+++ b/documentation/content/components.form.primitives.slider.md
@@ -61,7 +61,7 @@ tabs:
       `Slider.Steps` work well with the built in `step` property, which defaults to 1 and changes the size of each movement. For example, this would limit the slider to three values only.
 
 
-      <CodeBlock live={true} preview={true} code={`<Slider defaultValue={[50]} min={10} max={20} step={5}>
+      <CodeBlock live={true} preview={true} code={`<Slider defaultValue={[15]} min={10} max={20} step={5} css={{ width: '320px' }}>
         <Slider.Steps
           min={10}
           max={20}


### PR DESCRIPTION
Simply adding with to some examples to fix them

Before

![image](https://github.com/Atom-Learning/components/assets/4931116/6d8588f2-ab0c-4dda-9a32-6ca7358bd34a)


After

![image](https://github.com/Atom-Learning/components/assets/4931116/a27d41c6-46c1-42b3-ae10-8646b31e7ad4)

Before

https://github.com/Atom-Learning/components/assets/4931116/73187419-08d1-4846-8293-77fa13ddb930

After

https://github.com/Atom-Learning/components/assets/4931116/96b4c420-8081-47eb-8c64-cc9d77dec3c4


