### PR TITLE
fix: use hashes for classes created via createTheme

### DIFF
--- a/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -245,14 +245,14 @@ exports[`Accordion component renders an accordion 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .interactive-loContrast {
+  .t-dVJiaJ {
     --colors-interactiveForeground: var(--colors-foreground);
     --colors-interactive1: var(--colors-accent1);
     --colors-interactive2: var(--colors-accent2);
     --colors-interactive3: var(--colors-accent3);
   }
 
-  .accent-grey1 {
+  .t-hwCMvs {
     --colors-accent1: #FFFFFF;
     --colors-accent2: var(--colors-grey100);
     --colors-accent3: var(--colors-grey200);
@@ -386,7 +386,7 @@ exports[`Accordion component renders an accordion 1`] = `
         aria-controls="radix-0"
         aria-disabled="true"
         aria-expanded="true"
-        class="c-dkSJnW interactive-loContrast accent-grey1"
+        class="c-dkSJnW t-dVJiaJ t-hwCMvs"
         data-radix-collection-item=""
         data-state="open"
         id="radix-1"
@@ -422,7 +422,7 @@ exports[`Accordion component renders an accordion 1`] = `
       <button
         aria-controls="radix-2"
         aria-expanded="false"
-        class="c-dkSJnW interactive-loContrast accent-grey1"
+        class="c-dkSJnW t-dVJiaJ t-hwCMvs"
         data-radix-collection-item=""
         data-state="closed"
         id="radix-3"

--- a/lib/src/components/badge/__snapshots__/Badge.test.tsx.snap
+++ b/lib/src/components/badge/__snapshots__/Badge.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`Badge component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .info {
+  .t-bYtrHU {
     --colors-textSubtle: var(--colors-blue900);
     --colors-backgroundSubtle: var(--colors-blue100);
     --colors-textBold: #FFF;
@@ -330,7 +330,7 @@ exports[`Badge component renders 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW c-lkWDnA c-lkWDnA-gichzl-emphasis-subtle c-lkWDnA-dvmlHl-size-sm info"
+    class="c-dhzjXW c-lkWDnA c-lkWDnA-gichzl-emphasis-subtle c-lkWDnA-dvmlHl-size-sm t-bYtrHU"
     role="status"
   >
     <p
@@ -587,14 +587,14 @@ exports[`Badge component renders a md size and danger theme 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .info {
+  .t-bYtrHU {
     --colors-textSubtle: var(--colors-blue900);
     --colors-backgroundSubtle: var(--colors-blue100);
     --colors-textBold: #FFF;
     --colors-backgroundBold: var(--colors-blue800);
   }
 
-  .danger {
+  .t-dgJqaz {
     --colors-textSubtle: var(--colors-dangerMid);
     --colors-backgroundSubtle: var(--colors-dangerLight);
     --colors-textBold: #FFF;
@@ -686,7 +686,7 @@ exports[`Badge component renders a md size and danger theme 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW c-lkWDnA c-lkWDnA-gichzl-emphasis-subtle c-lkWDnA-iPuTML-size-md danger"
+    class="c-dhzjXW c-lkWDnA c-lkWDnA-gichzl-emphasis-subtle c-lkWDnA-iPuTML-size-md t-dgJqaz"
     role="status"
   >
     <p
@@ -943,14 +943,14 @@ exports[`Badge component renders with an icon 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .info {
+  .t-bYtrHU {
     --colors-textSubtle: var(--colors-blue900);
     --colors-backgroundSubtle: var(--colors-blue100);
     --colors-textBold: #FFF;
     --colors-backgroundBold: var(--colors-blue800);
   }
 
-  .danger {
+  .t-dgJqaz {
     --colors-textSubtle: var(--colors-dangerMid);
     --colors-backgroundSubtle: var(--colors-dangerLight);
     --colors-textBold: #FFF;
@@ -1061,7 +1061,7 @@ exports[`Badge component renders with an icon 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW c-lkWDnA c-lkWDnA-gichzl-emphasis-subtle c-lkWDnA-dvmlHl-size-sm info"
+    class="c-dhzjXW c-lkWDnA c-lkWDnA-gichzl-emphasis-subtle c-lkWDnA-dvmlHl-size-sm t-bYtrHU"
     role="status"
   >
     <svg

--- a/lib/src/components/badge/stitches.badge.colorscheme.config.ts
+++ b/lib/src/components/badge/stitches.badge.colorscheme.config.ts
@@ -4,7 +4,7 @@ import { createTheme } from '~/stitches'
  * Semantic themes
  */
 
-const info = createTheme('info', {
+const info = createTheme({
   colors: {
     textSubtle: '$blue900',
     backgroundSubtle: '$blue100',
@@ -13,7 +13,7 @@ const info = createTheme('info', {
   }
 })
 
-const neutral = createTheme('neutral', {
+const neutral = createTheme({
   colors: {
     textSubtle: '$grey900',
     backgroundSubtle: '$grey100',
@@ -22,7 +22,7 @@ const neutral = createTheme('neutral', {
   }
 })
 
-const success = createTheme('success', {
+const success = createTheme({
   colors: {
     textSubtle: '$successMid',
     backgroundSubtle: '$successLight',
@@ -31,7 +31,7 @@ const success = createTheme('success', {
   }
 })
 
-const danger = createTheme('danger', {
+const danger = createTheme({
   colors: {
     textSubtle: '$dangerMid',
     backgroundSubtle: '$dangerLight',
@@ -40,7 +40,7 @@ const danger = createTheme('danger', {
   }
 })
 
-const warning = createTheme('warning', {
+const warning = createTheme({
   colors: {
     textSubtle: '$warningText',
     backgroundSubtle: '$warningLight',
@@ -53,7 +53,7 @@ const warning = createTheme('warning', {
  * Non-semantic themes
  */
 
-const grey = createTheme('grey', {
+const grey = createTheme({
   colors: {
     textSubtle: '$grey1000',
     backgroundSubtle: '$grey200',
@@ -62,7 +62,7 @@ const grey = createTheme('grey', {
   }
 })
 
-const blue = createTheme('blue', {
+const blue = createTheme({
   colors: {
     textSubtle: '$blue1000',
     backgroundSubtle: '$blue200',
@@ -71,7 +71,7 @@ const blue = createTheme('blue', {
   }
 })
 
-const purple = createTheme('purple', {
+const purple = createTheme({
   colors: {
     textSubtle: '$purple1000',
     backgroundSubtle: '$purple200',
@@ -80,7 +80,7 @@ const purple = createTheme('purple', {
   }
 })
 
-const cyan = createTheme('cyan', {
+const cyan = createTheme({
   colors: {
     textSubtle: '$cyan1000',
     backgroundSubtle: '$cyan200',
@@ -89,7 +89,7 @@ const cyan = createTheme('cyan', {
   }
 })
 
-const green = createTheme('green', {
+const green = createTheme({
   colors: {
     textSubtle: '$green1000',
     backgroundSubtle: '$green200',
@@ -98,7 +98,7 @@ const green = createTheme('green', {
   }
 })
 
-const magenta = createTheme('magenta', {
+const magenta = createTheme({
   colors: {
     textSubtle: '$magenta1000',
     backgroundSubtle: '$magenta200',
@@ -107,7 +107,7 @@ const magenta = createTheme('magenta', {
   }
 })
 
-const red = createTheme('red', {
+const red = createTheme({
   colors: {
     textSubtle: '$red1000',
     backgroundSubtle: '$red200',
@@ -116,7 +116,7 @@ const red = createTheme('red', {
   }
 })
 
-const teal = createTheme('teal', {
+const teal = createTheme({
   colors: {
     textSubtle: '$teal1000',
     backgroundSubtle: '$teal200',
@@ -125,7 +125,7 @@ const teal = createTheme('teal', {
   }
 })
 
-const orange = createTheme('orange', {
+const orange = createTheme({
   colors: {
     textSubtle: '$orange1000',
     backgroundSubtle: '$orange200',
@@ -134,7 +134,7 @@ const orange = createTheme('orange', {
   }
 })
 
-const yellow = createTheme('yellow', {
+const yellow = createTheme({
   colors: {
     textSubtle: '$yellow1000',
     backgroundSubtle: '$yellow200',
@@ -143,7 +143,7 @@ const yellow = createTheme('yellow', {
   }
 })
 
-const lime = createTheme('lime', {
+const lime = createTheme({
   colors: {
     textSubtle: '$lime1000',
     backgroundSubtle: '$lime200',

--- a/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
+++ b/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`BannerRegular component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .base-purple1 {
+  .t-grLKLB {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: #FFFFFF;
@@ -580,7 +580,7 @@ exports[`BannerRegular component renders 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW c-bSYoqs c-bSYoqs-gsNHYh-emphasis-highContrast base-purple1"
+    class="c-dhzjXW c-bSYoqs c-bSYoqs-gsNHYh-emphasis-highContrast t-grLKLB"
     role="banner"
   >
     <div
@@ -871,7 +871,7 @@ exports[`BannerRegular component renders dismissible variant 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .base-purple1 {
+  .t-grLKLB {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: #FFFFFF;
@@ -1266,7 +1266,7 @@ exports[`BannerRegular component renders dismissible variant 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW c-bSYoqs c-bSYoqs-gsNHYh-emphasis-highContrast base-purple1"
+    class="c-dhzjXW c-bSYoqs c-bSYoqs-gsNHYh-emphasis-highContrast t-grLKLB"
     role="banner"
   >
     <div

--- a/lib/src/components/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/lib/src/components/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -105,36 +105,34 @@ exports[`DropdownMenu component renders 1`] = `
     tabindex="0"
   />
   <button
-    aria-controls="radix-1"
+    aria-controls="radix-4"
     aria-expanded="true"
     aria-haspopup="menu"
     aria-hidden="true"
     class="c-PJLV"
     data-aria-hidden="true"
     data-state="open"
-    id="radix-0"
+    id="radix-3"
     type="button"
   >
     TRIGGER
   </button>
   <div
     data-radix-popper-content-wrapper=""
-    dir="ltr"
-    style="position: fixed; left: 0px; top: 0px; transform: translate(0, -200%); min-width: max-content;"
+    style="position: fixed; left: 0px; top: 0px; transform: translate3d(0, -200%, 0); min-width: max-content;"
   >
     <div
-      aria-labelledby="radix-0"
+      aria-labelledby="radix-3"
       aria-orientation="vertical"
       class="c-ghAfvs"
       data-align="center"
       data-orientation="vertical"
-      data-radix-menu-content=""
       data-side="bottom"
       data-state="open"
       dir="ltr"
-      id="radix-1"
+      id="radix-4"
       role="menu"
-      style="outline: none; --radix-dropdown-menu-content-transform-origin: var(--radix-popper-transform-origin); --radix-dropdown-menu-content-available-width: var(--radix-popper-available-width); --radix-dropdown-menu-content-available-height: var(--radix-popper-available-height); --radix-dropdown-menu-trigger-width: var(--radix-popper-anchor-width); --radix-dropdown-menu-trigger-height: var(--radix-popper-anchor-height); animation: none; pointer-events: auto;"
+      style="outline: none; --radix-dropdown-menu-content-transform-origin: var(--radix-popper-transform-origin); animation: none; pointer-events: auto;"
       tabindex="-1"
     >
       <div

--- a/lib/src/components/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/lib/src/components/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -105,34 +105,36 @@ exports[`DropdownMenu component renders 1`] = `
     tabindex="0"
   />
   <button
-    aria-controls="radix-4"
+    aria-controls="radix-1"
     aria-expanded="true"
     aria-haspopup="menu"
     aria-hidden="true"
     class="c-PJLV"
     data-aria-hidden="true"
     data-state="open"
-    id="radix-3"
+    id="radix-0"
     type="button"
   >
     TRIGGER
   </button>
   <div
     data-radix-popper-content-wrapper=""
-    style="position: fixed; left: 0px; top: 0px; transform: translate3d(0, -200%, 0); min-width: max-content;"
+    dir="ltr"
+    style="position: fixed; left: 0px; top: 0px; transform: translate(0, -200%); min-width: max-content;"
   >
     <div
-      aria-labelledby="radix-3"
+      aria-labelledby="radix-0"
       aria-orientation="vertical"
       class="c-ghAfvs"
       data-align="center"
       data-orientation="vertical"
+      data-radix-menu-content=""
       data-side="bottom"
       data-state="open"
       dir="ltr"
-      id="radix-4"
+      id="radix-1"
       role="menu"
-      style="outline: none; --radix-dropdown-menu-content-transform-origin: var(--radix-popper-transform-origin); animation: none; pointer-events: auto;"
+      style="outline: none; --radix-dropdown-menu-content-transform-origin: var(--radix-popper-transform-origin); --radix-dropdown-menu-content-available-width: var(--radix-popper-available-width); --radix-dropdown-menu-content-available-height: var(--radix-popper-available-height); --radix-dropdown-menu-trigger-width: var(--radix-popper-anchor-width); --radix-dropdown-menu-trigger-height: var(--radix-popper-anchor-height); animation: none; pointer-events: auto;"
       tabindex="-1"
     >
       <div

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`Pagination component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .accent-purple1 {
+  .t-foghYE {
     --colors-accent1: #FFFFFF;
     --colors-accent2: var(--colors-purple100);
     --colors-accent3: var(--colors-purple200);
@@ -259,7 +259,7 @@ exports[`Pagination component renders 1`] = `
     --colors-accent11: var(--colors-purple1000);
   }
 
-  .base-purple2 {
+  .t-eGEuHI {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: var(--colors-purple100);
@@ -500,7 +500,7 @@ exports[`Pagination component renders 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW accent-purple1 base-purple2"
+    class="c-dhzjXW t-foghYE t-eGEuHI"
   >
     <button
       aria-label="Previous page"

--- a/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -245,14 +245,14 @@ exports[`Tabs component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .interactive-hiContrast {
+  .t-fjcNDs {
     --colors-interactiveForeground: var(--colors-foreground7plus);
     --colors-interactive1: var(--colors-accent9);
     --colors-interactive2: var(--colors-accent10);
     --colors-interactive3: var(--colors-accent11);
   }
 
-  .accent-blue1 {
+  .t-jcGjEo {
     --colors-accent1: #FFFFFF;
     --colors-accent2: var(--colors-blue100);
     --colors-accent3: var(--colors-blue200);
@@ -266,7 +266,7 @@ exports[`Tabs component renders 1`] = `
     --colors-accent11: var(--colors-blue1000);
   }
 
-  .base-grey1 {
+  .t-dmfxVJ {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: #FFFFFF;
@@ -405,7 +405,7 @@ exports[`Tabs component renders 1`] = `
     dir="ltr"
   >
     <div
-      class="PJLV c-idmIgS interactive-hiContrast accent-blue1 base-grey1"
+      class="PJLV c-idmIgS t-fjcNDs t-jcGjEo t-dmfxVJ"
     >
       <div
         aria-orientation="horizontal"

--- a/lib/src/components/tile-interactive/__snapshots__/TileInteractive.test.tsx.snap
+++ b/lib/src/components/tile-interactive/__snapshots__/TileInteractive.test.tsx.snap
@@ -245,14 +245,14 @@ exports[`TileInteractive component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .interactive-loContrast {
+  .t-dVJiaJ {
     --colors-interactiveForeground: var(--colors-foreground);
     --colors-interactive1: var(--colors-accent1);
     --colors-interactive2: var(--colors-accent2);
     --colors-interactive3: var(--colors-accent3);
   }
 
-  .accent-blue2 {
+  .t-ctbriF {
     --colors-accent1: var(--colors-blue100);
     --colors-accent2: var(--colors-blue200);
     --colors-accent3: var(--colors-blue300);
@@ -266,7 +266,7 @@ exports[`TileInteractive component renders 1`] = `
     --colors-accent11: var(--colors-blue1100);
   }
 
-  .base-grey1 {
+  .t-dmfxVJ {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: #FFFFFF;
@@ -347,7 +347,7 @@ exports[`TileInteractive component renders 1`] = `
 
 <div>
   <button
-    class="c-htDHry interactive-loContrast accent-blue2 base-grey1 c-bZTcGT c-bZTcGT-iMShsb-css"
+    class="c-htDHry t-dVJiaJ t-ctbriF t-dmfxVJ c-bZTcGT c-bZTcGT-iMShsb-css"
     type="button"
   >
     A

--- a/lib/src/components/tile-toggle-group/__snapshots__/TileToggleGroup.test.tsx.snap
+++ b/lib/src/components/tile-toggle-group/__snapshots__/TileToggleGroup.test.tsx.snap
@@ -245,14 +245,14 @@ exports[`TileToggleGroup component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .interactive-loContrast {
+  .t-dVJiaJ {
     --colors-interactiveForeground: var(--colors-foreground);
     --colors-interactive1: var(--colors-accent1);
     --colors-interactive2: var(--colors-accent2);
     --colors-interactive3: var(--colors-accent3);
   }
 
-  .accent-blue2 {
+  .t-ctbriF {
     --colors-accent1: var(--colors-blue100);
     --colors-accent2: var(--colors-blue200);
     --colors-accent3: var(--colors-blue300);
@@ -266,7 +266,7 @@ exports[`TileToggleGroup component renders 1`] = `
     --colors-accent11: var(--colors-blue1100);
   }
 
-  .base-grey1 {
+  .t-dmfxVJ {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: #FFFFFF;
@@ -401,7 +401,7 @@ exports[`TileToggleGroup component renders 1`] = `
   >
     <button
       aria-pressed="true"
-      class="c-htDHry interactive-loContrast accent-blue2 base-grey1 c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-ctbriF t-dmfxVJ c-bZTcGT c-SVNbK"
       data-radix-collection-item=""
       data-state="on"
       tabindex="-1"
@@ -411,7 +411,7 @@ exports[`TileToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="c-htDHry interactive-loContrast accent-blue2 base-grey1 c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-ctbriF t-dmfxVJ c-bZTcGT c-SVNbK"
       data-disabled=""
       data-radix-collection-item=""
       data-state="on"
@@ -423,7 +423,7 @@ exports[`TileToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-htDHry interactive-loContrast accent-blue2 base-grey1 c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-ctbriF t-dmfxVJ c-bZTcGT c-SVNbK"
       data-radix-collection-item=""
       data-state="off"
       tabindex="-1"
@@ -433,7 +433,7 @@ exports[`TileToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-htDHry interactive-loContrast accent-blue2 base-grey1 c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-ctbriF t-dmfxVJ c-bZTcGT c-SVNbK"
       data-disabled=""
       data-radix-collection-item=""
       data-state="off"

--- a/lib/src/components/tile/__snapshots__/Tile.test.tsx.snap
+++ b/lib/src/components/tile/__snapshots__/Tile.test.tsx.snap
@@ -245,14 +245,14 @@ exports[`Tile component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .interactive-loContrast {
+  .t-dVJiaJ {
     --colors-interactiveForeground: var(--colors-foreground);
     --colors-interactive1: var(--colors-accent1);
     --colors-interactive2: var(--colors-accent2);
     --colors-interactive3: var(--colors-accent3);
   }
 
-  .accent-blue2 {
+  .t-ctbriF {
     --colors-accent1: var(--colors-blue100);
     --colors-accent2: var(--colors-blue200);
     --colors-accent3: var(--colors-blue300);
@@ -266,7 +266,7 @@ exports[`Tile component renders 1`] = `
     --colors-accent11: var(--colors-blue1100);
   }
 
-  .base-grey1 {
+  .t-dmfxVJ {
     --colors-foreground: var(--colors-grey1000);
     --colors-foreground7plus: #FFFFFF;
     --colors-base1: #FFFFFF;
@@ -345,10 +345,10 @@ exports[`Tile component renders 1`] = `
     class="c-jgdwfn c-jgdwfn-ejCoEP-direction-row c-jgdwfn-XefLA-wrap-wrap c-jgdwfn-awKDG-justify-start c-jgdwfn-jroWjL-align-center c-jgdwfn-dlytZv-gap-3"
   >
     <div
-      class="c-htDHry c-htDHry-ieZrHbP-css interactive-loContrast accent-blue2 base-grey1"
+      class="c-htDHry c-htDHry-ieZrHbP-css t-dVJiaJ t-ctbriF t-dmfxVJ"
     />
     <div
-      class="c-htDHry c-htDHry-ieZrHbP-css interactive-loContrast accent-blue2 base-grey1"
+      class="c-htDHry c-htDHry-ieZrHbP-css t-dVJiaJ t-ctbriF t-dmfxVJ"
     />
   </div>
 </div>

--- a/lib/src/experiments/color-scheme/stitches.colorscheme.config.ts
+++ b/lib/src/experiments/color-scheme/stitches.colorscheme.config.ts
@@ -17,7 +17,7 @@ const generateColors = ({ prefix, colorName, color0 = '' }) => {
   return colors
 }
 
-colorSchemes['interactive-loContrast'] = createTheme('interactive-loContrast', {
+colorSchemes['interactive-loContrast'] = createTheme({
   colors: {
     interactiveForeground: '$foreground',
     interactive1: '$accent1',
@@ -26,7 +26,7 @@ colorSchemes['interactive-loContrast'] = createTheme('interactive-loContrast', {
   }
 })
 
-colorSchemes['interactive-hiContrast'] = createTheme('interactive-hiContrast', {
+colorSchemes['interactive-hiContrast'] = createTheme({
   colors: {
     interactiveForeground: '$foreground7plus',
     interactive1: '$accent9',
@@ -68,7 +68,7 @@ const generateBase = () => {
   Object.entries(bases).forEach(
     ([name, { colorName, color0 = '' }]: [string, TcolorSetup]) => {
       const themeName = `base-${name}`
-      colorSchemes[themeName] = createTheme(themeName, {
+      colorSchemes[themeName] = createTheme({
         colors: {
           foreground: '$grey1000',
           foreground7plus: '#FFFFFF',
@@ -107,7 +107,7 @@ const generateAccent = () => {
   Object.entries(accents).forEach(
     ([name, { colorName, color0 = '' }]: [string, TcolorSetup]) => {
       const themeName = `accent-${name}`
-      colorSchemes[themeName] = createTheme(themeName, {
+      colorSchemes[themeName] = createTheme({
         colors: generateColors({ prefix: 'accent', colorName, color0 })
       })
     }


### PR DESCRIPTION
Spotted mistake, after a great question by @thomasdigby 
![Screenshot 2023-08-25 at 11 52 13](https://github.com/Atom-Learning/components/assets/6905473/d01908d4-fff2-4293-b6c8-79d4a51eb1fc)

I have been naming all of the classes in all my `createTheme` uses 🤦  That's what I get for copy/pasting and not reading the docs **thoroughly**... This is obviously not great, as we end up with generic classnames like `danger`!

In this PR, I'm undoing this mistake and letting `createTheme` classes just be hashes. As they should.

**No visual changes** but defo important css changes :)
