### PR TITLE
fix: remove bottom margin from validation messages

### DIFF
--- a/lib/src/components/create-password-field/CreatePasswordField.tsx
+++ b/lib/src/components/create-password-field/CreatePasswordField.tsx
@@ -87,7 +87,6 @@ export const CreatePasswordField = ({
         <Flex
           css={{
             mt: '$2',
-            mb: '$4',
             gap: '$2',
             flexWrap: 'wrap',
             flexDirection: messageDirection

--- a/lib/src/components/create-password-field/__snapshots__/CreatePasswordField.test.tsx.snap
+++ b/lib/src/components/create-password-field/__snapshots__/CreatePasswordField.test.tsx.snap
@@ -318,9 +318,8 @@ exports[`CreatePasswordField component displays validation styling to the input 
     right: 0;
   }
 
-  .c-dhzjXW-ihAOGrY-css {
+  .c-dhzjXW-icMcHdd-css {
     margin-top: var(--space-2);
-    margin-bottom: var(--space-4);
     gap: var(--space-2);
     flex-wrap: wrap;
     flex-direction: row;


### PR DESCRIPTION
### Description

This removes the bottom margin validation messages. I dont think it should have been added in the first place.
 - It might add unwanted space below the form field
 - The user should rather control how much margin (if any) should be applied. It can be applied though the css prop rather 