### PR TITLE
Fix: AlertDialog visible scroll bar

### DIFF
--- a/lib/src/components/alert-dialog/alert-context/AlertDialog.tsx
+++ b/lib/src/components/alert-dialog/alert-context/AlertDialog.tsx
@@ -50,7 +50,7 @@ export const Alert: React.FC<AlertDialogContentProps> = ({
       {description && (
         <Text
           as={AlertDialog.Description}
-          css={{ display: 'flex', overflowY: 'scroll' }}
+          css={{ display: 'flex', overflowY: 'auto' }}
         >
           {description}
         </Text>


### PR DESCRIPTION
### Description

If you have "always show scroll" bars on mac you will see the scroll bar on the alert dialog:
<img width="521" alt="image" src="https://github.com/Atom-Learning/components/assets/11061661/863a4ce2-283b-42aa-b433-e97b7a648480">

**Fix:**

<img width="519" alt="image" src="https://github.com/Atom-Learning/components/assets/11061661/5844865e-9bff-4fdf-b295-9c773b104f7b">

scroll needed

<img width="666" alt="Screenshot 2023-10-24 at 11 07 52" src="https://github.com/Atom-Learning/components/assets/11061661/91455e33-b766-4894-b25d-df1e59116fc5">

