### PR TITLE
fix: form inputs - hideLabel passed down to FieldWrapper

### DIFF
--- a/lib/src/components/date-field/DateField.tsx
+++ b/lib/src/components/date-field/DateField.tsx
@@ -12,6 +12,7 @@ type DateFieldProps = DateInputProps & FieldElementWrapperProps
 
 export const DateField: React.FC<DateFieldProps> = ({
   css,
+  hideLabel,
   label,
   name,
   validation,
@@ -29,6 +30,7 @@ export const DateField: React.FC<DateFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}

--- a/lib/src/components/input-field/InputField.tsx
+++ b/lib/src/components/input-field/InputField.tsx
@@ -17,6 +17,7 @@ export const InputField: React.FC<InputFieldProps> = ({
   validation,
   prompt,
   description,
+  hideLabel,
   ...remainingProps
 }) => {
   const { register } = useFormContext()
@@ -29,6 +30,7 @@ export const InputField: React.FC<InputFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}

--- a/lib/src/components/number-input-field/NumberInputField.tsx
+++ b/lib/src/components/number-input-field/NumberInputField.tsx
@@ -10,6 +10,7 @@ import { NumberInput } from '../number-input/NumberInput'
 
 export interface NumberInputFieldProps extends NumberInputProps {
   css?: CSS
+  hideLabel?: boolean
   description?: string
   label: string
   name: string
@@ -20,6 +21,7 @@ export interface NumberInputFieldProps extends NumberInputProps {
 export const NumberInputField: React.FC<NumberInputFieldProps> = ({
   css,
   defaultValue = 0,
+  hideLabel,
   value,
   prompt,
   description,
@@ -51,6 +53,7 @@ export const NumberInputField: React.FC<NumberInputFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}

--- a/lib/src/components/password-field/PasswordField.tsx
+++ b/lib/src/components/password-field/PasswordField.tsx
@@ -16,6 +16,7 @@ type PasswordFieldProps = React.ComponentProps<typeof PasswordInput> &
 
 export const PasswordField: React.FC<PasswordFieldProps> = ({
   css = {},
+  hideLabel,
   label = 'Password',
   name,
   prompt = undefined,
@@ -34,6 +35,7 @@ export const PasswordField: React.FC<PasswordFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}

--- a/lib/src/components/search-field/SearchField.tsx
+++ b/lib/src/components/search-field/SearchField.tsx
@@ -12,6 +12,7 @@ type SearchFieldProps = SearchInputProps & FieldElementWrapperProps
 
 export const SearchField: React.FC<SearchFieldProps> = ({
   css,
+  hideLabel,
   label,
   name,
   validation,
@@ -29,6 +30,7 @@ export const SearchField: React.FC<SearchFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}

--- a/lib/src/components/select-field/SelectField.tsx
+++ b/lib/src/components/select-field/SelectField.tsx
@@ -12,13 +12,13 @@ type SelectFieldProps = SelectProps & FieldElementWrapperProps
 
 export const SelectField: React.FC<SelectFieldProps> = ({
   css = undefined,
+  hideLabel,
   children,
   name,
   label,
   validation,
   prompt,
   description,
-  hideLabel,
   ...remainingProps
 }) => {
   const { register } = useFormContext()
@@ -31,10 +31,10 @@ export const SelectField: React.FC<SelectFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}
-      hideLabel={hideLabel}
     >
       <Select
         name={name}

--- a/lib/src/components/slider-field/SliderField.tsx
+++ b/lib/src/components/slider-field/SliderField.tsx
@@ -17,6 +17,7 @@ type SliderFieldProps = SliderProps &
 
 export const SliderField: React.FC<SliderFieldProps> = ({
   css,
+  hideLabel,
   label,
   name,
   defaultValue,
@@ -44,7 +45,7 @@ export const SliderField: React.FC<SliderFieldProps> = ({
   }, [JSON.stringify(value)])
 
   return (
-    <FieldWrapper css={css} fieldId={name} label={label}>
+    <FieldWrapper css={css} fieldId={name} label={label} hideLabel={hideLabel}>
       <Slider
         ref={ref}
         name={innerName}

--- a/lib/src/components/textarea-field/TextareaField.tsx
+++ b/lib/src/components/textarea-field/TextareaField.tsx
@@ -12,6 +12,7 @@ type TextareaFieldProps = TextareaProps & FieldElementWrapperProps
 
 export const TextareaField: React.FC<TextareaFieldProps> = ({
   css = undefined,
+  hideLabel,
   label,
   name,
   validation,
@@ -30,6 +31,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
       description={description}
       error={error}
       fieldId={name}
+      hideLabel={hideLabel}
       label={label}
       prompt={prompt}
       required={Boolean(validation?.required)}


### PR DESCRIPTION
Fixing all inputs (form fields) that did not pass `hideLabel` prop to the FieldWrapper
`hideLabel` is passed down to the input/textarea etc. as a part of `remainingProps`.
`hideLabel` should be rather passed to the FieldWrapper.

FieldWrapper expects to receive hideLabel
![Zrzut ekranu 2023-09-13 o 15 43 08](https://github.com/Atom-Learning/components/assets/23363033/2424478a-1d88-4902-9f18-05d72143a47b)

Issue example: `hideLabels` is not passed down from particular form field to the FieldWrapper
![Zrzut ekranu 2023-09-13 o 15 42 57](https://github.com/Atom-Learning/components/assets/23363033/2634e17d-6076-448e-9025-7011edd6c788)

Docs
![Zrzut ekranu 2023-09-13 o 15 40 59](https://github.com/Atom-Learning/components/assets/23363033/e85e6361-8de4-44da-b592-638eae20c0a7)

Implementation images

![Zrzut ekranu 2023-09-14 o 09 01 14](https://github.com/Atom-Learning/components/assets/23363033/ec7fb92c-fdde-4b83-beeb-df187c83a593)
![Zrzut ekranu 2023-09-14 o 09 01 41](https://github.com/Atom-Learning/components/assets/23363033/d31abc19-dd97-4678-b8e9-8994be9b3be3)




