### PR TITLE
Fix: Pagination truncation issue

### DIFF
--- a/lib/src/components/pagination/PaginationPages.tsx
+++ b/lib/src/components/pagination/PaginationPages.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
 import { Flex } from '../flex'
-import { TRUNCATED_THRESHOLD } from './pagination.constants'
 import { PaginationItem } from './PaginationItem'
 import { PaginationPopover } from './PaginationPopover'
 import { usePagination } from './usePagination'
@@ -9,7 +8,7 @@ import { usePagination } from './usePagination'
 export const PaginationPages = () => {
   const { pagesCount, paginationItems, paginationAlignment } = usePagination()
 
-  const isTruncated = pagesCount > TRUNCATED_THRESHOLD
+  const isTruncated = pagesCount > paginationItems.length
 
   return (
     <Flex gap={1}>

--- a/lib/src/components/pagination/pagination.constants.ts
+++ b/lib/src/components/pagination/pagination.constants.ts
@@ -1,5 +1,3 @@
-export const TRUNCATED_THRESHOLD = 4
-
 export enum VisibleElementsAmount {
   LESS = 6,
   MORE = 8

--- a/lib/src/components/pagination/pagination.helper.ts
+++ b/lib/src/components/pagination/pagination.helper.ts
@@ -40,9 +40,19 @@ export const getPaginationItemsToRender = (
    * We need to remove `2` from `visibleElementsCount` to account
    * for the previous & next buttons
    *
-   *  +---+  +---+  +---+  +---+
-   *  | 1 |  | 2 |  | 3 |  | 4 |
-   *  +---+  +---+  +---+  +---+
+   *  pagesCount: 4
+   *  visibleElementsCount: 6 // VisibleElementsAmount.LESS
+   *  returns [1, 2, 3, 4]
+   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *  | < |  | 1 |  | 2 |  | 3 |  | 4 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *
+   *  pagesCount: 6
+   *  visibleElementsCount:8 // VisibleElementsAmount.MORE
+   *  returns [1, 2, 3, 4, 5, 6]
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +---+  +---+
+   *  | < |  | 1 |  | 2 |  | 3 |  | 4 |  | 5 |  | 6 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +---+  +---+
    */
   if (pagesCount <= visibleElementsCount - 2) {
     return paginationItems
@@ -55,16 +65,16 @@ export const getPaginationItemsToRender = (
    *  currentPage: 1/2
    *  visibleElementsCount: 6 // VisibleElementsAmount.LESS
    *  returns [1, 2]
-   *  +---+  +---+  +---+  +---+
-   *  | 1 |  | 2 |  | … |  | 6 |
-   *  +---+  +---+  +---+  +---+
+   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *  | < |  | 1 |  | 2 |  | … |  | 6 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+
    *
    *  currentPage: 1/2/3
    *  visibleElementsCount: 8 // VisibleElementsAmount.MORE
    *  returns [1, 2, 3, 4]
-   *  +---+  +---+  +---+  +---+  +---+  +----+
-   *  | 1 |  | 2 |  | 3 |  | 4 |  | … |  | 10 |
-   *  +---+  +---+  +---+  +---+  +---+  +----+
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +----+  +---+
+   *  | < |  | 1 |  | 2 |  | 3 |  | 4 |  | … |  | 10 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +----+  +---+
    */
   if (
     visibleElementsCount === VisibleElementsAmount.MORE
@@ -82,16 +92,16 @@ export const getPaginationItemsToRender = (
    *  currentPage: 7
    *  visibleElementsCount: 6 // VisibleElementsAmount.LESS
    *  returns [7, 8]
-   *  +---+  +---+  +---+  +---+
-   *  | 1 |  | … |  | 7 |  | 8 |
-   *  +---+  +---+  +---+  +---+
+   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *  | < |  | 1 |  | … |  | 7 |  | 8 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+
    *
    *  currentPage: 7
    *  visibleElementsCount: 8 // VisibleElementsAmount.MORE
    *  returns [7, 8, 9, 10]
-   *  +---+  +---+  +---+  +---+  +---+  +---+
-   *  | 1 |  | … |  | 7 |  | 8 |  | 9 |  | 10 |
-   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +----+  +---+
+   *  | < |  | 1 |  | … |  | 7 |  | 8 |  | 9 |  | 10 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +----+  +---+
    */
   if (currentPage > pagesCount - paginationItemsLimit) {
     return paginationItems.slice(-paginationItemsLimit)
@@ -105,16 +115,16 @@ export const getPaginationItemsToRender = (
    *  currentPage: 4
    *  visibleElementsCount: 6 // VisibleElementsAmount.LESS
    *  returns [3, 4]
-   *  +---+  +---+  +---+  +---+
-   *  | 3 |  | 4 |  | … |  | 6 |
-   *  +---+  +---+  +---+  +---+
+   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *  | < |  | 3 |  | 4 |  | … |  | 6 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+
    *
    *  currentPage: 6
    *  visibleElementsCount: 8 // VisibleElementsAmount.MORE
    *  returns [4, 5, 6, 7]
-   *  +---+  +---+  +---+  +---+  +---+  +---+
-   *  | 4 |  | 5 |  | 6 |  | 7 |  | … |  | 10 |
-   *  +---+  +---+  +---+  +---+  +---+  +---+
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +----+  +---+
+   *  | < |  | 4 |  | 5 |  | 6 |  | 7 |  | … |  | 10 |  | > |
+   *  +---+  +---+  +---+  +---+  +---+  +---+  +----+  +---+
    */
   return paginationItems.slice(
     visibleElementsCount === VisibleElementsAmount.MORE

--- a/lib/src/components/pagination/pagination.helper.ts
+++ b/lib/src/components/pagination/pagination.helper.ts
@@ -1,7 +1,4 @@
-import {
-  TRUNCATED_THRESHOLD,
-  VisibleElementsAmount
-} from './pagination.constants'
+import { VisibleElementsAmount } from './pagination.constants'
 import { IPaginationAlignment } from './types'
 
 /**
@@ -38,13 +35,16 @@ export const getPaginationItemsToRender = (
 
   /**
    * If there are fewer pages than our threshold for truncating,
-   * render the entire page list
+   * render the entire page list.
+   *
+   * We need to remove `2` from `visibleElementsCount` to account
+   * for the previous & next buttons
    *
    *  +---+  +---+  +---+  +---+
    *  | 1 |  | 2 |  | 3 |  | 4 |
    *  +---+  +---+  +---+  +---+
    */
-  if (pagesCount <= TRUNCATED_THRESHOLD) {
+  if (pagesCount <= visibleElementsCount - 2) {
     return paginationItems
   }
 


### PR DESCRIPTION
Remove hard-coded `TRUNCATED_THRESHOLD` and use `visibleElementsCount` instead

### Before

![Screenshot 2023-09-01 at 09 43 46](https://github.com/Atom-Learning/components/assets/3226804/e20bf281-2a23-4e36-bbd6-0861de11f5de)
![Screenshot 2023-09-01 at 09 43 40](https://github.com/Atom-Learning/components/assets/3226804/6f9edcaa-e71a-4378-81a4-b7e288a00a50)

### After

![Screenshot 2023-09-01 at 09 43 23](https://github.com/Atom-Learning/components/assets/3226804/5723f4ac-f4b2-4024-b480-656db9d4fd68)
