### PR TITLE
B2B-165: fix horizontal scrolling when sticky columns are used

### DIFF
--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -777,7 +777,7 @@ describe('DataTable sticky columns', () => {
     const { container } = render(
       <Wrapper>
         <DataTable columns={columns} data={data}>
-          <DataTable.Table numberOfStickyColumns={1} />
+          <DataTable.Table scrollOptions={{ numberOfStickyColumns: 1 }} />
         </DataTable>
       </Wrapper>
     )

--- a/lib/src/components/data-table/DataTableTable.tsx
+++ b/lib/src/components/data-table/DataTableTable.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import { CSS } from '~/stitches'
+
 import { Table } from '../table'
 import { DataTable } from './DataTable'
 import { AsyncDataState } from './DataTable.types'
@@ -8,16 +10,18 @@ import { DataTableLoading } from './DataTableLoading'
 
 export type DataTableTableProps = Omit<
   React.ComponentProps<typeof Table>,
-  'children'
+  'children' | 'numberOfStickyColumns'
 > &
   Partial<
-    Pick<
-      React.ComponentProps<typeof DataTable.Head>,
-      'theme' | 'sortable' | 'headerCss'
-    >
+    Pick<React.ComponentProps<typeof DataTable.Head>, 'theme' | 'sortable'>
   > &
   Partial<Pick<React.ComponentProps<typeof Table.Body>, 'striped'>> & {
-    hasStickyHeader?: boolean
+    scrollOptions?: {
+      hasStickyHeader?: boolean
+      headerCss?: CSS
+      numberOfStickyColumns?: number
+      scrollContainerCss?: CSS
+    }
   }
 
 export const DataTableTable: React.FC<DataTableTableProps> = ({
@@ -25,9 +29,10 @@ export const DataTableTable: React.FC<DataTableTableProps> = ({
   striped,
   theme,
   css,
-  numberOfStickyColumns = 0,
-  hasStickyHeader = false,
-  headerCss,
+  scrollOptions = {
+    numberOfStickyColumns: 0,
+    hasStickyHeader: false
+  },
   ...props
 }) => {
   const { asyncDataState, getTotalRows } = useDataTable()
@@ -42,7 +47,8 @@ export const DataTableTable: React.FC<DataTableTableProps> = ({
 
       <Table
         {...props}
-        numberOfStickyColumns={numberOfStickyColumns}
+        numberOfStickyColumns={scrollOptions.numberOfStickyColumns}
+        scrollContainerCss={scrollOptions.scrollContainerCss}
         css={{
           ...css,
           ...(isPending && {
@@ -55,8 +61,8 @@ export const DataTableTable: React.FC<DataTableTableProps> = ({
         <DataTable.Head
           theme={theme}
           sortable={sortable}
-          isSticky={hasStickyHeader}
-          css={headerCss}
+          isSticky={scrollOptions.hasStickyHeader}
+          css={scrollOptions.headerCss}
         />
         <DataTable.Body striped={striped} />
       </Table>

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -827,27 +827,29 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     transition: opacity 250ms linear 150ms;
   }
 
-  .c-PJLV-iixGFrr-css {
+  .c-PJLV-iiXkAWq-css {
+    overflow: auto;
     max-width: 100%;
   }
 
-  .c-PJLV-iixGFrr-css td {
+  .c-PJLV-iiXkAWq-css td {
     background: inherit;
   }
 
-  .c-PJLV-ieWFZoG-css {
+  .c-PJLV-igbAmsf-css {
+    overflow: auto;
     max-width: 100%;
   }
 
-  .c-PJLV-ieWFZoG-css td:nth-of-type(1),
-  .c-PJLV-ieWFZoG-css th:nth-of-type(1) {
+  .c-PJLV-igbAmsf-css td:nth-of-type(1),
+  .c-PJLV-igbAmsf-css th:nth-of-type(1) {
     position: sticky;
     left: 0px;
     min-width: 0px;
     z-index: 2;
   }
 
-  .c-PJLV-ieWFZoG-css td {
+  .c-PJLV-igbAmsf-css td {
     background: inherit;
   }
 }
@@ -5142,34 +5144,36 @@ exports[`DataTable sticky columns renders 1`] = `
     transition: opacity 250ms linear 150ms;
   }
 
-  .c-PJLV-iixGFrr-css {
+  .c-PJLV-iiXkAWq-css {
+    overflow: auto;
     max-width: 100%;
   }
 
-  .c-PJLV-iixGFrr-css td {
+  .c-PJLV-iiXkAWq-css td {
     background: inherit;
   }
 
-  .c-PJLV-ieWFZoG-css {
+  .c-PJLV-igbAmsf-css {
+    overflow: auto;
     max-width: 100%;
   }
 
-  .c-PJLV-ieWFZoG-css td:nth-of-type(1),
-  .c-PJLV-ieWFZoG-css th:nth-of-type(1) {
+  .c-PJLV-igbAmsf-css td:nth-of-type(1),
+  .c-PJLV-igbAmsf-css th:nth-of-type(1) {
     position: sticky;
     left: 0px;
     min-width: 0px;
     z-index: 2;
   }
 
-  .c-PJLV-ieWFZoG-css td {
+  .c-PJLV-igbAmsf-css td {
     background: inherit;
   }
 }
 
 <div>
   <div
-    class="c-PJLV c-PJLV-ieWFZoG-css"
+    class="c-PJLV c-PJLV-igbAmsf-css"
     role="scrollbar"
   >
     <table

--- a/lib/src/components/table/Table.tsx
+++ b/lib/src/components/table/Table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { styled } from '~/stitches'
+import { CSS, styled } from '~/stitches'
 
 import { TableBody } from './TableBody'
 import { TableCell } from './TableCell'
@@ -67,12 +67,14 @@ const StyledTable = styled('table', {
 
 type TableProps = React.ComponentProps<typeof StyledTable> & {
   numberOfStickyColumns?: number
+  scrollContainerCss?: CSS
 }
 
 export const Table: React.FC<TableProps> & TableSubComponents = ({
   size = 'md',
   corners = 'round',
   numberOfStickyColumns = 0,
+  scrollContainerCss,
   ...rest
 }: TableProps) => {
   const tableComponent = <StyledTable size={size} corners={corners} {...rest} />
@@ -80,6 +82,7 @@ export const Table: React.FC<TableProps> & TableSubComponents = ({
   if (numberOfStickyColumns) {
     return (
       <TableStickyColumnsContainer
+        css={scrollContainerCss}
         numberOfStickyColumns={numberOfStickyColumns}
       >
         {tableComponent}

--- a/lib/src/components/table/TableStickyColumnsContainer.tsx
+++ b/lib/src/components/table/TableStickyColumnsContainer.tsx
@@ -34,6 +34,7 @@ export const TableStickyColumnsContainer: React.FC<
       role="scrollbar"
       ref={scrollContainerRef}
       css={{
+        overflow: 'auto',
         maxWidth: '100%',
         ...columnsCss,
         [`& td:nth-child(${numberOfStickyColumns}), th:nth-child(${numberOfStickyColumns})`]:

--- a/lib/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/lib/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -633,11 +633,12 @@ exports[`Table component renders with sticky columns 1`] = `
     width: 400px;
   }
 
-  .c-PJLV-iixGFrr-css {
+  .c-PJLV-iiXkAWq-css {
+    overflow: auto;
     max-width: 100%;
   }
 
-  .c-PJLV-iixGFrr-css td {
+  .c-PJLV-iiXkAWq-css td {
     background: inherit;
   }
 
@@ -646,26 +647,27 @@ exports[`Table component renders with sticky columns 1`] = `
     width: 300px;
   }
 
-  .c-PJLV-ieWFZoG-css {
+  .c-PJLV-igbAmsf-css {
+    overflow: auto;
     max-width: 100%;
   }
 
-  .c-PJLV-ieWFZoG-css td:nth-of-type(1),
-  .c-PJLV-ieWFZoG-css th:nth-of-type(1) {
+  .c-PJLV-igbAmsf-css td:nth-of-type(1),
+  .c-PJLV-igbAmsf-css th:nth-of-type(1) {
     position: sticky;
     left: 0px;
     min-width: 0px;
     z-index: 2;
   }
 
-  .c-PJLV-ieWFZoG-css td {
+  .c-PJLV-igbAmsf-css td {
     background: inherit;
   }
 }
 
 <div>
   <div
-    class="c-PJLV c-PJLV-ieWFZoG-css"
+    class="c-PJLV c-PJLV-igbAmsf-css"
     role="scrollbar"
   >
     <table


### PR DESCRIPTION
This PR fixes the broken horizontal scroll when using sticky columns and also makes the feature compatible with sticky headers. This will, however, add a vertical scrollbar to the container which wraps the table when using sticky columns, as shown in the video below:

https://github.com/Atom-Learning/components/assets/9009155/e762276f-6457-4ef0-83b6-3e9862a174f6

