### PR TITLE
fix: Pagination bugs

### DIFF
--- a/lib/src/components/pagination/PaginationItem.tsx
+++ b/lib/src/components/pagination/PaginationItem.tsx
@@ -3,23 +3,12 @@ import * as React from 'react'
 import { focusVisibleStyleBlock } from '~/utilities'
 
 import { styled } from '../../stitches'
-import { Box } from '..'
 import type { IPaginationItemProps } from './types'
 import { usePagination } from './usePagination'
 
-const Dot = styled(Box, {
-  position: 'absolute',
-  bottom: '-$1',
-  left: '0',
-  transform: 'translateX(50%)',
-  borderRadius: '$round',
-  size: '4px',
-  bg: '$accent9'
-})
-
 const StyledButton = styled('button', {
   alignItems: 'center',
-  border: 'unset',
+  border: '1px solid transparent',
   borderRadius: '$0',
   cursor: 'pointer',
   fontFamily: '$body',
@@ -32,6 +21,7 @@ const StyledButton = styled('button', {
   fontWeight: 400,
   color: '$grey800',
   bg: '$base1',
+  position: 'relative',
   '&:not(:disabled)': {
     '&:hover': {
       color: '$accent10',
@@ -77,16 +67,26 @@ const StyledButton = styled('button', {
       true: {
         fontWeight: 600,
         color: '$accent9',
+        '&:after': {
+          content: '',
+          position: 'absolute',
+          bottom: '$1',
+          left: '50%',
+          ml: '-2px',
+          borderRadius: '$round',
+          size: '4px',
+          bg: '$accent9'
+        },
         '&:not(:disabled)': {
           '&:hover': {
             color: '$accent10',
-            [`& ${Dot}`]: {
+            '&:after': {
               bg: '$accent10'
             }
           },
           '&:active': {
             color: '$accent11',
-            [`& ${Dot}`]: {
+            '&:after': {
               bg: '$accent11'
             }
           }
@@ -125,14 +125,7 @@ export const PaginationItem: React.FC<IPaginationItemProps> = ({
       aria-disabled={isDisabled}
       onMouseOver={handleOnHover}
     >
-      {isIndicated ? (
-        <Box css={{ position: 'relative' }}>
-          {pageNumber}
-          <Dot />
-        </Box>
-      ) : (
-        pageNumber
-      )}
+      {pageNumber}
     </StyledButton>
   )
 }

--- a/lib/src/components/pagination/PaginationItem.tsx
+++ b/lib/src/components/pagination/PaginationItem.tsx
@@ -72,7 +72,7 @@ const StyledButton = styled('button', {
           position: 'absolute',
           bottom: '$1',
           left: '50%',
-          ml: '-2px',
+          transform: 'translateX(-50%)',
           borderRadius: '$round',
           size: '4px',
           bg: '$accent9'

--- a/lib/src/components/pagination/PaginationPopover.tsx
+++ b/lib/src/components/pagination/PaginationPopover.tsx
@@ -1,7 +1,7 @@
 import { Ellypsis } from '@atom-learning/icons'
 import React from 'react'
 
-import { ActionIcon, Icon, Popover, Stack } from '..'
+import { ActionIcon, Flex, Icon, Popover } from '..'
 import { PaginationItem } from './PaginationItem'
 import { usePagination } from './usePagination'
 
@@ -26,7 +26,15 @@ export const PaginationPopover = () => {
         </ActionIcon>
       </Popover.Trigger>
       <Popover.Content size="md" showCloseButton={false} css={{ p: 0 }}>
-        <Stack css={{ p: '$4', display: 'flex', flexWrap: 'wrap' }} gap={1}>
+        <Flex
+          css={{
+            p: '$4',
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 1,
+            justifyContent: 'center'
+          }}
+        >
           {paginationItems?.map((pageNumber) => {
             return (
               <PaginationItem
@@ -36,7 +44,7 @@ export const PaginationPopover = () => {
               />
             )
           })}
-        </Stack>
+        </Flex>
       </Popover.Content>
     </Popover>
   )

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -222,9 +222,9 @@ exports[`Pagination component renders 1`] = `
     margin: 0;
   }
 
-  .c-dgBaxS {
+  .c-fznDru {
     align-items: center;
-    border: unset;
+    border: 1px solid transparent;
     border-radius: var(--radii-0);
     cursor: pointer;
     font-family: var(--fonts-body);
@@ -237,26 +237,27 @@ exports[`Pagination component renders 1`] = `
     font-weight: 400;
     color: var(--colors-grey800);
     background: var(--colors-base1);
+    position: relative;
   }
 
-  .c-dgBaxS:not(:disabled):hover {
+  .c-fznDru:not(:disabled):hover {
     color: var(--colors-accent10);
     background: var(--colors-base2);
   }
 
-  .c-dgBaxS:not(:disabled):active {
+  .c-fznDru:not(:disabled):active {
     background: var(--colors-base3);
     color: var(--colors-grey1000);
   }
 
-  .c-dgBaxS:not(:disabled):focus-visible {
+  .c-fznDru:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
   }
 
-  .c-dgBaxS:disabled {
+  .c-fznDru:disabled {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -351,23 +352,23 @@ exports[`Pagination component renders 1`] = `
     margin-left: var(--space-1);
   }
 
-  .c-dgBaxS-cVoMNQ-size-md {
+  .c-fznDru-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-dgBaxS-bxzneo-selected-true {
+  .c-fznDru-bxzneo-selected-true {
     border: 1px solid var(--colors-accent9);
     color: var(--colors-accent9);
     font-weight: 600;
   }
 
-  .c-dgBaxS-bxzneo-selected-true:not(:disabled):hover {
+  .c-fznDru-bxzneo-selected-true:not(:disabled):hover {
     border-color: var(--colors-accent10);
     color: var(--colors-accent10);
   }
 
-  .c-dgBaxS-bxzneo-selected-true:not(:disabled):active {
+  .c-fznDru-bxzneo-selected-true:not(:disabled):active {
     border-color: var(--colors-accent11);
     font-color: var(--accent11);
   }
@@ -425,14 +426,14 @@ exports[`Pagination component renders 1`] = `
       <button
         aria-current="page"
         aria-disabled="false"
-        class="c-dgBaxS c-dgBaxS-cVoMNQ-size-md c-dgBaxS-bxzneo-selected-true"
+        class="c-fznDru c-fznDru-cVoMNQ-size-md c-fznDru-bxzneo-selected-true"
       >
         1
       </button>
       <button
         aria-current="false"
         aria-disabled="false"
-        class="c-dgBaxS c-dgBaxS-cVoMNQ-size-md"
+        class="c-fznDru c-fznDru-cVoMNQ-size-md"
       >
         2
       </button>
@@ -472,7 +473,7 @@ exports[`Pagination component renders 1`] = `
       <button
         aria-current="false"
         aria-disabled="false"
-        class="c-dgBaxS c-dgBaxS-cVoMNQ-size-md"
+        class="c-fznDru c-fznDru-cVoMNQ-size-md"
       >
         6
       </button>


### PR DESCRIPTION
## Description
This PR fixes two small bugs in the `Navigation` component:
1. The 'indicated page' dot was sometimes not centered horizontally in the button.
2. There was additional spacing on the right side of the popover

## Changes
- Changed the way the indicated-page-dot is centered (now using `left` and `marginLeft`.
- Removed unnecessary elements around the indicated-page-dot.
- Changed the list of page numbers to use `Flex` with `gap` instead of `Stack`.
- Center aligned the page numbers, so that no extra space on the right appears when items move to the next line.

## Screenshots
### Before
<img width="431" alt="image" src="https://github.com/Atom-Learning/components/assets/2501587/5d8efb48-ca97-4155-b378-5b50d5eaec48">

### After
<img width="444" alt="image" src="https://github.com/Atom-Learning/components/assets/2501587/4ae64b3b-5ce7-4866-ad44-ec9bd3ebf320">