### PR TITLE
DS 383 fix data table pagination styles so it is responsive in small screens

### DIFF
--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -102,11 +102,13 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     font-weight: bold;
   }
 
-  .c-eIXSIu {
+  .c-dcdOyh {
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-variant-numeric: tabular-nums;
+    flex-wrap: wrap;
+    row-gap: var(--space-4);
   }
 
   .c-dyvMgW {
@@ -592,16 +594,33 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     align-items: center;
   }
 
+  .c-dyvMgW-iwvqwk-css {
+    padding-right: var(--space-4);
+  }
+
+@media (min-width: 550px) {
+    .c-dyvMgW-iwvqwk-css {
+      flex-basis: 50%;
+    }
+}
+
+  .c-dhzjXW-icVHJya-css {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+@media (min-width: 550px) {
+    .c-dhzjXW-icVHJya-css {
+      flex-basis: 50%;
+    }
+}
+
   .c-beXZpM-ihbpiMz-css {
     margin-right: var(--space-3);
   }
 
   .c-dyvMgW-igbZjeK-css {
     flex: none;
-  }
-
-  .c-dhzjXW-ibZmKkd-css {
-    justify-content: flex-end;
   }
 
   .c-fDzwZw-illEebI-css {
@@ -800,11 +819,13 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     font-weight: bold;
   }
 
-  .c-eIXSIu {
+  .c-dcdOyh {
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-variant-numeric: tabular-nums;
+    flex-wrap: wrap;
+    row-gap: var(--space-4);
   }
 
   .c-dyvMgW {
@@ -1135,16 +1156,33 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     align-items: center;
   }
 
+  .c-dyvMgW-iwvqwk-css {
+    padding-right: var(--space-4);
+  }
+
+@media (min-width: 550px) {
+    .c-dyvMgW-iwvqwk-css {
+      flex-basis: 50%;
+    }
+}
+
+  .c-dhzjXW-icVHJya-css {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+@media (min-width: 550px) {
+    .c-dhzjXW-icVHJya-css {
+      flex-basis: 50%;
+    }
+}
+
   .c-beXZpM-ihbpiMz-css {
     margin-right: var(--space-3);
   }
 
   .c-dyvMgW-igbZjeK-css {
     flex: none;
-  }
-
-  .c-dhzjXW-ibZmKkd-css {
-    justify-content: flex-end;
   }
 
   .c-fDzwZw-illEebI-css {
@@ -2282,11 +2320,13 @@ exports[`DataTable component renders 1`] = `
     font-weight: bold;
   }
 
-  .c-eIXSIu {
+  .c-dcdOyh {
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-variant-numeric: tabular-nums;
+    flex-wrap: wrap;
+    row-gap: var(--space-4);
   }
 
   .c-dyvMgW {
@@ -2569,16 +2609,33 @@ exports[`DataTable component renders 1`] = `
     align-items: center;
   }
 
+  .c-dyvMgW-iwvqwk-css {
+    padding-right: var(--space-4);
+  }
+
+@media (min-width: 550px) {
+    .c-dyvMgW-iwvqwk-css {
+      flex-basis: 50%;
+    }
+}
+
+  .c-dhzjXW-icVHJya-css {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+@media (min-width: 550px) {
+    .c-dhzjXW-icVHJya-css {
+      flex-basis: 50%;
+    }
+}
+
   .c-beXZpM-ihbpiMz-css {
     margin-right: var(--space-3);
   }
 
   .c-dyvMgW-igbZjeK-css {
     flex: none;
-  }
-
-  .c-dhzjXW-ibZmKkd-css {
-    justify-content: flex-end;
   }
 
   .c-fDzwZw-illEebI-css {
@@ -2935,76 +2992,80 @@ exports[`DataTable component renders 1`] = `
     </tbody>
   </table>
   <nav
-    class="c-eIXSIu"
+    class="c-dcdOyh"
   >
     <p
-      class="c-dyvMgW c-dyvMgW-bndJoy-size-sm"
+      class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-iwvqwk-css"
     >
       1 - 10 of 18 items
     </p>
     <div
-      class="c-dhzjXW c-dhzjXW-ijroWjL-css"
+      class="c-dhzjXW c-dhzjXW-icVHJya-css"
     >
-      <select
-        class="c-beXZpM c-beXZpM-cGAtlD-size-sm c-beXZpM-ihbpiMz-css"
+      <div
+        class="c-dhzjXW c-dhzjXW-ijroWjL-css"
       >
-        <option
-          value="0"
+        <select
+          class="c-beXZpM c-beXZpM-cGAtlD-size-sm c-beXZpM-ihbpiMz-css"
         >
-          1
-        </option>
-        <option
-          value="1"
+          <option
+            value="0"
+          >
+            1
+          </option>
+          <option
+            value="1"
+          >
+            2
+          </option>
+        </select>
+        <p
+          class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-igbZjeK-css"
         >
-          2
-        </option>
-      </select>
-      <p
-        class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-igbZjeK-css"
+          of 2 pages
+        </p>
+      </div>
+      <div
+        class="c-dhzjXW"
       >
-        of 2 pages
-      </p>
-    </div>
-    <div
-      class="c-dhzjXW c-dhzjXW-ibZmKkd-css"
-    >
-      <button
-        aria-label="Previous page"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-fDzwZw-illEebI-css c-PJLV"
-        data-state="closed"
-        disabled=""
-        name="Previous page"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        <button
+          aria-label="Previous page"
+          class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-fDzwZw-illEebI-css c-PJLV"
+          data-state="closed"
+          disabled=""
+          name="Previous page"
+          type="button"
         >
-          <polyline
-            points="14 18 8 12 14 6 14 6"
-          />
-        </svg>
-      </button>
-      <button
-        aria-label="Next page"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-PJLV"
-        data-state="closed"
-        name="Next page"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+          <svg
+            aria-hidden="true"
+            class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polyline
+              points="14 18 8 12 14 6 14 6"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="Next page"
+          class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-PJLV"
+          data-state="closed"
+          name="Next page"
+          type="button"
         >
-          <polyline
-            points="10 6 16 12 10 18 10 18"
-          />
-        </svg>
-      </button>
+          <svg
+            aria-hidden="true"
+            class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polyline
+              points="10 6 16 12 10 18 10 18"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </nav>
 </div>
@@ -3112,11 +3173,13 @@ exports[`DataTable server-side renders 1`] = `
     font-weight: bold;
   }
 
-  .c-eIXSIu {
+  .c-dcdOyh {
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-variant-numeric: tabular-nums;
+    flex-wrap: wrap;
+    row-gap: var(--space-4);
   }
 
   .c-dyvMgW {
@@ -3503,16 +3566,33 @@ exports[`DataTable server-side renders 1`] = `
     align-items: center;
   }
 
+  .c-dyvMgW-iwvqwk-css {
+    padding-right: var(--space-4);
+  }
+
+@media (min-width: 550px) {
+    .c-dyvMgW-iwvqwk-css {
+      flex-basis: 50%;
+    }
+}
+
+  .c-dhzjXW-icVHJya-css {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+@media (min-width: 550px) {
+    .c-dhzjXW-icVHJya-css {
+      flex-basis: 50%;
+    }
+}
+
   .c-beXZpM-ihbpiMz-css {
     margin-right: var(--space-3);
   }
 
   .c-dyvMgW-igbZjeK-css {
     flex: none;
-  }
-
-  .c-dhzjXW-ibZmKkd-css {
-    justify-content: flex-end;
   }
 
   .c-fDzwZw-illEebI-css {
@@ -3900,76 +3980,80 @@ exports[`DataTable server-side renders 1`] = `
     </tbody>
   </table>
   <nav
-    class="c-eIXSIu"
+    class="c-dcdOyh"
   >
     <p
-      class="c-dyvMgW c-dyvMgW-bndJoy-size-sm"
+      class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-iwvqwk-css"
     >
       1 - 10 of 18 items
     </p>
     <div
-      class="c-dhzjXW c-dhzjXW-ijroWjL-css"
+      class="c-dhzjXW c-dhzjXW-icVHJya-css"
     >
-      <select
-        class="c-beXZpM c-beXZpM-cGAtlD-size-sm c-beXZpM-ihbpiMz-css"
+      <div
+        class="c-dhzjXW c-dhzjXW-ijroWjL-css"
       >
-        <option
-          value="0"
+        <select
+          class="c-beXZpM c-beXZpM-cGAtlD-size-sm c-beXZpM-ihbpiMz-css"
         >
-          1
-        </option>
-        <option
-          value="1"
+          <option
+            value="0"
+          >
+            1
+          </option>
+          <option
+            value="1"
+          >
+            2
+          </option>
+        </select>
+        <p
+          class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-igbZjeK-css"
         >
-          2
-        </option>
-      </select>
-      <p
-        class="c-dyvMgW c-dyvMgW-bndJoy-size-sm c-dyvMgW-igbZjeK-css"
+          of 2 pages
+        </p>
+      </div>
+      <div
+        class="c-dhzjXW"
       >
-        of 2 pages
-      </p>
-    </div>
-    <div
-      class="c-dhzjXW c-dhzjXW-ibZmKkd-css"
-    >
-      <button
-        aria-label="Previous page"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-fDzwZw-illEebI-css c-PJLV"
-        data-state="closed"
-        disabled=""
-        name="Previous page"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        <button
+          aria-label="Previous page"
+          class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-fDzwZw-illEebI-css c-PJLV"
+          data-state="closed"
+          disabled=""
+          name="Previous page"
+          type="button"
         >
-          <polyline
-            points="14 18 8 12 14 6 14 6"
-          />
-        </svg>
-      </button>
-      <button
-        aria-label="Next page"
-        class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-PJLV"
-        data-state="closed"
-        name="Next page"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+          <svg
+            aria-hidden="true"
+            class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polyline
+              points="14 18 8 12 14 6 14 6"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="Next page"
+          class="c-fDzwZw c-fDzwZw-PrXKS-size-md c-fDzwZw-rloUt-isRounded-true c-fDzwZw-jpgoGt-cv c-PJLV"
+          data-state="closed"
+          name="Next page"
+          type="button"
         >
-          <polyline
-            points="10 6 16 12 10 18 10 18"
-          />
-        </svg>
-      </button>
+          <svg
+            aria-hidden="true"
+            class="c-dbrbZt c-dbrbZt-dMrjnF-size-md c-dbrbZt-iPJLV-css"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polyline
+              points="10 6 16 12 10 18 10 18"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </nav>
 </div>
@@ -4077,11 +4161,13 @@ exports[`DataTable sticky columns renders 1`] = `
     font-weight: bold;
   }
 
-  .c-eIXSIu {
+  .c-dcdOyh {
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-variant-numeric: tabular-nums;
+    flex-wrap: wrap;
+    row-gap: var(--space-4);
   }
 
   .c-dyvMgW {
@@ -4449,16 +4535,33 @@ exports[`DataTable sticky columns renders 1`] = `
     align-items: center;
   }
 
+  .c-dyvMgW-iwvqwk-css {
+    padding-right: var(--space-4);
+  }
+
+@media (min-width: 550px) {
+    .c-dyvMgW-iwvqwk-css {
+      flex-basis: 50%;
+    }
+}
+
+  .c-dhzjXW-icVHJya-css {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+@media (min-width: 550px) {
+    .c-dhzjXW-icVHJya-css {
+      flex-basis: 50%;
+    }
+}
+
   .c-beXZpM-ihbpiMz-css {
     margin-right: var(--space-3);
   }
 
   .c-dyvMgW-igbZjeK-css {
     flex: none;
-  }
-
-  .c-dhzjXW-ibZmKkd-css {
-    justify-content: flex-end;
   }
 
   .c-fDzwZw-illEebI-css {

--- a/lib/src/components/data-table/pagination/Pagination.tsx
+++ b/lib/src/components/data-table/pagination/Pagination.tsx
@@ -12,7 +12,9 @@ const StyledNav = styled('nav', {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  fontVariantNumeric: 'tabular-nums'
+  fontVariantNumeric: 'tabular-nums',
+  flexWrap: 'wrap',
+  rowGap: '$4'
 })
 
 type PaginationProps = React.ComponentProps<typeof StyledNav>
@@ -50,32 +52,46 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
 
   return (
     <StyledNav {...props}>
-      <Text size="sm">
+      <Text
+        size="sm"
+        css={{
+          pr: '$4',
+          '@sm': { flexBasis: '50%' }
+        }}
+      >
         {`${recordsCountFrom.toString()} - ${recordsCountTo.toString()} of ${getTotalRows()} items`}
       </Text>
 
-      <GotoPageSelect
-        gotoPage={setPageIndex}
-        pageCount={getPageCount()}
-        pageIndex={paginationState.pageIndex}
-        disabled={isPaginationDisabled}
-      />
+      <Flex
+        css={{
+          justifyContent: 'space-between',
+          width: '100%',
+          '@sm': { flexBasis: '50%' }
+        }}
+      >
+        <GotoPageSelect
+          gotoPage={setPageIndex}
+          pageCount={getPageCount()}
+          pageIndex={paginationState.pageIndex}
+          disabled={isPaginationDisabled}
+        />
 
-      <Flex css={{ justifyContent: 'flex-end' }}>
-        <DirectionButton
-          direction="previous"
-          disabled={paginationState.pageIndex === 0 || isPaginationDisabled}
-          onClick={previousPage}
-          css={{ mr: '$4' }}
-        />
-        <DirectionButton
-          direction="next"
-          disabled={
-            paginationState.pageIndex === getPageCount() - 1 ||
-            isPaginationDisabled
-          }
-          onClick={nextPage}
-        />
+        <Flex>
+          <DirectionButton
+            direction="previous"
+            disabled={paginationState.pageIndex === 0 || isPaginationDisabled}
+            onClick={previousPage}
+            css={{ mr: '$4' }}
+          />
+          <DirectionButton
+            direction="next"
+            disabled={
+              paginationState.pageIndex === getPageCount() - 1 ||
+              isPaginationDisabled
+            }
+            onClick={nextPage}
+          />
+        </Flex>
       </Flex>
     </StyledNav>
   )


### PR DESCRIPTION
Please ignore `NaN`, `undefined` etc in the screenshot. It's just a rushed sandbox DataTable to work with the layout.

Desktop
<img width="993" alt="image" src="https://github.com/Atom-Learning/components/assets/4931116/cde3e054-24e5-4279-a12c-aca1be51b7cc">


Mobile
<img width="354" alt="image" src="https://github.com/Atom-Learning/components/assets/4931116/29ac2ca3-65af-46c4-92d9-385af13ef3cc">
