### PR TITLE
Fix: Revert `Button`/`Link` types

### DIFF
--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -1,11 +1,13 @@
-import type { CSS, VariantProps } from '@stitches/react'
+import type { VariantProps } from '@stitches/react'
 import { darken, opacify } from 'color2k'
 import * as React from 'react'
 
+import { Box } from '~/components/box'
 import { StyledIcon } from '~/components/icon'
 import { Loader } from '~/components/loader'
 import { styled, theme } from '~/stitches'
-import { PolymorphicComponentPropWithRef } from '~/types'
+import { NavigatorActions } from '~/types'
+import { Override } from '~/utilities'
 import { isExternalLink } from '~/utilities/uri'
 
 const getButtonOutlineVariant = (
@@ -122,7 +124,6 @@ export const StyledButton = styled('button', {
       }
     }
   },
-
   compoundVariants: [
     {
       theme: 'primary',
@@ -191,13 +192,7 @@ export const StyledButton = styled('button', {
         darken(theme.colors.primaryDark.value, 0.15)
       )
     }
-  ],
-
-  defaultVariants: {
-    appearance: 'solid',
-    size: 'md',
-    theme: 'primary'
-  }
+  ]
 })
 
 const LoaderContentsWrapper = styled('span', {
@@ -211,9 +206,6 @@ const LoaderContentsWrapper = styled('span', {
       md: { gap: '$3' },
       lg: { gap: '$3' }
     }
-  },
-  defaultVariants: {
-    size: 'md'
   }
 })
 
@@ -227,59 +219,60 @@ const WithLoader = ({
   </>
 )
 
-type ButtonProps<
-  H extends string | undefined,
-  C extends React.ElementType
-> = PolymorphicComponentPropWithRef<
-  C,
+type ButtonProps = Override<
+  React.ComponentProps<typeof StyledButton>,
   VariantProps<typeof StyledButton> & {
-    css?: CSS
-    href?: H
+    as?: React.ComponentType | React.ElementType
+    children: React.ReactNode
+    href?: string
     isLoading?: boolean
-  }
+  } & NavigatorActions
 >
 
-export const Button: <
-  H extends string | undefined = undefined,
-  C extends React.ElementType = H extends string ? 'a' : typeof StyledButton
->(
-  props: ButtonProps<H, C>
-) => React.ReactElement | null = React.forwardRef(
-  <
-    H extends string | undefined = undefined,
-    C extends React.ElementType = H extends string ? 'a' : typeof StyledButton
-  >(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
     {
       children,
-      as,
-      href,
-      isLoading = false,
+      isLoading,
       onClick,
+      href,
+      appearance = 'solid',
+      size = 'md',
+      theme = 'primary',
+      type = 'button',
       ...rest
-    }: ButtonProps<H, C>,
-    ref?: ButtonProps<H, C>['ref']
+    },
+    ref
   ) => {
-    const externalLinkProps = isExternalLink(href)
-      ? { target: '_blank', rel: 'noopener noreferrer' }
+    const linkSpecificProps = href
+      ? {
+          as: 'a',
+          href,
+          ...(isExternalLink(href)
+            ? { target: '_blank', rel: 'noopener noreferrer' }
+            : {})
+        }
       : {}
+    const buttonSpecificProps = !href ? { type } : {}
 
+    // Note: button is not disabled when loading for accessibility purposes.
+    // Instead the click action is not fired and the button looks faded
     return (
       <StyledButton
-        as={as || (href ? 'a' : undefined)}
-        href={href}
         isLoading={isLoading}
         onClick={!isLoading ? onClick : undefined}
-        type={!href ? 'button' : undefined}
+        appearance={appearance}
+        size={size}
+        theme={theme}
         {...rest}
-        {...externalLinkProps}
+        {...linkSpecificProps}
+        {...buttonSpecificProps}
         ref={ref}
       >
-        {isLoading ? (
-          <WithLoader size={rest.size}>{children}</WithLoader>
-        ) : (
-          children
-        )}
+        {isLoading ? <WithLoader size={size}>{children}</WithLoader> : children}
       </StyledButton>
     )
   }
-)
+) as React.FC<ButtonProps>
+
+Button.displayName = 'Button'

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -192,7 +192,12 @@ export const StyledButton = styled('button', {
         darken(theme.colors.primaryDark.value, 0.15)
       )
     }
-  ]
+  ],
+  defaultVariants: {
+    appearance: 'solid',
+    size: 'md',
+    theme: 'primary'
+  }
 })
 
 const LoaderContentsWrapper = styled('span', {
@@ -206,6 +211,9 @@ const LoaderContentsWrapper = styled('span', {
       md: { gap: '$3' },
       lg: { gap: '$3' }
     }
+  },
+  defaultVariants: {
+    size: 'md'
   }
 })
 
