### PR TITLE
Fix: `Link` polymorphic types

### DIFF
--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
 
 import { styled } from '~/stitches'
-import { NavigatorActions } from '~/types'
-import { Override } from '~/utilities'
+import { PolymorphicComponentPropWithRef } from '~/types'
 import { isExternalLink } from '~/utilities/uri'
 
 import { StyledHeading } from '../heading/Heading'
 import { StyledLi } from '../list/List'
 import { StyledMarkdownEmphasis } from '../markdown-content/components'
 import { StyledText, textVariants } from '../text/Text'
+import type { CSS, VariantProps } from '@stitches/react'
 
 export const StyledLink = styled('a', {
   bg: 'unset',
@@ -33,29 +33,51 @@ export const StyledLink = styled('a', {
         content: 'none'
       }
     },
-  variants: textVariants
+  variants: textVariants,
+  defaultVariants: {
+    size: 'md'
+  }
 })
 
-type LinkProps = Override<
-  React.ComponentProps<typeof StyledLink>,
-  {
-    as?: React.ComponentType | React.ElementType
-  } & NavigatorActions
+type LinkProps<
+  H extends string | undefined,
+  C extends React.ElementType
+> = PolymorphicComponentPropWithRef<
+  C,
+  VariantProps<typeof StyledLink> & {
+    css?: CSS
+    href?: H
+  }
 >
 
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ size = 'md', href, ...props }, ref) => (
-    <StyledLink
-      {...(isExternalLink(href)
-        ? { target: '_blank', rel: 'noopener noreferrer' }
-        : {})}
-      {...(!href && { as: 'button', noCapsize: true })}
-      size={size}
-      href={href}
-      {...props}
-      ref={ref}
-    />
-  )
-) as React.FC<LinkProps>
+export const Link: <
+  H extends string | undefined = undefined,
+  C extends React.ElementType = H extends string ? typeof StyledLink : 'button'
+>(
+  props: LinkProps<H, C>
+) => React.ReactElement | null = React.forwardRef(
+  <
+    H extends string | undefined = undefined,
+    C extends React.ElementType = H extends string
+      ? typeof StyledLink
+      : 'button'
+  >(
+    { as, href, ...rest }: LinkProps<H, C>,
+    ref?: LinkProps<H, C>['ref']
+  ) => {
+    const externalLinkProps = isExternalLink(href)
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : {}
 
-Link.displayName = 'Link'
+    return (
+      <StyledLink
+        as={as || (!href ? 'button' : undefined)}
+        noCapsize={!href ? true : undefined}
+        href={href}
+        {...rest}
+        {...externalLinkProps}
+        ref={ref}
+      />
+    )
+  }
+)


### PR DESCRIPTION
Applied @Mhoog's polymorphic type fixes to the `Link` component (which has the same (but opposite) `a || button` style polymorphism)