### PR TITLE
fix: list item display in one line

### DIFF
--- a/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/lib/src/components/markdown-content/__snapshots__/MarkdownContent.test.tsx.snap
@@ -333,8 +333,12 @@ exports[`MarkdownContent component renders 1`] = `
     width: 100%;
   }
 
-  .c-bBdCwN-igZTZYS-css p:before,
-  .c-bBdCwN-igZTZYS-css p:after {
+  .c-bBdCwN-idpBzHh-css p {
+    display: inline;
+  }
+
+  .c-bBdCwN-idpBzHh-css p:before,
+  .c-bBdCwN-idpBzHh-css p:after {
     display: none;
   }
 }
@@ -459,7 +463,7 @@ exports[`MarkdownContent component renders 1`] = `
       Unordered
     </h3>
     <ul
-      class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-igZTZYS-css"
+      class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-idpBzHh-css"
     >
       <li
         class="c-PJLV"
@@ -496,7 +500,7 @@ exports[`MarkdownContent component renders 1`] = `
           Sub-lists are made by indenting 2 spaces:
         </p>
         <ul
-          class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-igZTZYS-css"
+          class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-idpBzHh-css"
         >
           <li
             class="c-PJLV"
@@ -507,7 +511,7 @@ exports[`MarkdownContent component renders 1`] = `
               Marker character change forces new list start:
             </p>
             <ul
-              class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-igZTZYS-css"
+              class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-idpBzHh-css"
             >
               <li
                 class="c-PJLV"
@@ -520,7 +524,7 @@ exports[`MarkdownContent component renders 1`] = `
               </li>
             </ul>
             <ul
-              class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-igZTZYS-css"
+              class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-idpBzHh-css"
             >
               <li
                 class="c-PJLV"
@@ -533,7 +537,7 @@ exports[`MarkdownContent component renders 1`] = `
               </li>
             </ul>
             <ul
-              class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-igZTZYS-css"
+              class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-ldmvkx-as-ul c-bBdCwN-idpBzHh-css"
             >
               <li
                 class="c-PJLV"
@@ -564,7 +568,7 @@ exports[`MarkdownContent component renders 1`] = `
       Ordered
     </h3>
     <ol
-      class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-bEVto-as-ol c-bBdCwN-igZTZYS-css"
+      class="c-bBdCwN c-bBdCwN-gvmVBy-size-md c-bBdCwN-fmPQHp-noCapsize-true c-bBdCwN-bEVto-as-ol c-bBdCwN-idpBzHh-css"
     >
       <li
         class="c-PJLV"

--- a/lib/src/components/markdown-content/components/MarkdownList.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownList.tsx
@@ -17,7 +17,13 @@ export const MarkdownList: React.FC<MarkdownListProps> = ({
   css
 }) => (
   <List
-    css={{ '& p:before, & p:after': { display: 'none' }, ...css } as CSS}
+    css={
+      {
+        '& p': { display: 'inline' },
+        '& p:before, & p:after': { display: 'none' },
+        ...css
+      } as CSS
+    }
     ordered={node.ordered || undefined}
   >
     {node.children?.map(handleNode)}


### PR DESCRIPTION
Fixes list items not displaying correctly in `<MarkdownContent />` component.

`<List.Item>` inside markdown renders a nested `<p>` element.

```html
<li class="c-PJLV">
 <p class="c-dyvMgW c-dyvMgW-gvmVBy-size-md">Lorem ipsum dolor sit amet</p>
</li>
```

Before / After

<img width="277" alt="image" src="https://github.com/Atom-Learning/components/assets/11061661/0bee6f5d-7a44-4a52-9557-ee75aa641508"> |  <img width="362" alt="image" src="https://github.com/Atom-Learning/components/assets/11061661/74f7597b-f1c5-4955-a375-c6b8876b39cf">