@@ -230,46 +238,29 @@ type ButtonProps = Override<
 >
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      children,
-      isLoading,
-      onClick,
-      href,
-      appearance = 'solid',
-      size = 'md',
-      theme = 'primary',
-      type = 'button',
-      ...rest
-    },
-    ref
-  ) => {
-    const linkSpecificProps = href
-      ? {
-          as: 'a',
-          href,
-          ...(isExternalLink(href)
-            ? { target: '_blank', rel: 'noopener noreferrer' }
-            : {})
-        }
+  ({ children, as, href, isLoading = false, onClick, ...rest }, ref) => {
+    const externalLinkProps = isExternalLink(href)
+      ? { target: '_blank', rel: 'noopener noreferrer' }
       : {}
-    const buttonSpecificProps = !href ? { type } : {}
 
     // Note: button is not disabled when loading for accessibility purposes.
     // Instead the click action is not fired and the button looks faded
     return (
       <StyledButton
+        as={as || (href ? 'a' : undefined)}
+        href={href}
         isLoading={isLoading}
         onClick={!isLoading ? onClick : undefined}
-        appearance={appearance}
-        size={size}
-        theme={theme}
+        type={!href ? 'button' : undefined}
         {...rest}
-        {...linkSpecificProps}
-        {...buttonSpecificProps}
+        {...externalLinkProps}
         ref={ref}
       >
-        {isLoading ? <WithLoader size={size}>{children}</WithLoader> : children}
+        {isLoading ? (
+          <WithLoader size={rest.size}>{children}</WithLoader>
+        ) : (
+          children
+        )}
       </StyledButton>
     )
   }

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -124,6 +124,7 @@ export const StyledButton = styled('button', {
       }
     }
   },
+
   compoundVariants: [
     {
       theme: 'primary',
@@ -193,6 +194,7 @@ export const StyledButton = styled('button', {
       )
     }
   ],
+
   defaultVariants: {
     appearance: 'solid',
     size: 'md',
@@ -243,8 +245,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ? { target: '_blank', rel: 'noopener noreferrer' }
       : {}
 
-    // Note: button is not disabled when loading for accessibility purposes.
-    // Instead the click action is not fired and the button looks faded
     return (
       <StyledButton
         as={as || (href ? 'a' : undefined)}

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -1,8 +1,8 @@
-import type { CSS, VariantProps } from '@stitches/react'
 import * as React from 'react'
 
 import { styled } from '~/stitches'
-import { PolymorphicComponentPropWithRef } from '~/types'
+import { NavigatorActions } from '~/types'
+import { Override } from '~/utilities'
 import { isExternalLink } from '~/utilities/uri'
 
 import { StyledHeading } from '../heading/Heading'
@@ -33,51 +33,29 @@ export const StyledLink = styled('a', {
         content: 'none'
       }
     },
-  variants: textVariants,
-  defaultVariants: {
-    size: 'md'
-  }
+  variants: textVariants
 })
 
-type LinkProps<
-  H extends string | undefined,
-  C extends React.ElementType
-> = PolymorphicComponentPropWithRef<
-  C,
-  VariantProps<typeof StyledLink> & {
-    css?: CSS
-    href?: H
-  }
+type LinkProps = Override<
+  React.ComponentProps<typeof StyledLink>,
+  {
+    as?: React.ComponentType | React.ElementType
+  } & NavigatorActions
 >
 
-export const Link: <
-  H extends string | undefined = undefined,
-  C extends React.ElementType = H extends string ? typeof StyledLink : 'button'
->(
-  props: LinkProps<H, C>
-) => React.ReactElement | null = React.forwardRef(
-  <
-    H extends string | undefined = undefined,
-    C extends React.ElementType = H extends string
-      ? typeof StyledLink
-      : 'button'
-  >(
-    { as, href, ...rest }: LinkProps<H, C>,
-    ref?: LinkProps<H, C>['ref']
-  ) => {
-    const externalLinkProps = isExternalLink(href)
-      ? { target: '_blank', rel: 'noopener noreferrer' }
-      : {}
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ size = 'md', href, ...props }, ref) => (
+    <StyledLink
+      {...(isExternalLink(href)
+        ? { target: '_blank', rel: 'noopener noreferrer' }
+        : {})}
+      {...(!href && { as: 'button', noCapsize: true })}
+      size={size}
+      href={href}
+      {...props}
+      ref={ref}
+    />
+  )
+) as React.FC<LinkProps>
 
-    return (
-      <StyledLink
-        as={as || (!href ? 'button' : undefined)}
-        noCapsize={!href ? true : undefined}
-        href={href}
-        {...rest}
-        {...externalLinkProps}
-        ref={ref}
-      />
-    )
-  }
-)
+Link.displayName = 'Link'

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -33,7 +33,10 @@ export const StyledLink = styled('a', {
         content: 'none'
       }
     },
-  variants: textVariants
+  variants: textVariants,
+  defaultVariants: {
+    size: 'md'
+  }
 })
 
 type LinkProps = Override<
@@ -44,18 +47,21 @@ type LinkProps = Override<
 >
 
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ size = 'md', href, ...props }, ref) => (
-    <StyledLink
-      {...(isExternalLink(href)
-        ? { target: '_blank', rel: 'noopener noreferrer' }
-        : {})}
-      {...(!href && { as: 'button', noCapsize: true })}
-      size={size}
-      href={href}
-      {...props}
-      ref={ref}
-    />
-  )
+  ({ as, href, ...rest }, ref) => {
+    const externalLinkProps = isExternalLink(href)
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : {}
+    return (
+      <StyledLink
+        as={as || (!href ? 'button' : undefined)}
+        noCapsize={!href ? true : undefined}
+        href={href}
+        {...rest}
+        {...externalLinkProps}
+        ref={ref}
+      />
+    )
+  }
 ) as React.FC<LinkProps>
 
 Link.displayName = 'Link'

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -51,6 +51,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     const externalLinkProps = isExternalLink(href)
       ? { target: '_blank', rel: 'noopener noreferrer' }
       : {}
+
     return (
       <StyledLink
         as={as || (!href ? 'button' : undefined)}


### PR DESCRIPTION
There's a sizable cold-start performance regression with the new types for `Button` and `Link`, we don't know what the cause is yet but it's pretty impactful on DX so we're temporarily reverting the change to unblocks future DS release.