### PR TITLE
fix: allow null or undefined as children for BannerRegularActions

### DIFF
--- a/lib/src/components/banner/banner-regular/BannerRegularActions.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularActions.tsx
@@ -32,6 +32,10 @@ export const BannerRegularActions: React.FC<
   return (
     <Stack gap={gap} {...props}>
       {React.Children.map(children, (child, index) => {
+        // if child is undefined or null, React.isValidElement returns false and hence error is thrown.
+        // This line will prevent that from happening
+        if (child == null) return child
+
         if (!React.isValidElement(child)) {
           throw new Error(
             `Child passed to ${BannerRegularActions.displayName} is not a valid element`


### PR DESCRIPTION
`BannerRegularActions` throws error if the children are rendered conditionally.

The following throws an error when it should not
```tsx
<BannerRegular
      colorScheme={{ base: 'purple1' }}
      emphasis="highContrast"
      size="md"
      value=""
    >
      <BannerRegular.Content>
        <BannerRegular.Heading>Example Heading</BannerRegular.Heading>
        <BannerRegular.Text>This is an example text</BannerRegular.Text>
        <BannerRegular.Actions>
          <BannerRegular.Button>Primary CTA</BannerRegular.Button>
          {false && <BannerRegular.Button>Secondary CTA</BannerRegular.Button>} <== undefined
        </BannerRegular.Actions>
      </BannerRegular.Content>
    </BannerRegular>
```