### PR TITLE
Fix: Override create password field `name` prop to be optional

### DIFF
--- a/lib/src/components/create-password-field/CreatePasswordField.tsx
+++ b/lib/src/components/create-password-field/CreatePasswordField.tsx
@@ -11,11 +11,13 @@ import { Flex } from '../flex'
 import { InlineMessage } from '../inline-message'
 import { PasswordField } from '../password-field'
 import { PasswordInput } from '../password-input'
+import { Override } from '~/utilities'
 
 type ValidationResult = Record<string, boolean>
 
-type CreatePasswordFieldProps = React.ComponentProps<typeof PasswordInput> &
-  Omit<FieldElementWrapperProps, 'label' | 'name'> & {
+type CreatePasswordFieldProps = Override<
+  React.ComponentProps<typeof PasswordInput> & FieldElementWrapperProps,
+  {
     label?: string
     name?: string
     validate: (
@@ -24,6 +26,7 @@ type CreatePasswordFieldProps = React.ComponentProps<typeof PasswordInput> &
     defaultValidation: ValidationResult
     messageDirection?: CSS['flexDirection']
   }
+>
 
 export const CreatePasswordField = ({
   validate,


### PR DESCRIPTION
### Description

Even though the `name` prop is defaulted, but because its still required by `PasswordInput` and the prop types extend from that it still needed to be applied.

Problem:
![image](https://github.com/Atom-Learning/components/assets/11061661/15b2a7df-efe5-4ba7-8731-c4a9f5d6ef08)

Fix:
![image](https://github.com/Atom-Learning/components/assets/11061661/381f9379-ea94-4c18-bbe2-df140e5bc8fa)
