### PR TITLE
chore: fixed errors in markdown jsx for toast docs

### DIFF
--- a/documentation/content/components.feedback.toast.md
+++ b/documentation/content/components.feedback.toast.md
@@ -23,7 +23,8 @@ tabs:
       </ToastProvider>`} language={"tsx"} />
 
 
-      This component can render a string message by default. However, it can be overriden to show more complex component structure [Render more than a string](https://react-hot-toast.com/docs/toast). For more information on other configuration options and props, please read about the underlying behaviour at [react-hot-toast](https://react-hot-toast.com/)
+      This component can render a string message by default. However, it can be overriden to show more complex component structure [Render more than a string](https://react-hot-toast.com/docs/toast). For more information on other configuration options and props, please read about the underlying behaviour at [react-hot-toast](https://react-hot-toast.com/).
+
 
       We can create a custom toast UI by passing in a component to the `toast` function. The Toast component used by the ToastProvider is exported for easy reuse.
 
@@ -39,8 +40,8 @@ tabs:
                     <Toast.Icon is={Info} />
                     <Text>This is my custom toast</Text>
                     <Toast.Close onDismiss={() => alert('Toast has been dismissed.')} />
-                  </Flex>
-                ))
+                  </Toast>
+                )
               }
               >
                 Click for custom toast


### PR DESCRIPTION
Small fix to the JSX in the markdown for toast component.