### PR TITLE
Fix: limit commit type to feat, fix or perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
       "body-max-line-length": [
         0,
         "always"
+      ],
+      "type-enum": [
+        2,
+        "always", ["feat", "fix", "perf"]
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       ],
       "type-enum": [
         2,
-        "always", ["feat", "fix", "perf"]
+        "always", ["build", "ci", "docs", "feat", "fix", "perf", "refactor", "test"]
       ]
     }
   },


### PR DESCRIPTION
Adds a commitlint rule to limit the commit message types to `feat`, `fix` or `perf` based on our [semantic versioning](https://atomlearning.design/components/overview/versioning)

![image](https://github.com/Atom-Learning/components/assets/11061661/70e04976-0917-4838-b272-5f01d3f01b6d)
