### PR TITLE
[FIXES FOR:] Ds 465 👩🏻‍💻 build navigation sidedrawer

### DIFF
--- a/lib/src/components/drawer/Drawer.styles.ts
+++ b/lib/src/components/drawer/Drawer.styles.ts
@@ -1,5 +1,4 @@
 export const drawerSection = {
-  py: '$4',
-  px: '$2',
+  p: '$4',
   width: '100%'
 }

--- a/lib/src/components/drawer/DrawerClose.tsx
+++ b/lib/src/components/drawer/DrawerClose.tsx
@@ -5,8 +5,8 @@ import React from 'react'
 import { ActionIcon } from '../action-icon/ActionIcon'
 import { Icon } from '../icon/Icon'
 
-export const DrawerClose: React.FC<React.ComponentProps<typeof ActionIcon>> = (
-  props
+export const DrawerClose = (
+  props: Omit<React.ComponentProps<typeof ActionIcon>, 'children'>
 ) => (
   <DialogClose asChild>
     <ActionIcon

--- a/lib/src/components/drawer/DrawerHeader.tsx
+++ b/lib/src/components/drawer/DrawerHeader.tsx
@@ -4,5 +4,6 @@ import { drawerSection } from './Drawer.styles'
 
 export const DrawerHeader = styled('div', {
   ...drawerSection,
+  minHeight: '$6', // At least the height of the TopBar
   borderBottom: '1px solid $base3'
 })

--- a/lib/src/components/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/lib/src/components/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -300,12 +300,10 @@ exports[`Drawer opens the popover once trigger is clicked 1`] = `
     display: flex;
   }
 
-  .c-fTmeBd {
-    padding-top: var(--space-4);
-    padding-bottom: var(--space-4);
-    padding-left: var(--space-2);
-    padding-right: var(--space-2);
+  .c-ljxqHl {
+    padding: var(--space-4);
     width: 100%;
+    min-height: var(--sizes-6);
     border-bottom: 1px solid var(--colors-base3);
   }
 
@@ -333,21 +331,15 @@ exports[`Drawer opens the popover once trigger is clicked 1`] = `
     vertical-align: middle;
   }
 
-  .c-hhmfgL {
-    padding-top: var(--space-4);
-    padding-bottom: var(--space-4);
-    padding-left: var(--space-2);
-    padding-right: var(--space-2);
+  .c-gMZPby {
+    padding: var(--space-4);
     width: 100%;
     flex-grow: 1;
     overflow-y: auto;
   }
 
-  .c-WGKTx {
-    padding-top: var(--space-4);
-    padding-bottom: var(--space-4);
-    padding-left: var(--space-2);
-    padding-right: var(--space-2);
+  .c-dOWjeQ {
+    padding: var(--space-4);
     width: 100%;
     border-top: 1px solid var(--colors-base3);
   }
@@ -436,7 +428,7 @@ exports[`Drawer opens the popover once trigger is clicked 1`] = `
   tabindex="-1"
 >
   <div
-    class="c-fTmeBd"
+    class="c-ljxqHl"
   >
     HEADER
     <button
@@ -457,12 +449,12 @@ exports[`Drawer opens the popover once trigger is clicked 1`] = `
     </button>
   </div>
   <div
-    class="c-hhmfgL"
+    class="c-gMZPby"
   >
     BODY
   </div>
   <div
-    class="c-WGKTx"
+    class="c-dOWjeQ"
   >
     FOOTER
   </div>

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.tsx
@@ -33,17 +33,16 @@ type TNavigationVerticalProps = Omit<
   | 'onValueChange'
 >
 
-type TNavigationVerticalType =
-  React.ForwardRefExoticComponent<TNavigationVerticalProps> & {
-    Link: typeof NavigationMenuVerticalLink
-    Accordion: typeof NavigationMenuVerticalAccordion
-    AccordionContent: typeof NavigationMenuVerticalAccordionContent
-    AccordionTrigger: typeof NavigationMenuVerticalAccordionTrigger
-    Item: typeof NavigationMenuVerticalItem
-    ItemContent: typeof NavigationMenuVerticalItemContent
-    Icon: typeof NavigationMenuVerticalIcon
-    Text: typeof NavigationMenuVerticalText
-  }
+type TNavigationVerticalType = React.FC<TNavigationVerticalProps> & {
+  Link: typeof NavigationMenuVerticalLink
+  Accordion: typeof NavigationMenuVerticalAccordion
+  AccordionContent: typeof NavigationMenuVerticalAccordionContent
+  AccordionTrigger: typeof NavigationMenuVerticalAccordionTrigger
+  Item: typeof NavigationMenuVerticalItem
+  ItemContent: typeof NavigationMenuVerticalItemContent
+  Icon: typeof NavigationMenuVerticalIcon
+  Text: typeof NavigationMenuVerticalText
+}
 
 export const NavigationMenuVertical = (({ children, ...rest }) => {
   return (

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalAccordionTrigger.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalAccordionTrigger.tsx
@@ -38,7 +38,7 @@ export const NavigationMenuVerticalAccordionTrigger = ({
 
   return (
     <Link asChild>
-      <StyledNavigationMenuVerticalAccordionTrigger size="md" {...rest} asChild>
+      <StyledNavigationMenuVerticalAccordionTrigger size="lg" {...rest} asChild>
         <Flex
           as="button"
           type="button"

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
@@ -23,7 +23,7 @@ export const NavigationMenuVerticalLink: React.FC<
   return (
     <NavigationMenuVerticalItem>
       <StyledNavigationMenuVerticalLink
-        size="md"
+        size="lg"
         {...rest}
         onSelect={preventEvent}
         asChild

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { styled } from '~/stitches'
 import { preventEvent } from '~/utilities/event'
+import { isExternalLink } from '~/utilities/uri'
 
 import { navigationMenuVerticalItemStyles } from './NavigationMenuVertical.styles'
 import { NavigationMenuVerticalItem } from './NavigationMenuVerticalItem'
@@ -15,32 +16,39 @@ const StyledNavigationMenuVerticalLink = styled(
 
 type NavigationMenuVerticalItemProps = React.ComponentProps<
   typeof StyledNavigationMenuVerticalLink
->
+> & {
+  as?: React.ComponentType | React.ElementType
+}
 
 export const NavigationMenuVerticalLink: React.FC<
   NavigationMenuVerticalItemProps
-> = ({ href, children, ...rest }) => {
+> = ({ as, href, children, ...rest }) => {
+  const linkProps = isExternalLink(href)
+    ? { target: '_blank', rel: 'noopener noreferrer' }
+    : {}
+
+  const buttonProps = {
+    type: 'button'
+  }
+
+  const Component = as || (href ? 'a' : 'button')
+  const componentProps = as ? {} : href ? linkProps : buttonProps
+
   return (
     <NavigationMenuVerticalItem>
       <StyledNavigationMenuVerticalLink
         size="lg"
+        href={href}
         {...rest}
+        {...componentProps}
         onSelect={preventEvent}
-        asChild
+        asChild // ?: Can't use `as` for this as we lose `data-active` etc. attributes when we try to. Using `asChild` and `Component` as a workaround.
       >
-        {href ? (
-          <a href={href}>
-            <NavigationMenuVerticalItemContent>
-              {children}
-            </NavigationMenuVerticalItemContent>
-          </a>
-        ) : (
-          <button type="button">
-            <NavigationMenuVerticalItemContent>
-              {children}
-            </NavigationMenuVerticalItemContent>
-          </button>
-        )}
+        <Component>
+          <NavigationMenuVerticalItemContent>
+            {children}
+          </NavigationMenuVerticalItemContent>
+        </Component>
       </StyledNavigationMenuVerticalLink>
     </NavigationMenuVerticalItem>
   )

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -123,8 +123,8 @@ exports[`NavigationMenuVertical renders 1`] = `
     display: table;
   }
 
-  .c-jgcFYa-fpZSlG-size-md {
-    min-height: var(--sizes-4);
+  .c-jgcFYa-jLELKD-size-lg {
+    min-height: var(--sizes-5);
   }
 }
 
@@ -147,7 +147,7 @@ exports[`NavigationMenuVertical renders 1`] = `
       >
         <button
           aria-current="page"
-          class="c-jgcFYa c-jgcFYa-fpZSlG-size-md"
+          class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
           data-active=""
           data-radix-collection-item=""
           type="button"
@@ -167,7 +167,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-jgcFYa c-jgcFYa-fpZSlG-size-md"
+          class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
           data-radix-collection-item=""
           href="google.com"
         >
@@ -328,8 +328,8 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     display: table;
   }
 
-  .c-jgcFYa-fpZSlG-size-md {
-    min-height: var(--sizes-4);
+  .c-jgcFYa-jLELKD-size-lg {
+    min-height: var(--sizes-5);
   }
 
   .c-dhzjXW-knmidH-justify-space-between {
@@ -367,7 +367,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
         >
           <button
             aria-current="page"
-            class="c-jgcFYa c-jgcFYa-fpZSlG-size-md"
+            class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
             data-active=""
             data-radix-collection-item=""
             type="button"
@@ -387,7 +387,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-jgcFYa c-jgcFYa-fpZSlG-size-md"
+            class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
             data-radix-collection-item=""
             href="google.com"
           >
@@ -409,7 +409,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           <button
             aria-controls="radix-0"
             aria-expanded="true"
-            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-jgcFYa c-jgcFYa-fpZSlG-size-md"
+            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-jgcFYa c-jgcFYa-jLELKD-size-lg"
             data-radix-collection-item=""
             data-state="open"
             data-testid="accordion-trigger"

--- a/lib/src/utilities/event/preventEvent.ts
+++ b/lib/src/utilities/event/preventEvent.ts
@@ -2,7 +2,7 @@
 Used to block default radix hover to open menu behaviour
 Props: https://github.com/radix-ui/primitives/issues/1630
 */
-export const preventEvent = (event: React.PointerEvent | Event): void => {
+export const preventEvent = (event: React.PointerEvent | Event | React.SyntheticEvent): void => {
   const e = event as Event
   e.preventDefault()
 }


### PR DESCRIPTION
While trying to replace uses of `Sidedrawer`  with the new components I have discovered some issues.
This PR is an attempt to fix said issues and unblock the replacement a bit. 
(Might make more changes but these ones are from the first day - more important ones)

* **Major:** `as` isn't working correctly with `NavigationMenuVerticalLink`. We need it to work with this element to set a link to be a `React Router Dom` `Link` 

**before**
![Screenshot 2023-09-28 at 13 58 53](https://github.com/Atom-Learning/components/assets/6905473/f53ae383-0d75-41c1-a45d-294c9a49273c) ![Screenshot 2023-09-28 at 14 00 30](https://github.com/Atom-Learning/components/assets/6905473/62f043c7-811c-4e09-a4f6-451d056868c7)

**after**: (in principle it works)
![Screenshot 2023-09-28 at 14 00 00](https://github.com/Atom-Learning/components/assets/6905473/5e517f7c-96ef-42e5-8c12-286462a9b3f3)

* **Mid**: attempt to silence Drawer.Close complaining about missing `children` prop in implementation. It doesn't accept children so changed the type to omit.
![Screenshot 2023-09-28 at 14 03 52](https://github.com/Atom-Learning/components/assets/6905473/85341d24-0341-46eb-872a-ffa3313e01b0)

* **Minor**: Drawer paddings change and add min-height to the Header
![Screenshot 2023-09-28 at 14 05 17](https://github.com/Atom-Learning/components/assets/6905473/ca009c4b-f853-4e5b-af78-1e523e87176a)


* **Minor**: Change NavigationMenuLink and Accordion to default to use the "lg" size as per design requirements
![Screenshot 2023-09-28 at 14 04 41](https://github.com/Atom-Learning/components/assets/6905473/cb392e84-0dba-4b36-99ac-53f569c46e8a)
