### PR TITLE
fix: removed pointer-events auto from ToastWrapper

### DIFF
--- a/lib/src/components/toast/ToastProvider.tsx
+++ b/lib/src/components/toast/ToastProvider.tsx
@@ -41,7 +41,6 @@ const ToastWrapper = styled('div', {
   width: '100%',
   display: 'flex',
   justifyContent: 'center',
-  pointerEvents: 'auto',
   alignItems: 'center',
   borderRadius: '$0',
   boxSizing: 'border-box',


### PR DESCRIPTION
Fixes an issue with the latest update to the ToastProvider whereby once a toast was on screen, you couldn't click on anything else behind it.

- Removed `pointerEvents: 'auto'` from ToastWrapper

BEFORE:

https://github.com/Atom-Learning/components/assets/44065175/b07742bc-c28b-4e9d-9b5b-7eb3dc26b972

AFTER:

https://github.com/Atom-Learning/components/assets/44065175/11120464-8b99-4e64-abff-0f429a0939e1

