### PR TITLE
Fix: Add external link props to links

### DIFF
--- a/lib/src/components/action-icon/ActionIcon.test.tsx
+++ b/lib/src/components/action-icon/ActionIcon.test.tsx
@@ -7,95 +7,88 @@ import { Icon } from '../icon/Icon'
 import { Tooltip } from '../tooltip'
 import { ActionIcon } from '.'
 
-const Wrapper = ({ children }) => (
-  <Tooltip.Provider>{children}</Tooltip.Provider>
-)
+const customRender = (children) =>
+  render(<Tooltip.Provider>{children}</Tooltip.Provider>)
 
 describe('ActionIcon component', () => {
   it('renders', async () => {
-    const { container } = render(
-      <Wrapper>
-        <ActionIcon label="Mark as complete" onClick={() => null}>
-          <Icon is={() => <svg />} />
-        </ActionIcon>
-      </Wrapper>
+    const { container } = customRender(
+      <ActionIcon label="Mark as complete" onClick={() => null}>
+        <Icon is={() => <svg />} />
+      </ActionIcon>
     )
 
     expect(container).toMatchSnapshot()
   })
 
   it('throws with missing or invalid child', async () => {
-    expectToThrow(() =>
-      render(
-        <Wrapper>
-          <ActionIcon />
-        </Wrapper>
-      )
-    )
+    expectToThrow(() => customRender(<ActionIcon />))
+
+    expectToThrow(() => customRender(<ActionIcon>An invalid child</ActionIcon>))
 
     expectToThrow(() =>
-      render(
-        <Wrapper>
-          <ActionIcon>An invalid child</ActionIcon>
-        </Wrapper>
-      )
-    )
-
-    expectToThrow(() =>
-      render(
-        <Wrapper>
-          <ActionIcon>
-            <p>An invalid child</p>
-          </ActionIcon>
-        </Wrapper>
+      customRender(
+        <ActionIcon>
+          <p>An invalid child</p>
+        </ActionIcon>
       )
     )
   })
 
   it('has no programmatically detectable a11y issues', async () => {
-    const { container } = render(
-      <Wrapper>
-        <ActionIcon label="Mark as complete">
-          <Icon is={() => <svg />} />
-        </ActionIcon>
-      </Wrapper>
+    const { container } = customRender(
+      <ActionIcon label="Mark as complete">
+        <Icon is={() => <svg />} />
+      </ActionIcon>
     )
 
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('renders a link', () => {
-    render(
-      <Wrapper>
-        <ActionIcon
-          label="Mark as complete"
-          href="https:/www.google.com"
-          role="link"
-        >
-          <Icon is={() => <svg />} />
-        </ActionIcon>
-      </Wrapper>
+    customRender(
+      <ActionIcon label="Mark as complete" href="/somewhere">
+        <Icon is={() => <svg />} />
+      </ActionIcon>
+    )
+    expect(screen.queryByRole('link')).toHaveAttribute('href', '/somewhere')
+    expect(screen.queryByRole('link')).not.toHaveAttribute('target')
+    expect(screen.queryByRole('link')).not.toHaveAttribute('rel')
+  })
+
+  it('renders an external link with the correct attributes', () => {
+    const { container } = customRender(
+      <ActionIcon label="Mark as complete" href="https://www.google.com">
+        <Icon is={() => <svg />} />
+      </ActionIcon>
     )
     expect(screen.queryByRole('link')).toHaveAttribute(
       'href',
-      'https:/www.google.com'
+      'https://www.google.com'
     )
+    expect(screen.queryByRole('link')).toHaveAttribute('target', '_blank')
+    expect(screen.queryByRole('link')).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    )
+
+    expect(container).toMatchSnapshot()
   })
 
   it('renders a disabled link', () => {
-    render(
-      <Wrapper>
-        <ActionIcon
-          disabled
-          label="Mark as complete"
-          href="https:/www.google.com"
-          role="link"
-        >
-          <Icon is={() => <svg />} />
-        </ActionIcon>
-      </Wrapper>
+    customRender(
+      <ActionIcon
+        disabled
+        label="Mark as complete"
+        href="https://www.google.com"
+        role="link"
+      >
+        <Icon is={() => <svg />} />
+      </ActionIcon>
     )
 
     expect(screen.queryByRole('link')).not.toHaveAttribute('href')
+    expect(screen.queryByRole('link')).toHaveAttribute('target')
+    expect(screen.queryByRole('link')).toHaveAttribute('rel')
   })
 })

--- a/lib/src/components/action-icon/ActionIcon.tsx
+++ b/lib/src/components/action-icon/ActionIcon.tsx
@@ -11,6 +11,7 @@ import { OptionalTooltipWrapper } from '~/utilities/optional-tooltip-wrapper'
 
 import { Icon } from '../icon/Icon'
 import { ActionIconSizeMap } from './ActionIcon.constants'
+import { isExternalLink } from '~/utilities/uri'
 
 const getSimpleVariant = (base: string, interact: string, active: string) => ({
   bg: 'transparent',
@@ -237,6 +238,9 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
           'aria-disabled': !!disabled
         } as const)
       : ({ type: 'button' } as const)
+    const externalLinkProps = isExternalLink(href)
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : {}
 
     return (
       <OptionalTooltipWrapper
@@ -246,6 +250,7 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
       >
         <StyledButton
           {...optionalLinkProps}
+          {...externalLinkProps}
           {...remainingProps}
           aria-label={label}
           theme={theme}

--- a/lib/src/components/action-icon/ActionIcon.tsx
+++ b/lib/src/components/action-icon/ActionIcon.tsx
@@ -11,7 +11,7 @@ import { OptionalTooltipWrapper } from '~/utilities/optional-tooltip-wrapper'
 
 import { Icon } from '../icon/Icon'
 import { ActionIconSizeMap } from './ActionIcon.constants'
-import { isExternalLink } from '~/utilities/uri'
+import { getExternalAnchorProps } from '~/utilities/uri'
 
 const getSimpleVariant = (base: string, interact: string, active: string) => ({
   bg: 'transparent',
@@ -238,9 +238,6 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
           'aria-disabled': !!disabled
         } as const)
       : ({ type: 'button' } as const)
-    const externalLinkProps = isExternalLink(href)
-      ? { target: '_blank', rel: 'noopener noreferrer' }
-      : {}
 
     return (
       <OptionalTooltipWrapper
@@ -250,7 +247,7 @@ export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
       >
         <StyledButton
           {...optionalLinkProps}
-          {...externalLinkProps}
+          {...getExternalAnchorProps(href)}
           {...remainingProps}
           aria-label={label}
           theme={theme}

--- a/lib/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
+++ b/lib/src/components/action-icon/__snapshots__/ActionIcon.test.tsx.snap
@@ -124,3 +124,131 @@ exports[`ActionIcon component renders 1`] = `
   </button>
 </div>
 `;
+
+exports[`ActionIcon component renders an external link with the correct attributes 1`] = `
+@media  {
+  .c-fDzwZw {
+    align-items: center;
+    -webkit-appearance: none;
+    appearance: none;
+    background: white;
+    border: unset;
+    border-radius: var(--radii-0);
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: unset;
+    transition: all 100ms ease-out;
+  }
+
+  .c-dbrbZt {
+    display: inline-block;
+    fill: none;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-hVoQtf {
+    background-color: var(--colors-tonal500);
+    border-radius: var(--radii-0);
+    box-shadow: var(--shadows-0);
+    color: white;
+    font-family: var(--fonts-body);
+    font-size: var(--fontSizes-sm);
+    line-height: 1.5;
+    white-space: normal;
+    padding-left: var(--space-3);
+    padding-right: var(--space-3);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+    z-index: 10;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf {
+      animation-duration: 75ms;
+      animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+      will-change: transform, opacity;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="top"] {
+      animation-name: k-ftcNPK;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="right"] {
+      animation-name: k-hbaHED;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="bottom"] {
+      animation-name: k-daNevH;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .c-hVoQtf[data-state="delayed-open"][data-side="left"] {
+      animation-name: k-fvyGIa;
+    }
+}
+}
+
+@media  {
+  .c-fDzwZw-elrktp-size-sm {
+    height: var(--sizes-3);
+    width: var(--sizes-3);
+  }
+
+  .c-dbrbZt-cyeZeh-size-sm {
+    height: var(--sizes-1);
+    width: var(--sizes-1);
+    stroke-width: 1.5;
+  }
+
+  .c-hVoQtf-gWQnqe-size-md {
+    max-width: 250px;
+  }
+}
+
+@media  {
+  .c-fDzwZw-cmVfvW-cv {
+    background: transparent;
+    color: var(--colors-primary);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):hover,
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):focus {
+    color: var(--colors-primaryMid);
+  }
+
+  .c-fDzwZw-cmVfvW-cv:not(:disabled):active {
+    color: var(--colors-primaryDark);
+  }
+
+  .c-fDzwZw-cmVfvW-cv[disabled] {
+    color: var(--colors-tonal400);
+    cursor: not-allowed;
+  }
+}
+
+<div>
+  <a
+    aria-disabled="false"
+    aria-label="Mark as complete"
+    class="c-fDzwZw c-fDzwZw-elrktp-size-sm c-fDzwZw-cmVfvW-cv c-PJLV"
+    data-state="closed"
+    href="https://www.google.com"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <svg />
+  </a>
+</div>
+`;

--- a/lib/src/components/button/Button.test.tsx
+++ b/lib/src/components/button/Button.test.tsx
@@ -144,7 +144,19 @@ describe(`Button component`, () => {
 
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', 'https://app.atomlearning.co.uk')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     expect(link).not.toHaveAttribute('type', 'button')
+  })
+
+  it('renders an anchor if provided a link', async () => {
+    render(<Button href="/somewhere">ATOM</Button>)
+
+    const link = screen.getByRole('link')
+
+    expect(link).toHaveAttribute('href', '/somewhere')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
   })
 
   describe('Loading state', () => {
@@ -182,15 +194,6 @@ describe(`Button component`, () => {
       fireEvent.click(screen.getByRole('button'))
 
       expect(handleClick).toHaveBeenCalledTimes(0)
-    })
-
-    it('renders an anchor if provided a link', async () => {
-      render(<Button href="https://atomlearning.co.uk">ATOM</Button>)
-
-      expect(await screen.findByRole('link')).toHaveAttribute(
-        'href',
-        'https://atomlearning.co.uk'
-      )
     })
   })
 })

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -8,7 +8,7 @@ import { Loader } from '~/components/loader'
 import { styled, theme } from '~/stitches'
 import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
-import { isExternalLink } from '~/utilities/uri'
+import { getExternalAnchorProps } from '~/utilities/uri'
 
 const getButtonOutlineVariant = (
   base: string,
@@ -240,30 +240,24 @@ type ButtonProps = Override<
 >
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, as, href, isLoading = false, onClick, ...rest }, ref) => {
-    const externalLinkProps = isExternalLink(href)
-      ? { target: '_blank', rel: 'noopener noreferrer' }
-      : {}
-
-    return (
-      <StyledButton
-        as={as || (href ? 'a' : undefined)}
-        href={href}
-        isLoading={isLoading}
-        onClick={!isLoading ? onClick : undefined}
-        type={!href ? 'button' : undefined}
-        {...rest}
-        {...externalLinkProps}
-        ref={ref}
-      >
-        {isLoading ? (
-          <WithLoader size={rest.size}>{children}</WithLoader>
-        ) : (
-          children
-        )}
-      </StyledButton>
-    )
-  }
+  ({ children, as, href, isLoading = false, onClick, ...rest }, ref) => (
+    <StyledButton
+      as={as || (href ? 'a' : undefined)}
+      href={href}
+      isLoading={isLoading}
+      onClick={!isLoading ? onClick : undefined}
+      type={!href ? 'button' : undefined}
+      {...rest}
+      {...getExternalAnchorProps(href)}
+      ref={ref}
+    >
+      {isLoading ? (
+        <WithLoader size={rest.size}>{children}</WithLoader>
+      ) : (
+        children
+      )}
+    </StyledButton>
+  )
 ) as React.FC<ButtonProps>
 
 Button.displayName = 'Button'

--- a/lib/src/components/dropdown-menu/DropdownMenu.test.tsx
+++ b/lib/src/components/dropdown-menu/DropdownMenu.test.tsx
@@ -11,6 +11,9 @@ const ExampleDropdownMenu = (props) => (
     <DropdownMenu.Content>
       <DropdownMenu.Item>Item 1</DropdownMenu.Item>
       <DropdownMenu.Item>Item 2</DropdownMenu.Item>
+      <DropdownMenu.LinkItem href="http://google.com">
+        Item 3
+      </DropdownMenu.LinkItem>
       <DropdownMenu.Separator />
       <DropdownMenu.LinkItem href="/logout">Log Out</DropdownMenu.LinkItem>
     </DropdownMenu.Content>

--- a/lib/src/components/dropdown-menu/DropdownMenuLinkItem.tsx
+++ b/lib/src/components/dropdown-menu/DropdownMenuLinkItem.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { styled } from '~/stitches'
 
 import { DropdownMenuItem } from './DropdownMenuItem'
-import { isExternalLink } from '~/utilities/uri'
+import { getExternalAnchorProps } from '~/utilities/uri'
 
 const StyledLink = styled('a', {
   textDecoration: 'none'
@@ -11,15 +11,10 @@ const StyledLink = styled('a', {
 
 export const DropdownMenuLinkItem: React.FC<
   React.ComponentProps<typeof DropdownMenuItem> & { href: string }
-> = ({ children, href, ...props }) => {
-  const externalLinkProps = isExternalLink(href)
-    ? { target: '_blank', rel: 'noopener noreferrer' }
-    : {}
-  return (
-    <DropdownMenuItem {...props} asChild>
-      <StyledLink href={href} role="menuitem" {...externalLinkProps}>
-        {children}
-      </StyledLink>
-    </DropdownMenuItem>
-  )
-}
+> = ({ children, href, ...props }) => (
+  <DropdownMenuItem {...props} asChild>
+    <StyledLink href={href} role="menuitem" {...getExternalAnchorProps(href)}>
+      {children}
+    </StyledLink>
+  </DropdownMenuItem>
+)

--- a/lib/src/components/dropdown-menu/DropdownMenuLinkItem.tsx
+++ b/lib/src/components/dropdown-menu/DropdownMenuLinkItem.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { styled } from '~/stitches'
 
 import { DropdownMenuItem } from './DropdownMenuItem'
+import { isExternalLink } from '~/utilities/uri'
 
 const StyledLink = styled('a', {
   textDecoration: 'none'
@@ -10,10 +11,15 @@ const StyledLink = styled('a', {
 
 export const DropdownMenuLinkItem: React.FC<
   React.ComponentProps<typeof DropdownMenuItem> & { href: string }
-> = ({ children, href, ...props }) => (
-  <DropdownMenuItem {...props} asChild>
-    <StyledLink href={href} role="menuitem">
-      {children}
-    </StyledLink>
-  </DropdownMenuItem>
-)
+> = ({ children, href, ...props }) => {
+  const externalLinkProps = isExternalLink(href)
+    ? { target: '_blank', rel: 'noopener noreferrer' }
+    : {}
+  return (
+    <DropdownMenuItem {...props} asChild>
+      <StyledLink href={href} role="menuitem" {...externalLinkProps}>
+        {children}
+      </StyledLink>
+    </DropdownMenuItem>
+  )
+}

--- a/lib/src/components/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/lib/src/components/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -41,15 +41,15 @@ exports[`DropdownMenu component renders 1`] = `
     text-decoration: underline;
   }
 
+  .c-cIdiJW {
+    text-decoration: none;
+  }
+
   .c-gBsmUO {
     height: 1px;
     background-color: var(--colors-tonal200);
     margin-top: var(--space-2);
     margin-bottom: var(--space-2);
-  }
-
-  .c-cIdiJW {
-    text-decoration: none;
   }
 
   .c-ghAfvs {
@@ -105,14 +105,14 @@ exports[`DropdownMenu component renders 1`] = `
     tabindex="0"
   />
   <button
-    aria-controls="radix-4"
+    aria-controls="radix-5"
     aria-expanded="true"
     aria-haspopup="menu"
     aria-hidden="true"
     class="c-PJLV"
     data-aria-hidden="true"
     data-state="open"
-    id="radix-3"
+    id="radix-4"
     type="button"
   >
     TRIGGER
@@ -122,7 +122,7 @@ exports[`DropdownMenu component renders 1`] = `
     style="position: fixed; left: 0px; top: 0px; transform: translate3d(0, -200%, 0); min-width: max-content;"
   >
     <div
-      aria-labelledby="radix-3"
+      aria-labelledby="radix-4"
       aria-orientation="vertical"
       class="c-ghAfvs"
       data-align="center"
@@ -130,7 +130,7 @@ exports[`DropdownMenu component renders 1`] = `
       data-side="bottom"
       data-state="open"
       dir="ltr"
-      id="radix-4"
+      id="radix-5"
       role="menu"
       style="outline: none; --radix-dropdown-menu-content-transform-origin: var(--radix-popper-transform-origin); animation: none; pointer-events: auto;"
       tabindex="-1"
@@ -153,6 +153,18 @@ exports[`DropdownMenu component renders 1`] = `
       >
         Item 2
       </div>
+      <a
+        class="c-cIdiJW c-iLVhIC"
+        data-orientation="vertical"
+        data-radix-collection-item=""
+        href="http://google.com"
+        rel="noopener noreferrer"
+        role="menuitem"
+        tabindex="-1"
+        target="_blank"
+      >
+        Item 3
+      </a>
       <div
         aria-orientation="horizontal"
         class="c-gBsmUO"

--- a/lib/src/components/link/Link.test.tsx
+++ b/lib/src/components/link/Link.test.tsx
@@ -13,6 +13,7 @@ describe(`Link component`, () => {
     const link = await screen.getByText('GOOGLE')
 
     expect(link).toHaveAttribute('href', 'https://google.com/')
+    expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveTextContent('GOOGLE')
     expect(container).toMatchSnapshot()
   })

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { styled } from '~/stitches'
 import { NavigatorActions } from '~/types'
 import { Override } from '~/utilities'
-import { isExternalLink } from '~/utilities/uri'
+import { getExternalAnchorProps } from '~/utilities/uri'
 
 import { StyledHeading } from '../heading/Heading'
 import { StyledLi } from '../list/List'
@@ -47,22 +47,16 @@ type LinkProps = Override<
 >
 
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ as, href, ...rest }, ref) => {
-    const externalLinkProps = isExternalLink(href)
-      ? { target: '_blank', rel: 'noopener noreferrer' }
-      : {}
-
-    return (
-      <StyledLink
-        as={as || (!href ? 'button' : undefined)}
-        noCapsize={!href ? true : undefined}
-        href={href}
-        {...rest}
-        {...externalLinkProps}
-        ref={ref}
-      />
-    )
-  }
+  ({ as, href, ...rest }, ref) => (
+    <StyledLink
+      as={as || (!href ? 'button' : undefined)}
+      noCapsize={!href ? true : undefined}
+      href={href}
+      {...rest}
+      {...getExternalAnchorProps(href)}
+      ref={ref}
+    />
+  )
 ) as React.FC<LinkProps>
 
 Link.displayName = 'Link'

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.test.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -12,8 +12,11 @@ const NavigationMenuVerticalImplementation = ({
   return (
     <NavigationMenuVertical defaultValue="trigger">
       <NavigationMenuVertical.Link active>Button</NavigationMenuVertical.Link>
-      <NavigationMenuVertical.Link href="google.com">
-        Link
+      <NavigationMenuVertical.Link href="/somewhere">
+        Relative Link
+      </NavigationMenuVertical.Link>
+      <NavigationMenuVertical.Link href="http://google.com">
+        External Link
       </NavigationMenuVertical.Link>
       {children}
     </NavigationMenuVertical>
@@ -24,17 +27,18 @@ const mockOnOpenChange = jest.fn((_value) => null)
 
 describe('NavigationMenuVertical', () => {
   it('renders', async () => {
-    const { findByRole } = render(<NavigationMenuVerticalImplementation />)
+    render(<NavigationMenuVerticalImplementation />)
 
-    const navigation = await findByRole('navigation')
-    await findByRole('link', { name: 'Link' })
-    await findByRole('button', { name: 'Button' })
+    const navigation = await screen.findByRole('navigation')
+    await screen.findByRole('link', { name: 'Relative Link' })
+    await screen.findByRole('link', { name: 'External Link' })
+    await screen.findByRole('button', { name: 'Button' })
 
     expect(navigation).toMatchSnapshot()
   })
 
   it('renders accordion and interacts correctly', async () => {
-    const { findByRole, container, getByTestId } = render(
+    const { container } = render(
       <NavigationMenuVerticalImplementation>
         <NavigationMenuVertical.Accordion
           onOpenChange={mockOnOpenChange}
@@ -52,11 +56,11 @@ describe('NavigationMenuVertical', () => {
 
     expect(container).toMatchSnapshot()
 
-    const accordionTrigger = await findByRole('button', {
+    const accordionTrigger = await screen.findByRole('button', {
       name: 'Accordion Trigger'
     })
     expect(accordionTrigger).toHaveAttribute('data-state', 'open')
-    const accordionContent = getByTestId('accordion-content')
+    const accordionContent = screen.getByTestId('accordion-content')
     expect(accordionContent).toBeVisible()
 
     userEvent.click(accordionTrigger)

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { styled } from '~/stitches'
 import { preventEvent } from '~/utilities/event'
-import { isExternalLink } from '~/utilities/uri'
+import { getExternalAnchorProps } from '~/utilities/uri'
 
 import { navigationMenuVerticalItemStyles } from './NavigationMenuVertical.styles'
 import { NavigationMenuVerticalItem } from './NavigationMenuVerticalItem'
@@ -23,16 +23,12 @@ type NavigationMenuVerticalItemProps = React.ComponentProps<
 export const NavigationMenuVerticalLink: React.FC<
   NavigationMenuVerticalItemProps
 > = ({ as, href, children, ...rest }) => {
-  const linkProps = isExternalLink(href)
-    ? { target: '_blank', rel: 'noopener noreferrer' }
-    : {}
-
-  const buttonProps = {
-    type: 'button'
-  }
-
   const Component = as || (href ? 'a' : 'button')
-  const componentProps = as ? {} : href ? linkProps : buttonProps
+  const componentProps = as
+    ? {}
+    : href
+    ? getExternalAnchorProps(href)
+    : { type: 'button' }
 
   return (
     <NavigationMenuVerticalItem>

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         <a
           class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
           data-radix-collection-item=""
-          href="google.com"
+          href="/somewhere"
         >
           <div
             class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
@@ -177,7 +177,28 @@ exports[`NavigationMenuVertical renders 1`] = `
             <span
               class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-ixvUrA"
             >
-              Link
+              Relative Link
+            </span>
+          </div>
+        </a>
+      </li>
+      <li
+        class="c-PJLV"
+      >
+        <a
+          class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+          data-radix-collection-item=""
+          href="http://google.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <div
+            class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
+          >
+            <span
+              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-ixvUrA"
+            >
+              External Link
             </span>
           </div>
         </a>
@@ -389,7 +410,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           <a
             class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
             data-radix-collection-item=""
-            href="google.com"
+            href="/somewhere"
           >
             <div
               class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
@@ -397,7 +418,28 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
               <span
                 class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-ixvUrA"
               >
-                Link
+                Relative Link
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          class="c-PJLV"
+        >
+          <a
+            class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+            data-radix-collection-item=""
+            href="http://google.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <div
+              class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
+            >
+              <span
+                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-ixvUrA"
+              >
+                External Link
               </span>
             </div>
           </a>

--- a/lib/src/components/navigation/NavigationMenuLink.tsx
+++ b/lib/src/components/navigation/NavigationMenuLink.tsx
@@ -8,7 +8,7 @@ import {
   navigationMenuBaseItemStyles,
   navigationMenuDisabledItemStyles
 } from './NavigationMenu.styles'
-import { isExternalLink } from '~/utilities/uri'
+import { getExternalAnchorProps } from '~/utilities/uri'
 
 const DisabledButton = styled('button', {
   ...navigationMenuBaseItemStyles,
@@ -61,31 +61,26 @@ export const NavigationMenuLink = React.forwardRef<
   (
     { children, href, disabled, css, variant = 'link', ...props },
     forwardedRef
-  ) => {
-    const externalLinkProps = isExternalLink(href)
-      ? { target: '_blank', rel: 'noopener noreferrer' }
-      : {}
-    return (
-      <ListItem>
-        {disabled ? (
-          <DisabledButton disabled {...props}>
-            {children}
-          </DisabledButton>
-        ) : (
-          <StyledLink
-            href={href}
-            ref={forwardedRef}
-            elementType={variant}
-            css={css}
-            {...externalLinkProps}
-            {...props}
-          >
-            {children}
-          </StyledLink>
-        )}
-      </ListItem>
-    )
-  }
+  ) => (
+    <ListItem>
+      {disabled ? (
+        <DisabledButton disabled {...props}>
+          {children}
+        </DisabledButton>
+      ) : (
+        <StyledLink
+          href={href}
+          ref={forwardedRef}
+          elementType={variant}
+          css={css}
+          {...getExternalAnchorProps(href)}
+          {...props}
+        >
+          {children}
+        </StyledLink>
+      )}
+    </ListItem>
+  )
 )
 
 NavigationMenuLink.displayName = 'NavigationMenuLink'

--- a/lib/src/components/navigation/NavigationMenuLink.tsx
+++ b/lib/src/components/navigation/NavigationMenuLink.tsx
@@ -8,6 +8,7 @@ import {
   navigationMenuBaseItemStyles,
   navigationMenuDisabledItemStyles
 } from './NavigationMenu.styles'
+import { isExternalLink } from '~/utilities/uri'
 
 const DisabledButton = styled('button', {
   ...navigationMenuBaseItemStyles,
@@ -60,25 +61,31 @@ export const NavigationMenuLink = React.forwardRef<
   (
     { children, href, disabled, css, variant = 'link', ...props },
     forwardedRef
-  ) => (
-    <ListItem>
-      {disabled ? (
-        <DisabledButton disabled {...props}>
-          {children}
-        </DisabledButton>
-      ) : (
-        <StyledLink
-          href={href}
-          ref={forwardedRef}
-          elementType={variant}
-          css={css}
-          {...props}
-        >
-          {children}
-        </StyledLink>
-      )}
-    </ListItem>
-  )
+  ) => {
+    const externalLinkProps = isExternalLink(href)
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : {}
+    return (
+      <ListItem>
+        {disabled ? (
+          <DisabledButton disabled {...props}>
+            {children}
+          </DisabledButton>
+        ) : (
+          <StyledLink
+            href={href}
+            ref={forwardedRef}
+            elementType={variant}
+            css={css}
+            {...externalLinkProps}
+            {...props}
+          >
+            {children}
+          </StyledLink>
+        )}
+      </ListItem>
+    )
+  }
 )
 
 NavigationMenuLink.displayName = 'NavigationMenuLink'

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -343,6 +343,8 @@ exports[`Nav component renders 1`] = `
                 class="c-dIYQCX c-govTNd c-govTNd-gkgtJA-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/colours"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <div
                   class="c-dhzjXW c-dhzjXW-iiTKOFX-css"
@@ -367,6 +369,8 @@ exports[`Nav component renders 1`] = `
                 class="c-dIYQCX c-govTNd c-govTNd-gkgtJA-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/effects"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Effects
               </a>
@@ -378,6 +382,8 @@ exports[`Nav component renders 1`] = `
                 class="c-dIYQCX c-govTNd c-govTNd-gkgtJA-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/icons"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 Icons
               </a>

--- a/lib/src/utilities/uri/index.ts
+++ b/lib/src/utilities/uri/index.ts
@@ -1,9 +1,9 @@
-export const isExternalLink = (link = '') => {
-  if (typeof window === 'undefined') return false
+export const isExternalUrl = (url?: string) => {
+  if (typeof window === 'undefined' || !url) return false
 
-  const isAbsolute = /^https?:\/\//.test(link)
-  return isAbsolute && new URL(link).origin !== window.location.origin
+  const isAbsoluteUrl = /^https?:\/\//.test(url)
+  return isAbsoluteUrl && new URL(url).origin !== window.location.origin
 }
 
-export const getExternalAnchorProps = (url: string) =>
-  isExternalLink(url) ? { target: '_blank', rel: 'noopener noreferrer' } : {}
+export const getExternalAnchorProps = (url?: string) =>
+  isExternalUrl(url) ? { target: '_blank', rel: 'noopener noreferrer' } : {}

--- a/lib/src/utilities/uri/index.ts
+++ b/lib/src/utilities/uri/index.ts
@@ -4,3 +4,6 @@ export const isExternalLink = (link = '') => {
   const isAbsolute = /^https?:\/\//.test(link)
   return isAbsolute && new URL(link).origin !== window.location.origin
 }
+
+export const getExternalAnchorProps = (url = '') =>
+  isExternalLink(url) ? { target: '_blank', rel: 'noopener noreferrer' } : {}

--- a/lib/src/utilities/uri/index.ts
+++ b/lib/src/utilities/uri/index.ts
@@ -5,5 +5,5 @@ export const isExternalLink = (link = '') => {
   return isAbsolute && new URL(link).origin !== window.location.origin
 }
 
-export const getExternalAnchorProps = (url = '') =>
+export const getExternalAnchorProps = (url: string) =>
   isExternalLink(url) ? { target: '_blank', rel: 'noopener noreferrer' } : {}


### PR DESCRIPTION
A minor fix to ensure that any component that can render a link also contains the logic to add props specific to external hrefs. e.g. `<a href="http://google.com" />` now renders as `<a href="http://google.com" target="_blank" rel="noopener noreferrer" />`

Please let me know if I've missed anything.