### PR TITLE
Fix: `Button`/`Icon`/`isLoading` combo

### DIFF
--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -10,6 +10,30 @@ import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
 import { isExternalLink } from '~/utilities/uri'
 
+const LoaderContentsWrapper = styled('span', {
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'center',
+  visibility: 'hidden',
+  variants: {
+    size: {
+      sm: { gap: '$2' },
+      md: { gap: '$3' },
+      lg: { gap: '$3' }
+    }
+  }
+})
+
+const WithLoader = ({
+  size,
+  children
+}: React.ComponentProps<typeof LoaderContentsWrapper>) => (
+  <>
+    <Loader css={{ position: 'absolute' }} />
+    <LoaderContentsWrapper size={size}>{children}</LoaderContentsWrapper>
+  </>
+)
+
 const getButtonOutlineVariant = (
   base: string,
   interact: string,
@@ -104,6 +128,7 @@ export const StyledButton = styled('button', {
         lineHeight: 1.5,
         height: '$5',
         px: '$5',
+        gap: '$3',
         [`& ${StyledIcon}`]: { size: 22 }
       }
     },
@@ -195,29 +220,6 @@ export const StyledButton = styled('button', {
   ]
 })
 
-const WithLoader = ({ isLoading, children }) => {
-  if (typeof isLoading !== 'boolean') {
-    return children
-  }
-  return (
-    <>
-      <Loader
-        css={{
-          opacity: isLoading ? 1 : 0,
-          position: 'absolute',
-          transition: 'opacity 150ms'
-        }}
-      />
-      <Box
-        as="span"
-        css={isLoading ? { opacity: 0, transition: 'opacity 150ms' } : {}}
-      >
-        {children}
-      </Box>
-    </>
-  )
-}
-
 type ButtonProps = Override<
   React.ComponentProps<typeof StyledButton>,
   VariantProps<typeof StyledButton> & {
@@ -232,7 +234,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       children,
-      isLoading,
+      isLoading = false,
       onClick,
       href,
       appearance = 'solid',
@@ -258,7 +260,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     // Instead the click action is not fired and the button looks faded
     return (
       <StyledButton
-        isLoading={isLoading || false}
+        isLoading={isLoading}
         onClick={!isLoading ? onClick : undefined}
         appearance={appearance}
         size={size}
@@ -268,7 +270,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...buttonSpecificProps}
         ref={ref}
       >
-        <WithLoader isLoading={isLoading}>{children}</WithLoader>
+        {isLoading ? <WithLoader size={size}>{children}</WithLoader> : children}
       </StyledButton>
     )
   }

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -2,7 +2,6 @@ import type { VariantProps } from '@stitches/react'
 import { darken, opacify } from 'color2k'
 import * as React from 'react'
 
-import { Box } from '~/components/box'
 import { StyledIcon } from '~/components/icon'
 import { Loader } from '~/components/loader'
 import { styled, theme } from '~/stitches'

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -9,30 +9,6 @@ import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
 import { isExternalLink } from '~/utilities/uri'
 
-const LoaderContentsWrapper = styled('span', {
-  alignItems: 'center',
-  display: 'flex',
-  justifyContent: 'center',
-  visibility: 'hidden',
-  variants: {
-    size: {
-      sm: { gap: '$2' },
-      md: { gap: '$3' },
-      lg: { gap: '$3' }
-    }
-  }
-})
-
-const WithLoader = ({
-  size,
-  children
-}: React.ComponentProps<typeof LoaderContentsWrapper>) => (
-  <>
-    <Loader css={{ position: 'absolute' }} />
-    <LoaderContentsWrapper size={size}>{children}</LoaderContentsWrapper>
-  </>
-)
-
 const getButtonOutlineVariant = (
   base: string,
   interact: string,
@@ -218,6 +194,30 @@ export const StyledButton = styled('button', {
     }
   ]
 })
+
+const LoaderContentsWrapper = styled('span', {
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'center',
+  visibility: 'hidden',
+  variants: {
+    size: {
+      sm: { gap: '$2' },
+      md: { gap: '$3' },
+      lg: { gap: '$3' }
+    }
+  }
+})
+
+const WithLoader = ({
+  size,
+  children
+}: React.ComponentProps<typeof LoaderContentsWrapper>) => (
+  <>
+    <Loader css={{ position: 'absolute' }} />
+    <LoaderContentsWrapper size={size}>{children}</LoaderContentsWrapper>
+  </>
+)
 
 type ButtonProps = Override<
   React.ComponentProps<typeof StyledButton>,

--- a/lib/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/lib/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -53,6 +53,13 @@ exports[`Button component Loading state renders a loading button 1`] = `
   .c-jBOHFZ:nth-child(3) {
     animation-delay: 0;
   }
+
+  .c-gTMqnE {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    visibility: hidden;
+  }
 }
 
 @media  {
@@ -87,6 +94,10 @@ exports[`Button component Loading state renders a loading button 1`] = `
     width: 6px;
     margin-left: 2px;
     margin-right: 2px;
+  }
+
+  .c-gTMqnE-fVlWzK-size-md {
+    gap: var(--space-3);
   }
 }
 
@@ -158,16 +169,9 @@ exports[`Button component Loading state renders a loading button 1`] = `
 }
 
 @media  {
-  .c-dhzjXW-ihMdMjL-css {
+  .c-dhzjXW-icXxGAL-css {
     justify-content: center;
-    opacity: 1;
     position: absolute;
-    transition: opacity 150ms;
-  }
-
-  .c-PJLV-ikHJJOk-css {
-    opacity: 0;
-    transition: opacity 150ms;
   }
 }
 
@@ -177,7 +181,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
     type="button"
   >
     <div
-      class="c-dhzjXW c-dhzjXW-ihMdMjL-css"
+      class="c-dhzjXW c-dhzjXW-icXxGAL-css"
       role="alert"
     >
       <span
@@ -196,7 +200,7 @@ exports[`Button component Loading state renders a loading button 1`] = `
       />
     </div>
     <span
-      class="c-PJLV c-PJLV-ikHJJOk-css"
+      class="c-gTMqnE c-gTMqnE-fVlWzK-size-md"
     >
       BUTTON
     </span>


### PR DESCRIPTION
When using `Button` with an `Icon` _and_ `isLoading`, the space between icon and text is not applied, this has now been fixed. While I was doing this work, I though it would help to remove the unnecessary animating state from the loader as it's currently bloating our snapshots and has little to no UX value. Also also I fixed the space between icon and text for large buttons.