### PR TITLE
Refactor: rename hasStickyHeader prop

### DIFF
--- a/lib/src/components/data-table/DataTableHead.tsx
+++ b/lib/src/components/data-table/DataTableHead.tsx
@@ -11,14 +11,14 @@ type DataTableHeadProps = Omit<
   'children'
 > & {
   sortable?: boolean
-  hasStickyHeader?: boolean
+  isSticky?: boolean
   headerCss?: CSS
 }
 
 export const DataTableHead: React.FC<DataTableHeadProps> = ({
   sortable = true,
   theme = 'light',
-  hasStickyHeader = false,
+  isSticky = false,
   ...props
 }) => {
   const {
@@ -33,7 +33,7 @@ export const DataTableHead: React.FC<DataTableHeadProps> = ({
   }, [sortable, setIsSortable])
 
   return (
-    <Table.Header theme={theme} hasStickyHeader={hasStickyHeader} {...props}>
+    <Table.Header theme={theme} isSticky={isSticky} {...props}>
       {getHeaderGroups().map((headerGroup) => {
         return (
           <Table.Row key={headerGroup.id}>

--- a/lib/src/components/data-table/DataTableTable.tsx
+++ b/lib/src/components/data-table/DataTableTable.tsx
@@ -13,10 +13,12 @@ export type DataTableTableProps = Omit<
   Partial<
     Pick<
       React.ComponentProps<typeof DataTable.Head>,
-      'theme' | 'sortable' | 'hasStickyHeader' | 'headerCss'
+      'theme' | 'sortable' | 'headerCss'
     >
   > &
-  Partial<Pick<React.ComponentProps<typeof Table.Body>, 'striped'>>
+  Partial<Pick<React.ComponentProps<typeof Table.Body>, 'striped'>> & {
+    hasStickyHeader?: boolean
+  }
 
 export const DataTableTable: React.FC<DataTableTableProps> = ({
   sortable,
@@ -53,7 +55,7 @@ export const DataTableTable: React.FC<DataTableTableProps> = ({
         <DataTable.Head
           theme={theme}
           sortable={sortable}
-          hasStickyHeader={hasStickyHeader}
+          isSticky={hasStickyHeader}
           css={headerCss}
         />
         <DataTable.Body striped={striped} />

--- a/lib/src/components/table/TableHeader.tsx
+++ b/lib/src/components/table/TableHeader.tsx
@@ -30,7 +30,7 @@ const StyledTableHeader = styled('thead', {
         }
       }
     },
-    hasStickyHeader: {
+    isSticky: {
       true: {
         position: 'sticky',
         top: 0,
@@ -44,16 +44,10 @@ type TableHeaderProps = React.ComponentProps<typeof StyledTableHeader>
 
 export const TableHeader: React.FC<TableHeaderProps> = ({
   theme = 'primaryDark',
-  hasStickyHeader = false,
+  isSticky = false,
   ...rest
 }: TableHeaderProps) => {
-  return (
-    <StyledTableHeader
-      theme={theme}
-      hasStickyHeader={hasStickyHeader}
-      {...rest}
-    />
-  )
+  return <StyledTableHeader theme={theme} isSticky={isSticky} {...rest} />
 }
 
 TableHeader.displayName = 'TableHeader'


### PR DESCRIPTION
This PR simply renames the `hasStickyHeader` that gets passed to the table header component into `isSticky`