### PR TITLE
Feat/add stitches theme to navigation and topbar

### DIFF
--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.styles.ts
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.styles.ts
@@ -11,10 +11,12 @@ export const navigationMenuVerticalItemStyles = {
   p: '$2',
   pl: `var(--navigation-menu-vertical-item-pl)`,
   width: '100%',
+  color: '$text',
+  bg: '$background',
   '--navigation-menu-vertical-item-font-weight': 400,
   '&[data-active]': {
-    background: '$accent2',
-    color: '$accent9',
+    bg: '$backgroundSelected',
+    color: '$textSelected',
     '--navigation-menu-vertical-item-font-weight': 600
   },
   '&[data-state=open]': {
@@ -26,10 +28,10 @@ export const navigationMenuVerticalItemStyles = {
   },
   '&:not([data-disabled])': {
     '&:hover': {
-      background: '$base2'
+      bg: '$backgroundHover'
     },
     '&:active': {
-      background: '$base3'
+      bg: '$backgroundActive'
     },
     '&:focus-visible': focusVisibleStyleBlock()
   },

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.tsx
@@ -2,6 +2,7 @@ import { Root } from '@radix-ui/react-navigation-menu'
 import React from 'react'
 
 import { styled } from '~/stitches'
+import { colorSchemes as navigationMenuVerticalColorSchemes } from './stitches.navigationMenuVertical.colorscheme.config'
 
 import { NavigationMenuVerticalAccordion } from './NavigationMenuVerticalAccordion'
 import { NavigationMenuVerticalAccordionContent } from './NavigationMenuVerticalAccordionContent'
@@ -46,7 +47,11 @@ type TNavigationVerticalType = React.FC<TNavigationVerticalProps> & {
 
 export const NavigationMenuVertical = (({ children, ...rest }) => {
   return (
-    <StyledRoot {...rest} orientation="vertical">
+    <StyledRoot
+      className={navigationMenuVerticalColorSchemes['light']}
+      {...rest}
+      orientation="vertical"
+    >
       <NavigationMenuVerticalList>{children}</NavigationMenuVerticalList>
     </StyledRoot>
   )

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -2,6 +2,260 @@
 
 exports[`NavigationMenuVertical renders 1`] = `
 @media  {
+  :root,
+  .t-kAUxbu {
+    --default-colors: [object Object];
+    --default-space: [object Object];
+    --default-fontSizes: [object Object];
+    --default-fonts: [object Object];
+    --default-sizes: [object Object];
+    --default-radii: [object Object];
+    --default-shadows: [object Object];
+    --default-ratios: [object Object];
+    --colors-textForeground: hsl(0, 0%, 12%);
+    --colors-textSubtle: hsl(0, 0%, 33%);
+    --colors-textPlaceholder: hsl(0, 0%, 46%);
+    --colors-background: hsl(0, 0%, 96%);
+    --colors-backgroundAccent: hsl(215, 100%, 98%);
+    --colors-grey100: hsl(0, 0%, 96%);
+    --colors-grey200: hsl(0, 0%, 92%);
+    --colors-grey300: hsl(0, 0%, 88%);
+    --colors-grey400: hsl(0, 0%, 81%);
+    --colors-grey500: hsl(0, 0%, 73%);
+    --colors-grey600: hsl(0, 0%, 62%);
+    --colors-grey700: hsl(0, 0%, 46%);
+    --colors-grey800: hsl(0, 0%, 33%);
+    --colors-grey900: hsl(0, 0%, 20%);
+    --colors-grey1000: hsl(0, 0%, 12%);
+    --colors-grey1100: hsl(0, 0%, 10%);
+    --colors-grey1200: hsl(0, 0%, 6%);
+    --colors-blue100: hsl(215, 100%, 98%);
+    --colors-blue200: hsl(212, 100%, 95%);
+    --colors-blue300: hsl(211, 100%, 92%);
+    --colors-blue400: hsl(211, 100%, 88%);
+    --colors-blue500: hsl(212, 100%, 80%);
+    --colors-blue600: hsl(213, 100%, 71%);
+    --colors-blue700: hsl(214, 100%, 58%);
+    --colors-blue800: hsl(217, 92%, 51%);
+    --colors-blue900: hsl(223, 78%, 44%);
+    --colors-blue1000: hsl(228, 82%, 35%);
+    --colors-blue1100: hsl(228, 63%, 23%);
+    --colors-blue1200: hsl(227, 57%, 11%);
+    --colors-purple100: hsl(282, 100%, 98%);
+    --colors-purple200: hsl(270, 100%, 95%);
+    --colors-purple300: hsl(271, 100%, 92%);
+    --colors-purple400: hsl(270, 100%, 89%);
+    --colors-purple500: hsl(270, 90%, 81%);
+    --colors-purple600: hsl(271, 97%, 69%);
+    --colors-purple700: hsl(273, 84%, 47%);
+    --colors-purple800: hsl(273, 94%, 48%);
+    --colors-purple900: hsl(268, 79%, 42%);
+    --colors-purple1000: hsl(266, 82%, 32%);
+    --colors-purple1100: hsl(265, 63%, 23%);
+    --colors-purple1200: hsl(265, 61%, 14%);
+    --colors-cyan100: hsl(198, 100%, 97%);
+    --colors-cyan200: hsl(199, 100%, 94%);
+    --colors-cyan300: hsl(201, 100%, 89%);
+    --colors-cyan400: hsl(200, 100%, 84%);
+    --colors-cyan500: hsl(201, 96%, 73%);
+    --colors-cyan600: hsl(202, 85%, 60%);
+    --colors-cyan700: hsl(204, 81%, 46%);
+    --colors-cyan800: hsl(205, 100%, 38%);
+    --colors-cyan900: hsl(206, 100%, 30%);
+    --colors-cyan1000: hsl(205, 100%, 21%);
+    --colors-cyan1100: hsl(206, 97%, 15%);
+    --colors-cyan1200: hsl(207, 73%, 9%);
+    --colors-green100: hsl(135, 80%, 96%);
+    --colors-green200: hsl(135, 72%, 92%);
+    --colors-green300: hsl(135, 68%, 83%);
+    --colors-green400: hsl(135, 65%, 76%);
+    --colors-green500: hsl(136, 56%, 62%);
+    --colors-green600: hsl(137, 42%, 49%);
+    --colors-green700: hsl(138, 51%, 35%);
+    --colors-green800: hsl(138, 68%, 29%);
+    --colors-green900: hsl(138, 74%, 21%);
+    --colors-green1000: hsl(138, 89%, 14%);
+    --colors-green1100: hsl(135, 91%, 9%);
+    --colors-green1200: hsl(123, 56%, 6%);
+    --colors-magenta100: hsl(330, 100%, 99%);
+    --colors-magenta200: hsl(329, 100%, 96%);
+    --colors-magenta300: hsl(332, 100%, 92%);
+    --colors-magenta400: hsl(333, 100%, 90%);
+    --colors-magenta500: hsl(333, 90%, 80%);
+    --colors-magenta600: hsl(333, 87%, 72%);
+    --colors-magenta700: hsl(333, 75%, 59%);
+    --colors-magenta800: hsl(333, 69%, 49%);
+    --colors-magenta900: hsl(333, 74%, 36%);
+    --colors-magenta1000: hsl(333, 86%, 25%);
+    --colors-magenta1100: hsl(333, 95%, 16%);
+    --colors-magenta1200: hsl(334, 62%, 10%);
+    --colors-red100: hsl(0, 100%, 99%);
+    --colors-red200: hsl(0, 100%, 96%);
+    --colors-red300: hsl(357, 100%, 93%);
+    --colors-red400: hsl(356, 100%, 90%);
+    --colors-red500: hsl(356, 96%, 83%);
+    --colors-red600: hsl(357, 90%, 73%);
+    --colors-red700: hsl(357, 80%, 59%);
+    --colors-red800: hsl(357, 76%, 49%);
+    --colors-red900: hsl(357, 73%, 37%);
+    --colors-red1000: hsl(357, 79%, 26%);
+    --colors-red1100: hsl(357, 91%, 17%);
+    --colors-red1200: hsl(357, 73%, 10%);
+    --colors-teal100: hsl(180, 83%, 95%);
+    --colors-teal200: hsl(180, 75%, 88%);
+    --colors-teal300: hsl(180, 71%, 78%);
+    --colors-teal400: hsl(179, 70%, 71%);
+    --colors-teal500: hsl(179, 65%, 52%);
+    --colors-teal600: hsl(179, 76%, 41%);
+    --colors-teal700: hsl(179, 91%, 31%);
+    --colors-teal800: hsl(178, 100%, 25%);
+    --colors-teal900: hsl(180, 100%, 18%);
+    --colors-teal1000: hsl(183, 100%, 13%);
+    --colors-teal1100: hsl(187, 92%, 10%);
+    --colors-teal1200: hsl(186, 56%, 7%);
+    --colors-orange100: hsl(38, 100%, 95%);
+    --colors-orange200: hsl(38, 100%, 90%);
+    --colors-orange300: hsl(37, 100%, 84%);
+    --colors-orange400: hsl(36, 96%, 78%);
+    --colors-orange500: hsl(33, 100%, 67%);
+    --colors-orange600: hsl(31, 97%, 57%);
+    --colors-orange700: hsl(30, 92%, 46%);
+    --colors-orange800: hsl(29, 100%, 43%);
+    --colors-orange900: hsl(27, 100%, 36%);
+    --colors-orange1000: hsl(24, 100%, 26%);
+    --colors-orange1100: hsl(20, 97%, 15%);
+    --colors-orange1200: hsl(20, 96%, 11%);
+    --colors-yellow100: hsl(53, 94%, 93%);
+    --colors-yellow200: hsl(54, 92%, 85%);
+    --colors-yellow300: hsl(54, 92%, 75%);
+    --colors-yellow400: hsl(52, 97%, 63%);
+    --colors-yellow500: hsl(51, 100%, 46%);
+    --colors-yellow600: hsl(49, 100%, 39%);
+    --colors-yellow700: hsl(48, 100%, 35%);
+    --colors-yellow800: hsl(46, 100%, 30%);
+    --colors-yellow900: hsl(44, 100%, 22%);
+    --colors-yellow1000: hsl(44, 100%, 18%);
+    --colors-yellow1100: hsl(41, 100%, 11%);
+    --colors-yellow1200: hsl(39, 100%, 8%);
+    --colors-lime100: hsl(73, 94%, 93%);
+    --colors-lime200: hsl(73, 94%, 87%);
+    --colors-lime300: hsl(73, 90%, 77%);
+    --colors-lime400: hsl(74, 82%, 69%);
+    --colors-lime500: hsl(74, 68%, 58%);
+    --colors-lime600: hsl(74, 77%, 41%);
+    --colors-lime700: hsl(75, 100%, 31%);
+    --colors-lime800: hsl(75, 100%, 27%);
+    --colors-lime900: hsl(75, 100%, 19%);
+    --colors-lime1000: hsl(75, 100%, 15%);
+    --colors-lime1100: hsl(75, 100%, 9%);
+    --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-tonal50: hsl(0, 0%, 96%);
+    --colors-tonal100: hsl(0, 0%, 92%);
+    --colors-tonal200: hsl(0, 0%, 62%);
+    --colors-tonal300: hsl(0, 0%, 46%);
+    --colors-tonal400: hsl(0, 0%, 33%);
+    --colors-tonal500: hsl(0, 0%, 20%);
+    --colors-tonal600: hsl(0, 0%, 12%);
+    --colors-alpha100: hsla(0, 0%, 20%, 0.1);
+    --colors-alpha150: hsla(0, 0%, 20%, 0.15);
+    --colors-alpha200: hsla(0, 0%, 20%, 0.2);
+    --colors-alpha250: hsla(0, 0%, 20%, 0.25);
+    --colors-alpha600: hsla(0, 0%, 20%, 0.6);
+    --colors-primaryLight: hsl(215, 100%, 98%);
+    --colors-primary: hsl(217, 92%, 51%);
+    --colors-primaryMid: hsl(223, 78%, 44%);
+    --colors-primaryDark: hsl(228, 82%, 35%);
+    --colors-secondary: hsl(204, 100%, 72%);
+    --colors-brandRed: hsl(0, 91%, 64%);
+    --colors-brandRedAccent: hsl(14, 100%, 71%);
+    --colors-brandGreen: hsl(128, 47%, 53%);
+    --colors-brandGreenAccent: hsl(168, 100%, 20%);
+    --colors-brandPurple: hsl(256, 65%, 62%);
+    --colors-brandPurpleAccent: hsl(256, 93%, 35%);
+    --colors-brandYellow: hsl(41, 100%, 55%);
+    --colors-brandYellowAccent: hsl(33, 100%, 50%);
+    --colors-successLight: hsl(119, 44%, 94%);
+    --colors-success: hsl(119, 100%, 27%);
+    --colors-successMid: hsl(124, 100%, 22%);
+    --colors-successDark: hsl(126, 100%, 17%);
+    --colors-dangerLight: hsl(0, 77%, 95%);
+    --colors-danger: hsl(0, 96%, 48%);
+    --colors-dangerMid: hsl(0, 96%, 41%);
+    --colors-dangerDark: hsl(0, 97%, 34%);
+    --colors-warningLight: hsl(39, 100%, 94%);
+    --colors-warning: hsl(41, 100%, 55%);
+    --colors-warningMid: hsl(41, 89%, 48%);
+    --colors-warningDark: hsl(41, 100%, 41%);
+    --colors-warningText: hsl(24, 100%, 37%);
+    --colors-subjectEnglish: hsl(0, 91%, 64%);
+    --colors-subjectMaths: hsl(217, 92%, 51%);
+    --colors-subjectScience: hsl(256, 65%, 62%);
+    --colors-subjectVerbalReasoning: hsl(128, 47%, 53%);
+    --colors-subjectNonVerbalReasoning: hsl(41, 100%, 55%);
+    --colors-subjectCreativeWriting: hsl(33, 100%, 50%);
+    --colors-subjectExamSkills: hsl(256, 93%, 35%);
+    --colors-glBlueLight: hsl(222, 68%, 78%);
+    --colors-glBluePrimary: hsl(222, 56%, 55%);
+    --colors-glBlueDark: hsl(222, 35%, 43%);
+    --space-0: 0.125rem;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 2rem;
+    --space-6: 2.5rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-9: 5rem;
+    --space-24: 1.5rem;
+    --fontSizes-xs: 0.75rem;
+    --fontSizes-sm: 0.875rem;
+    --fontSizes-md: 1rem;
+    --fontSizes-lg: 1.3125rem;
+    --fontSizes-xl: 1.75rem;
+    --fontSizes-2xl: 2.3125rem;
+    --fontSizes-3xl: 3.125rem;
+    --fontSizes-4xl: 5.625rem;
+    --fonts-sans: system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-mono: 'SFMono-Regular', Consolas, Menlo, monospace;
+    --fonts-display: 'Space Grotesk', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-body: 'Inter', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --sizes-0: 0.5rem;
+    --sizes-1: 1rem;
+    --sizes-2: 1.5rem;
+    --sizes-3: 2rem;
+    --sizes-4: 2.5rem;
+    --sizes-5: 3rem;
+    --sizes-6: 4rem;
+    --sizes-7: 6rem;
+    --sizes-8: 8rem;
+    --radii-0: 0.25rem;
+    --radii-1: 0.5rem;
+    --radii-2: 0.75rem;
+    --radii-3: 1rem;
+    --radii-round: 100rem;
+    --shadows-0: 0 1px 3px hsla(0, 0%, 20%, 0.1), 0 1px 2px hsla(0, 0%, 20%, 0.15);
+    --shadows-1: 0 3px 6px hsla(0, 0%, 20%, 0.1), 0 3px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-2: 0 10px 20px hsla(0, 0%, 20%, 0.1), 0 6px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-3: 0 14px 28px hsla(0, 0%, 20%, 0.15), 0 10px 10px hsla(0, 0%, 20%, 0.1);
+    --ratios-16-9: 16/9;
+    --ratios-3-2: 3/2;
+    --ratios-4-3: 4/3;
+    --ratios-1-1: 1/1;
+    --ratios-3-4: 3/4;
+  }
+
+  .t-gwhiDE {
+    --colors-text: var(--colors-foreground);
+    --colors-background: var(--colors-base1);
+    --colors-backgroundHover: var(--colors-base2);
+    --colors-backgroundActive: var(--colors-base3);
+    --colors-textSelected: var(--colors-accent9);
+    --colors-backgroundSelected: var(--colors-accent2);
+  }
+}
+
+@media  {
   .c-dhzjXW {
     display: flex;
   }
@@ -21,13 +275,13 @@ exports[`NavigationMenuVertical renders 1`] = `
     font-weight: var(--navigation-menu-vertical-item-font-weight);
   }
 
-  .c-jgcFYa {
+  .c-bcEwPX {
     padding: var(--space-2);
     border: none;
     outline: none;
     font: inherit;
-    color: inherit;
-    background: none;
+    color: var(--colors-text);
+    background: var(--colors-background);
     text-align: inherit;
     text-decoration: unset;
     cursor: pointer;
@@ -39,30 +293,30 @@ exports[`NavigationMenuVertical renders 1`] = `
     --navigation-menu-vertical-item-font-weight: 400;
   }
 
-  .c-jgcFYa[data-active] {
-    background: var(--colors-accent2);
-    color: var(--colors-accent9);
+  .c-bcEwPX[data-active] {
+    background: var(--colors-backgroundSelected);
+    color: var(--colors-textSelected);
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-jgcFYa[data-state=open] {
+  .c-bcEwPX[data-state=open] {
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-jgcFYa[data-disabled] {
+  .c-bcEwPX[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-jgcFYa:not([data-disabled]):hover {
-    background: var(--colors-base2);
+  .c-bcEwPX:not([data-disabled]):hover {
+    background: var(--colors-backgroundHover);
   }
 
-  .c-jgcFYa:not([data-disabled]):active {
-    background: var(--colors-base3);
+  .c-bcEwPX:not([data-disabled]):active {
+    background: var(--colors-backgroundActive);
   }
 
-  .c-jgcFYa:not([data-disabled]):focus-visible {
+  .c-bcEwPX:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
@@ -123,14 +377,14 @@ exports[`NavigationMenuVertical renders 1`] = `
     display: table;
   }
 
-  .c-jgcFYa-jLELKD-size-lg {
+  .c-bcEwPX-jLELKD-size-lg {
     min-height: var(--sizes-5);
   }
 }
 
 <nav
   aria-label="Main"
-  class="c-fGHEql"
+  class="c-fGHEql t-gwhiDE"
   data-orientation="vertical"
   dir="ltr"
 >
@@ -147,7 +401,7 @@ exports[`NavigationMenuVertical renders 1`] = `
       >
         <button
           aria-current="page"
-          class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+          class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
           data-active=""
           data-radix-collection-item=""
           type="button"
@@ -167,7 +421,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+          class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
           data-radix-collection-item=""
           href="/somewhere"
         >
@@ -186,7 +440,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+          class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
           data-radix-collection-item=""
           href="http://google.com"
           rel="noopener noreferrer"
@@ -210,6 +464,260 @@ exports[`NavigationMenuVertical renders 1`] = `
 
 exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = `
 @media  {
+  :root,
+  .t-kAUxbu {
+    --default-colors: [object Object];
+    --default-space: [object Object];
+    --default-fontSizes: [object Object];
+    --default-fonts: [object Object];
+    --default-sizes: [object Object];
+    --default-radii: [object Object];
+    --default-shadows: [object Object];
+    --default-ratios: [object Object];
+    --colors-textForeground: hsl(0, 0%, 12%);
+    --colors-textSubtle: hsl(0, 0%, 33%);
+    --colors-textPlaceholder: hsl(0, 0%, 46%);
+    --colors-background: hsl(0, 0%, 96%);
+    --colors-backgroundAccent: hsl(215, 100%, 98%);
+    --colors-grey100: hsl(0, 0%, 96%);
+    --colors-grey200: hsl(0, 0%, 92%);
+    --colors-grey300: hsl(0, 0%, 88%);
+    --colors-grey400: hsl(0, 0%, 81%);
+    --colors-grey500: hsl(0, 0%, 73%);
+    --colors-grey600: hsl(0, 0%, 62%);
+    --colors-grey700: hsl(0, 0%, 46%);
+    --colors-grey800: hsl(0, 0%, 33%);
+    --colors-grey900: hsl(0, 0%, 20%);
+    --colors-grey1000: hsl(0, 0%, 12%);
+    --colors-grey1100: hsl(0, 0%, 10%);
+    --colors-grey1200: hsl(0, 0%, 6%);
+    --colors-blue100: hsl(215, 100%, 98%);
+    --colors-blue200: hsl(212, 100%, 95%);
+    --colors-blue300: hsl(211, 100%, 92%);
+    --colors-blue400: hsl(211, 100%, 88%);
+    --colors-blue500: hsl(212, 100%, 80%);
+    --colors-blue600: hsl(213, 100%, 71%);
+    --colors-blue700: hsl(214, 100%, 58%);
+    --colors-blue800: hsl(217, 92%, 51%);
+    --colors-blue900: hsl(223, 78%, 44%);
+    --colors-blue1000: hsl(228, 82%, 35%);
+    --colors-blue1100: hsl(228, 63%, 23%);
+    --colors-blue1200: hsl(227, 57%, 11%);
+    --colors-purple100: hsl(282, 100%, 98%);
+    --colors-purple200: hsl(270, 100%, 95%);
+    --colors-purple300: hsl(271, 100%, 92%);
+    --colors-purple400: hsl(270, 100%, 89%);
+    --colors-purple500: hsl(270, 90%, 81%);
+    --colors-purple600: hsl(271, 97%, 69%);
+    --colors-purple700: hsl(273, 84%, 47%);
+    --colors-purple800: hsl(273, 94%, 48%);
+    --colors-purple900: hsl(268, 79%, 42%);
+    --colors-purple1000: hsl(266, 82%, 32%);
+    --colors-purple1100: hsl(265, 63%, 23%);
+    --colors-purple1200: hsl(265, 61%, 14%);
+    --colors-cyan100: hsl(198, 100%, 97%);
+    --colors-cyan200: hsl(199, 100%, 94%);
+    --colors-cyan300: hsl(201, 100%, 89%);
+    --colors-cyan400: hsl(200, 100%, 84%);
+    --colors-cyan500: hsl(201, 96%, 73%);
+    --colors-cyan600: hsl(202, 85%, 60%);
+    --colors-cyan700: hsl(204, 81%, 46%);
+    --colors-cyan800: hsl(205, 100%, 38%);
+    --colors-cyan900: hsl(206, 100%, 30%);
+    --colors-cyan1000: hsl(205, 100%, 21%);
+    --colors-cyan1100: hsl(206, 97%, 15%);
+    --colors-cyan1200: hsl(207, 73%, 9%);
+    --colors-green100: hsl(135, 80%, 96%);
+    --colors-green200: hsl(135, 72%, 92%);
+    --colors-green300: hsl(135, 68%, 83%);
+    --colors-green400: hsl(135, 65%, 76%);
+    --colors-green500: hsl(136, 56%, 62%);
+    --colors-green600: hsl(137, 42%, 49%);
+    --colors-green700: hsl(138, 51%, 35%);
+    --colors-green800: hsl(138, 68%, 29%);
+    --colors-green900: hsl(138, 74%, 21%);
+    --colors-green1000: hsl(138, 89%, 14%);
+    --colors-green1100: hsl(135, 91%, 9%);
+    --colors-green1200: hsl(123, 56%, 6%);
+    --colors-magenta100: hsl(330, 100%, 99%);
+    --colors-magenta200: hsl(329, 100%, 96%);
+    --colors-magenta300: hsl(332, 100%, 92%);
+    --colors-magenta400: hsl(333, 100%, 90%);
+    --colors-magenta500: hsl(333, 90%, 80%);
+    --colors-magenta600: hsl(333, 87%, 72%);
+    --colors-magenta700: hsl(333, 75%, 59%);
+    --colors-magenta800: hsl(333, 69%, 49%);
+    --colors-magenta900: hsl(333, 74%, 36%);
+    --colors-magenta1000: hsl(333, 86%, 25%);
+    --colors-magenta1100: hsl(333, 95%, 16%);
+    --colors-magenta1200: hsl(334, 62%, 10%);
+    --colors-red100: hsl(0, 100%, 99%);
+    --colors-red200: hsl(0, 100%, 96%);
+    --colors-red300: hsl(357, 100%, 93%);
+    --colors-red400: hsl(356, 100%, 90%);
+    --colors-red500: hsl(356, 96%, 83%);
+    --colors-red600: hsl(357, 90%, 73%);
+    --colors-red700: hsl(357, 80%, 59%);
+    --colors-red800: hsl(357, 76%, 49%);
+    --colors-red900: hsl(357, 73%, 37%);
+    --colors-red1000: hsl(357, 79%, 26%);
+    --colors-red1100: hsl(357, 91%, 17%);
+    --colors-red1200: hsl(357, 73%, 10%);
+    --colors-teal100: hsl(180, 83%, 95%);
+    --colors-teal200: hsl(180, 75%, 88%);
+    --colors-teal300: hsl(180, 71%, 78%);
+    --colors-teal400: hsl(179, 70%, 71%);
+    --colors-teal500: hsl(179, 65%, 52%);
+    --colors-teal600: hsl(179, 76%, 41%);
+    --colors-teal700: hsl(179, 91%, 31%);
+    --colors-teal800: hsl(178, 100%, 25%);
+    --colors-teal900: hsl(180, 100%, 18%);
+    --colors-teal1000: hsl(183, 100%, 13%);
+    --colors-teal1100: hsl(187, 92%, 10%);
+    --colors-teal1200: hsl(186, 56%, 7%);
+    --colors-orange100: hsl(38, 100%, 95%);
+    --colors-orange200: hsl(38, 100%, 90%);
+    --colors-orange300: hsl(37, 100%, 84%);
+    --colors-orange400: hsl(36, 96%, 78%);
+    --colors-orange500: hsl(33, 100%, 67%);
+    --colors-orange600: hsl(31, 97%, 57%);
+    --colors-orange700: hsl(30, 92%, 46%);
+    --colors-orange800: hsl(29, 100%, 43%);
+    --colors-orange900: hsl(27, 100%, 36%);
+    --colors-orange1000: hsl(24, 100%, 26%);
+    --colors-orange1100: hsl(20, 97%, 15%);
+    --colors-orange1200: hsl(20, 96%, 11%);
+    --colors-yellow100: hsl(53, 94%, 93%);
+    --colors-yellow200: hsl(54, 92%, 85%);
+    --colors-yellow300: hsl(54, 92%, 75%);
+    --colors-yellow400: hsl(52, 97%, 63%);
+    --colors-yellow500: hsl(51, 100%, 46%);
+    --colors-yellow600: hsl(49, 100%, 39%);
+    --colors-yellow700: hsl(48, 100%, 35%);
+    --colors-yellow800: hsl(46, 100%, 30%);
+    --colors-yellow900: hsl(44, 100%, 22%);
+    --colors-yellow1000: hsl(44, 100%, 18%);
+    --colors-yellow1100: hsl(41, 100%, 11%);
+    --colors-yellow1200: hsl(39, 100%, 8%);
+    --colors-lime100: hsl(73, 94%, 93%);
+    --colors-lime200: hsl(73, 94%, 87%);
+    --colors-lime300: hsl(73, 90%, 77%);
+    --colors-lime400: hsl(74, 82%, 69%);
+    --colors-lime500: hsl(74, 68%, 58%);
+    --colors-lime600: hsl(74, 77%, 41%);
+    --colors-lime700: hsl(75, 100%, 31%);
+    --colors-lime800: hsl(75, 100%, 27%);
+    --colors-lime900: hsl(75, 100%, 19%);
+    --colors-lime1000: hsl(75, 100%, 15%);
+    --colors-lime1100: hsl(75, 100%, 9%);
+    --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-tonal50: hsl(0, 0%, 96%);
+    --colors-tonal100: hsl(0, 0%, 92%);
+    --colors-tonal200: hsl(0, 0%, 62%);
+    --colors-tonal300: hsl(0, 0%, 46%);
+    --colors-tonal400: hsl(0, 0%, 33%);
+    --colors-tonal500: hsl(0, 0%, 20%);
+    --colors-tonal600: hsl(0, 0%, 12%);
+    --colors-alpha100: hsla(0, 0%, 20%, 0.1);
+    --colors-alpha150: hsla(0, 0%, 20%, 0.15);
+    --colors-alpha200: hsla(0, 0%, 20%, 0.2);
+    --colors-alpha250: hsla(0, 0%, 20%, 0.25);
+    --colors-alpha600: hsla(0, 0%, 20%, 0.6);
+    --colors-primaryLight: hsl(215, 100%, 98%);
+    --colors-primary: hsl(217, 92%, 51%);
+    --colors-primaryMid: hsl(223, 78%, 44%);
+    --colors-primaryDark: hsl(228, 82%, 35%);
+    --colors-secondary: hsl(204, 100%, 72%);
+    --colors-brandRed: hsl(0, 91%, 64%);
+    --colors-brandRedAccent: hsl(14, 100%, 71%);
+    --colors-brandGreen: hsl(128, 47%, 53%);
+    --colors-brandGreenAccent: hsl(168, 100%, 20%);
+    --colors-brandPurple: hsl(256, 65%, 62%);
+    --colors-brandPurpleAccent: hsl(256, 93%, 35%);
+    --colors-brandYellow: hsl(41, 100%, 55%);
+    --colors-brandYellowAccent: hsl(33, 100%, 50%);
+    --colors-successLight: hsl(119, 44%, 94%);
+    --colors-success: hsl(119, 100%, 27%);
+    --colors-successMid: hsl(124, 100%, 22%);
+    --colors-successDark: hsl(126, 100%, 17%);
+    --colors-dangerLight: hsl(0, 77%, 95%);
+    --colors-danger: hsl(0, 96%, 48%);
+    --colors-dangerMid: hsl(0, 96%, 41%);
+    --colors-dangerDark: hsl(0, 97%, 34%);
+    --colors-warningLight: hsl(39, 100%, 94%);
+    --colors-warning: hsl(41, 100%, 55%);
+    --colors-warningMid: hsl(41, 89%, 48%);
+    --colors-warningDark: hsl(41, 100%, 41%);
+    --colors-warningText: hsl(24, 100%, 37%);
+    --colors-subjectEnglish: hsl(0, 91%, 64%);
+    --colors-subjectMaths: hsl(217, 92%, 51%);
+    --colors-subjectScience: hsl(256, 65%, 62%);
+    --colors-subjectVerbalReasoning: hsl(128, 47%, 53%);
+    --colors-subjectNonVerbalReasoning: hsl(41, 100%, 55%);
+    --colors-subjectCreativeWriting: hsl(33, 100%, 50%);
+    --colors-subjectExamSkills: hsl(256, 93%, 35%);
+    --colors-glBlueLight: hsl(222, 68%, 78%);
+    --colors-glBluePrimary: hsl(222, 56%, 55%);
+    --colors-glBlueDark: hsl(222, 35%, 43%);
+    --space-0: 0.125rem;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 2rem;
+    --space-6: 2.5rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-9: 5rem;
+    --space-24: 1.5rem;
+    --fontSizes-xs: 0.75rem;
+    --fontSizes-sm: 0.875rem;
+    --fontSizes-md: 1rem;
+    --fontSizes-lg: 1.3125rem;
+    --fontSizes-xl: 1.75rem;
+    --fontSizes-2xl: 2.3125rem;
+    --fontSizes-3xl: 3.125rem;
+    --fontSizes-4xl: 5.625rem;
+    --fonts-sans: system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-mono: 'SFMono-Regular', Consolas, Menlo, monospace;
+    --fonts-display: 'Space Grotesk', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-body: 'Inter', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --sizes-0: 0.5rem;
+    --sizes-1: 1rem;
+    --sizes-2: 1.5rem;
+    --sizes-3: 2rem;
+    --sizes-4: 2.5rem;
+    --sizes-5: 3rem;
+    --sizes-6: 4rem;
+    --sizes-7: 6rem;
+    --sizes-8: 8rem;
+    --radii-0: 0.25rem;
+    --radii-1: 0.5rem;
+    --radii-2: 0.75rem;
+    --radii-3: 1rem;
+    --radii-round: 100rem;
+    --shadows-0: 0 1px 3px hsla(0, 0%, 20%, 0.1), 0 1px 2px hsla(0, 0%, 20%, 0.15);
+    --shadows-1: 0 3px 6px hsla(0, 0%, 20%, 0.1), 0 3px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-2: 0 10px 20px hsla(0, 0%, 20%, 0.1), 0 6px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-3: 0 14px 28px hsla(0, 0%, 20%, 0.15), 0 10px 10px hsla(0, 0%, 20%, 0.1);
+    --ratios-16-9: 16/9;
+    --ratios-3-2: 3/2;
+    --ratios-4-3: 4/3;
+    --ratios-1-1: 1/1;
+    --ratios-3-4: 3/4;
+  }
+
+  .t-gwhiDE {
+    --colors-text: var(--colors-foreground);
+    --colors-background: var(--colors-base1);
+    --colors-backgroundHover: var(--colors-base2);
+    --colors-backgroundActive: var(--colors-base3);
+    --colors-textSelected: var(--colors-accent9);
+    --colors-backgroundSelected: var(--colors-accent2);
+  }
+}
+
+@media  {
   .c-dhzjXW {
     display: flex;
   }
@@ -229,13 +737,13 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     font-weight: var(--navigation-menu-vertical-item-font-weight);
   }
 
-  .c-jgcFYa {
+  .c-bcEwPX {
     padding: var(--space-2);
     border: none;
     outline: none;
     font: inherit;
-    color: inherit;
-    background: none;
+    color: var(--colors-text);
+    background: var(--colors-background);
     text-align: inherit;
     text-decoration: unset;
     cursor: pointer;
@@ -247,30 +755,30 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     --navigation-menu-vertical-item-font-weight: 400;
   }
 
-  .c-jgcFYa[data-active] {
-    background: var(--colors-accent2);
-    color: var(--colors-accent9);
+  .c-bcEwPX[data-active] {
+    background: var(--colors-backgroundSelected);
+    color: var(--colors-textSelected);
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-jgcFYa[data-state=open] {
+  .c-bcEwPX[data-state=open] {
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-jgcFYa[data-disabled] {
+  .c-bcEwPX[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-jgcFYa:not([data-disabled]):hover {
-    background: var(--colors-base2);
+  .c-bcEwPX:not([data-disabled]):hover {
+    background: var(--colors-backgroundHover);
   }
 
-  .c-jgcFYa:not([data-disabled]):active {
-    background: var(--colors-base3);
+  .c-bcEwPX:not([data-disabled]):active {
+    background: var(--colors-backgroundActive);
   }
 
-  .c-jgcFYa:not([data-disabled]):focus-visible {
+  .c-bcEwPX:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
@@ -349,7 +857,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     display: table;
   }
 
-  .c-jgcFYa-jLELKD-size-lg {
+  .c-bcEwPX-jLELKD-size-lg {
     min-height: var(--sizes-5);
   }
 
@@ -371,7 +879,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
 <div>
   <nav
     aria-label="Main"
-    class="c-fGHEql"
+    class="c-fGHEql t-gwhiDE"
     data-orientation="vertical"
     dir="ltr"
   >
@@ -388,7 +896,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
         >
           <button
             aria-current="page"
-            class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+            class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
             data-active=""
             data-radix-collection-item=""
             type="button"
@@ -408,7 +916,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+            class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
             data-radix-collection-item=""
             href="/somewhere"
           >
@@ -427,7 +935,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+            class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
             data-radix-collection-item=""
             href="http://google.com"
             rel="noopener noreferrer"
@@ -451,7 +959,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           <button
             aria-controls="radix-0"
             aria-expanded="true"
-            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-jgcFYa c-jgcFYa-jLELKD-size-lg"
+            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-bcEwPX c-bcEwPX-jLELKD-size-lg"
             data-radix-collection-item=""
             data-state="open"
             data-testid="accordion-trigger"

--- a/lib/src/components/navigation-menu-vertical/stitches.navigationMenuVertical.colorscheme.config.ts
+++ b/lib/src/components/navigation-menu-vertical/stitches.navigationMenuVertical.colorscheme.config.ts
@@ -1,0 +1,29 @@
+import { createTheme } from '~/stitches'
+
+const light = createTheme({
+  colors: {
+    text: '$foreground',
+    background: '$base1',
+    backgroundHover: '$base2',
+    backgroundActive: '$base3',
+    textSelected: '$accent9',
+    backgroundSelected: '$accent2'
+  }
+})
+
+// @TODO: This should go into the Marketing website instead!
+const dark = createTheme({
+  colors: {
+    text: 'white',
+    background: '$blue1200',
+    backgroundHover: '$blue1100',
+    backgroundActive: '$blue1000',
+    textSelected: 'white',
+    backgroundSelected: '$blue1100'
+  }
+})
+
+export const colorSchemes = {
+  light,
+  dark
+}

--- a/lib/src/components/navigation-menu-vertical/stitches.navigationMenuVertical.colorscheme.config.ts
+++ b/lib/src/components/navigation-menu-vertical/stitches.navigationMenuVertical.colorscheme.config.ts
@@ -11,19 +11,6 @@ const light = createTheme({
   }
 })
 
-// @TODO: This should go into the Marketing website instead!
-const dark = createTheme({
-  colors: {
-    text: 'white',
-    background: '$blue1200',
-    backgroundHover: '$blue1100',
-    backgroundActive: '$blue1000',
-    textSelected: 'white',
-    backgroundSelected: '$blue1100'
-  }
-})
-
 export const colorSchemes = {
-  light,
-  dark
+  light
 }

--- a/lib/src/components/navigation/NavigationMenu.styles.ts
+++ b/lib/src/components/navigation/NavigationMenu.styles.ts
@@ -31,9 +31,9 @@ export const navigationMenuBaseItemStyles = {
 
 export const navigationMenuActiveItemStyles = {
   fontWeight: '600',
-  color: '$activeItemColor',
+  color: '$itemTextSelected',
   '&::after': {
-    backgroundColor: '$activeItemBackgroundColor',
+    backgroundColor: '$itemBackgroundSelected',
     borderRadius: '$1',
     bottom: 0,
     content: '',

--- a/lib/src/components/navigation/NavigationMenu.styles.ts
+++ b/lib/src/components/navigation/NavigationMenu.styles.ts
@@ -1,6 +1,6 @@
 export const navigationMenuDisabledItemStyles = {
   background: 'none',
-  color: '$tonal400',
+  color: '$text',
   opacity: '30%',
   cursor: 'default'
 }
@@ -8,15 +8,19 @@ export const navigationMenuDisabledItemStyles = {
 export const navigationMenuBaseItemStyles = {
   all: 'unset',
   position: 'relative',
-  color: '$tonal400',
+  color: '$text',
   outline: 'none',
   cursor: 'pointer',
   fontFamily: '$body',
   userSelect: 'none',
   padding: '$3',
   borderRadius: '$1',
-  '&:hover': { background: '$tonal50', color: '$tonal600' },
-  '&:active': { background: '$tonal100', color: '$tonal600' },
+  background: '$background',
+  '&:hover': { background: '$backgroundHover', color: '$textHover' },
+  '&:active': {
+    background: '$backgroundActive',
+    color: '$textActive'
+  },
   '&:focus-visible': {
     boxShadow: 'inset 0 0 0 2px $colors$primary'
   },
@@ -27,9 +31,9 @@ export const navigationMenuBaseItemStyles = {
 
 export const navigationMenuActiveItemStyles = {
   fontWeight: '600',
-  color: '$tonal500',
+  color: '$activeItemColor',
   '&::after': {
-    backgroundColor: '$tonal500',
+    backgroundColor: '$activeItemBackgroundColor',
     borderRadius: '$1',
     bottom: 0,
     content: '',

--- a/lib/src/components/navigation/NavigationMenu.tsx
+++ b/lib/src/components/navigation/NavigationMenu.tsx
@@ -14,6 +14,7 @@ import {
 } from './NavigationMenuDropdownItem'
 import { NavigationMenuDropdownTrigger } from './NavigationMenuDropdownTrigger'
 import { NavigationMenuLink } from './NavigationMenuLink'
+import { colorSchemes as navigationMenuColorSchemes } from './stitches.navigationMenu.colorscheme.config'
 
 type NavigationMenuSubComponents = {
   Link: typeof NavigationMenuLink
@@ -108,7 +109,12 @@ export const NavigationMenu: React.FC<NavigationMenuProps> &
 
   return (
     <NavigationMenuContext.Provider value={{ onNodeUpdate }}>
-      <StyledMenu onValueChange={setActiveItem} css={css} {...props}>
+      <StyledMenu
+        className={navigationMenuColorSchemes['light']}
+        onValueChange={setActiveItem}
+        css={css}
+        {...props}
+      >
         <StyledList ref={listRef}>{children}</StyledList>
         <ViewportPosition>
           <StyledViewport

--- a/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
@@ -12,13 +12,15 @@ const StyledList = styled('ul', {
 
 const StyledContent = styled(NavigationMenuPrimitive.Content, {
   p: '$3',
-  bg: 'white',
+  bg: '$navigationDropdown',
   mt: '4px',
   boxShadow: '$1',
   borderRadius: '$1'
 })
 
-type NavigationMenuDropdownContentProps = typeof StyledContent
+type NavigationMenuDropdownContentProps = React.ComponentProps<
+  typeof StyledContent
+>
 
 export const NavigationMenuDropdownContent: React.FC<
   NavigationMenuDropdownContentProps

--- a/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
@@ -12,7 +12,7 @@ const StyledList = styled('ul', {
 
 const StyledContent = styled(NavigationMenuPrimitive.Content, {
   p: '$3',
-  bg: '$navigationDropdownBackground',
+  bg: '$dropdownBackground',
   mt: '4px',
   boxShadow: '$1',
   borderRadius: '$1'

--- a/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
@@ -12,7 +12,7 @@ const StyledList = styled('ul', {
 
 const StyledContent = styled(NavigationMenuPrimitive.Content, {
   p: '$3',
-  bg: '$navigationDropdown',
+  bg: '$navigationDropdownBackground',
   mt: '4px',
   boxShadow: '$1',
   borderRadius: '$1'

--- a/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
@@ -20,7 +20,7 @@ const StyledTrigger = styled(
     borderRadius: '$1',
     justifyContent: 'space-between',
     '&[data-state="open"]': {
-      background: '$tonal100'
+      background: '$triggerOpenBackground'
     },
     variants: {
       active: { true: { ...navigationMenuActiveItemStyles } }

--- a/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
@@ -20,7 +20,7 @@ const StyledTrigger = styled(
     borderRadius: '$1',
     justifyContent: 'space-between',
     '&[data-state="open"]': {
-      background: '$triggerOpenBackground'
+      background: '$triggerBackgroundOpen'
     },
     variants: {
       active: { true: { ...navigationMenuActiveItemStyles } }

--- a/lib/src/components/navigation/NavigationMenuLink.tsx
+++ b/lib/src/components/navigation/NavigationMenuLink.tsx
@@ -28,19 +28,19 @@ const StyledLink = styled(
       elementType: {
         dropdownItem: {
           '&[data-active]': {
-            background: '$backgroundDataActive',
-            color: '$dataActiveText',
+            background: '$backgroundSelected',
+            color: '$textSelected',
             '&:hover': {
-              background: '$dataActiveBackgroundHover',
-              color: '$dataActiveTextHover'
+              background: '$backgroundSelectedHover',
+              color: '$textSelectedHover'
             },
             '&:active': {
-              background: '$dataActiveBackground',
-              color: '$dataActivePressedText'
+              background: '$backgroundSelectedPressed',
+              color: '$textSelectedPressed'
             },
             '&:focus-visible': {
               boxShadow: '0 0 0 2px $colors$primary',
-              color: '$dataActiveFocus'
+              color: '$textSelectedFocus'
             }
           }
         },

--- a/lib/src/components/navigation/NavigationMenuLink.tsx
+++ b/lib/src/components/navigation/NavigationMenuLink.tsx
@@ -28,13 +28,19 @@ const StyledLink = styled(
       elementType: {
         dropdownItem: {
           '&[data-active]': {
-            background: '$primaryLight',
-            color: '$primary',
-            '*': { color: '$primary' },
-            '&:hover': { background: '$tonal50' },
-            '&:active': { background: '$tonal100' },
+            background: '$backgroundDataActive',
+            color: '$dataActiveText',
+            '&:hover': {
+              background: '$dataActiveBackgroundHover',
+              color: '$dataActiveTextHover'
+            },
+            '&:active': {
+              background: '$dataActiveBackground',
+              color: '$dataActivePressedText'
+            },
             '&:focus-visible': {
-              boxShadow: '0 0 0 2px $colors$primary'
+              boxShadow: '0 0 0 2px $colors$primary',
+              color: '$dataActiveFocus'
             }
           }
         },

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -2,10 +2,275 @@
 
 exports[`Nav component renders 1`] = `
 @media  {
-  .c-dIYQCX {
+  :root,
+  .t-kAUxbu {
+    --default-colors: [object Object];
+    --default-space: [object Object];
+    --default-fontSizes: [object Object];
+    --default-fonts: [object Object];
+    --default-sizes: [object Object];
+    --default-radii: [object Object];
+    --default-shadows: [object Object];
+    --default-ratios: [object Object];
+    --colors-textForeground: hsl(0, 0%, 12%);
+    --colors-textSubtle: hsl(0, 0%, 33%);
+    --colors-textPlaceholder: hsl(0, 0%, 46%);
+    --colors-background: hsl(0, 0%, 96%);
+    --colors-backgroundAccent: hsl(215, 100%, 98%);
+    --colors-grey100: hsl(0, 0%, 96%);
+    --colors-grey200: hsl(0, 0%, 92%);
+    --colors-grey300: hsl(0, 0%, 88%);
+    --colors-grey400: hsl(0, 0%, 81%);
+    --colors-grey500: hsl(0, 0%, 73%);
+    --colors-grey600: hsl(0, 0%, 62%);
+    --colors-grey700: hsl(0, 0%, 46%);
+    --colors-grey800: hsl(0, 0%, 33%);
+    --colors-grey900: hsl(0, 0%, 20%);
+    --colors-grey1000: hsl(0, 0%, 12%);
+    --colors-grey1100: hsl(0, 0%, 10%);
+    --colors-grey1200: hsl(0, 0%, 6%);
+    --colors-blue100: hsl(215, 100%, 98%);
+    --colors-blue200: hsl(212, 100%, 95%);
+    --colors-blue300: hsl(211, 100%, 92%);
+    --colors-blue400: hsl(211, 100%, 88%);
+    --colors-blue500: hsl(212, 100%, 80%);
+    --colors-blue600: hsl(213, 100%, 71%);
+    --colors-blue700: hsl(214, 100%, 58%);
+    --colors-blue800: hsl(217, 92%, 51%);
+    --colors-blue900: hsl(223, 78%, 44%);
+    --colors-blue1000: hsl(228, 82%, 35%);
+    --colors-blue1100: hsl(228, 63%, 23%);
+    --colors-blue1200: hsl(227, 57%, 11%);
+    --colors-purple100: hsl(282, 100%, 98%);
+    --colors-purple200: hsl(270, 100%, 95%);
+    --colors-purple300: hsl(271, 100%, 92%);
+    --colors-purple400: hsl(270, 100%, 89%);
+    --colors-purple500: hsl(270, 90%, 81%);
+    --colors-purple600: hsl(271, 97%, 69%);
+    --colors-purple700: hsl(273, 84%, 47%);
+    --colors-purple800: hsl(273, 94%, 48%);
+    --colors-purple900: hsl(268, 79%, 42%);
+    --colors-purple1000: hsl(266, 82%, 32%);
+    --colors-purple1100: hsl(265, 63%, 23%);
+    --colors-purple1200: hsl(265, 61%, 14%);
+    --colors-cyan100: hsl(198, 100%, 97%);
+    --colors-cyan200: hsl(199, 100%, 94%);
+    --colors-cyan300: hsl(201, 100%, 89%);
+    --colors-cyan400: hsl(200, 100%, 84%);
+    --colors-cyan500: hsl(201, 96%, 73%);
+    --colors-cyan600: hsl(202, 85%, 60%);
+    --colors-cyan700: hsl(204, 81%, 46%);
+    --colors-cyan800: hsl(205, 100%, 38%);
+    --colors-cyan900: hsl(206, 100%, 30%);
+    --colors-cyan1000: hsl(205, 100%, 21%);
+    --colors-cyan1100: hsl(206, 97%, 15%);
+    --colors-cyan1200: hsl(207, 73%, 9%);
+    --colors-green100: hsl(135, 80%, 96%);
+    --colors-green200: hsl(135, 72%, 92%);
+    --colors-green300: hsl(135, 68%, 83%);
+    --colors-green400: hsl(135, 65%, 76%);
+    --colors-green500: hsl(136, 56%, 62%);
+    --colors-green600: hsl(137, 42%, 49%);
+    --colors-green700: hsl(138, 51%, 35%);
+    --colors-green800: hsl(138, 68%, 29%);
+    --colors-green900: hsl(138, 74%, 21%);
+    --colors-green1000: hsl(138, 89%, 14%);
+    --colors-green1100: hsl(135, 91%, 9%);
+    --colors-green1200: hsl(123, 56%, 6%);
+    --colors-magenta100: hsl(330, 100%, 99%);
+    --colors-magenta200: hsl(329, 100%, 96%);
+    --colors-magenta300: hsl(332, 100%, 92%);
+    --colors-magenta400: hsl(333, 100%, 90%);
+    --colors-magenta500: hsl(333, 90%, 80%);
+    --colors-magenta600: hsl(333, 87%, 72%);
+    --colors-magenta700: hsl(333, 75%, 59%);
+    --colors-magenta800: hsl(333, 69%, 49%);
+    --colors-magenta900: hsl(333, 74%, 36%);
+    --colors-magenta1000: hsl(333, 86%, 25%);
+    --colors-magenta1100: hsl(333, 95%, 16%);
+    --colors-magenta1200: hsl(334, 62%, 10%);
+    --colors-red100: hsl(0, 100%, 99%);
+    --colors-red200: hsl(0, 100%, 96%);
+    --colors-red300: hsl(357, 100%, 93%);
+    --colors-red400: hsl(356, 100%, 90%);
+    --colors-red500: hsl(356, 96%, 83%);
+    --colors-red600: hsl(357, 90%, 73%);
+    --colors-red700: hsl(357, 80%, 59%);
+    --colors-red800: hsl(357, 76%, 49%);
+    --colors-red900: hsl(357, 73%, 37%);
+    --colors-red1000: hsl(357, 79%, 26%);
+    --colors-red1100: hsl(357, 91%, 17%);
+    --colors-red1200: hsl(357, 73%, 10%);
+    --colors-teal100: hsl(180, 83%, 95%);
+    --colors-teal200: hsl(180, 75%, 88%);
+    --colors-teal300: hsl(180, 71%, 78%);
+    --colors-teal400: hsl(179, 70%, 71%);
+    --colors-teal500: hsl(179, 65%, 52%);
+    --colors-teal600: hsl(179, 76%, 41%);
+    --colors-teal700: hsl(179, 91%, 31%);
+    --colors-teal800: hsl(178, 100%, 25%);
+    --colors-teal900: hsl(180, 100%, 18%);
+    --colors-teal1000: hsl(183, 100%, 13%);
+    --colors-teal1100: hsl(187, 92%, 10%);
+    --colors-teal1200: hsl(186, 56%, 7%);
+    --colors-orange100: hsl(38, 100%, 95%);
+    --colors-orange200: hsl(38, 100%, 90%);
+    --colors-orange300: hsl(37, 100%, 84%);
+    --colors-orange400: hsl(36, 96%, 78%);
+    --colors-orange500: hsl(33, 100%, 67%);
+    --colors-orange600: hsl(31, 97%, 57%);
+    --colors-orange700: hsl(30, 92%, 46%);
+    --colors-orange800: hsl(29, 100%, 43%);
+    --colors-orange900: hsl(27, 100%, 36%);
+    --colors-orange1000: hsl(24, 100%, 26%);
+    --colors-orange1100: hsl(20, 97%, 15%);
+    --colors-orange1200: hsl(20, 96%, 11%);
+    --colors-yellow100: hsl(53, 94%, 93%);
+    --colors-yellow200: hsl(54, 92%, 85%);
+    --colors-yellow300: hsl(54, 92%, 75%);
+    --colors-yellow400: hsl(52, 97%, 63%);
+    --colors-yellow500: hsl(51, 100%, 46%);
+    --colors-yellow600: hsl(49, 100%, 39%);
+    --colors-yellow700: hsl(48, 100%, 35%);
+    --colors-yellow800: hsl(46, 100%, 30%);
+    --colors-yellow900: hsl(44, 100%, 22%);
+    --colors-yellow1000: hsl(44, 100%, 18%);
+    --colors-yellow1100: hsl(41, 100%, 11%);
+    --colors-yellow1200: hsl(39, 100%, 8%);
+    --colors-lime100: hsl(73, 94%, 93%);
+    --colors-lime200: hsl(73, 94%, 87%);
+    --colors-lime300: hsl(73, 90%, 77%);
+    --colors-lime400: hsl(74, 82%, 69%);
+    --colors-lime500: hsl(74, 68%, 58%);
+    --colors-lime600: hsl(74, 77%, 41%);
+    --colors-lime700: hsl(75, 100%, 31%);
+    --colors-lime800: hsl(75, 100%, 27%);
+    --colors-lime900: hsl(75, 100%, 19%);
+    --colors-lime1000: hsl(75, 100%, 15%);
+    --colors-lime1100: hsl(75, 100%, 9%);
+    --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-tonal50: hsl(0, 0%, 96%);
+    --colors-tonal100: hsl(0, 0%, 92%);
+    --colors-tonal200: hsl(0, 0%, 62%);
+    --colors-tonal300: hsl(0, 0%, 46%);
+    --colors-tonal400: hsl(0, 0%, 33%);
+    --colors-tonal500: hsl(0, 0%, 20%);
+    --colors-tonal600: hsl(0, 0%, 12%);
+    --colors-alpha100: hsla(0, 0%, 20%, 0.1);
+    --colors-alpha150: hsla(0, 0%, 20%, 0.15);
+    --colors-alpha200: hsla(0, 0%, 20%, 0.2);
+    --colors-alpha250: hsla(0, 0%, 20%, 0.25);
+    --colors-alpha600: hsla(0, 0%, 20%, 0.6);
+    --colors-primaryLight: hsl(215, 100%, 98%);
+    --colors-primary: hsl(217, 92%, 51%);
+    --colors-primaryMid: hsl(223, 78%, 44%);
+    --colors-primaryDark: hsl(228, 82%, 35%);
+    --colors-secondary: hsl(204, 100%, 72%);
+    --colors-brandRed: hsl(0, 91%, 64%);
+    --colors-brandRedAccent: hsl(14, 100%, 71%);
+    --colors-brandGreen: hsl(128, 47%, 53%);
+    --colors-brandGreenAccent: hsl(168, 100%, 20%);
+    --colors-brandPurple: hsl(256, 65%, 62%);
+    --colors-brandPurpleAccent: hsl(256, 93%, 35%);
+    --colors-brandYellow: hsl(41, 100%, 55%);
+    --colors-brandYellowAccent: hsl(33, 100%, 50%);
+    --colors-successLight: hsl(119, 44%, 94%);
+    --colors-success: hsl(119, 100%, 27%);
+    --colors-successMid: hsl(124, 100%, 22%);
+    --colors-successDark: hsl(126, 100%, 17%);
+    --colors-dangerLight: hsl(0, 77%, 95%);
+    --colors-danger: hsl(0, 96%, 48%);
+    --colors-dangerMid: hsl(0, 96%, 41%);
+    --colors-dangerDark: hsl(0, 97%, 34%);
+    --colors-warningLight: hsl(39, 100%, 94%);
+    --colors-warning: hsl(41, 100%, 55%);
+    --colors-warningMid: hsl(41, 89%, 48%);
+    --colors-warningDark: hsl(41, 100%, 41%);
+    --colors-warningText: hsl(24, 100%, 37%);
+    --colors-subjectEnglish: hsl(0, 91%, 64%);
+    --colors-subjectMaths: hsl(217, 92%, 51%);
+    --colors-subjectScience: hsl(256, 65%, 62%);
+    --colors-subjectVerbalReasoning: hsl(128, 47%, 53%);
+    --colors-subjectNonVerbalReasoning: hsl(41, 100%, 55%);
+    --colors-subjectCreativeWriting: hsl(33, 100%, 50%);
+    --colors-subjectExamSkills: hsl(256, 93%, 35%);
+    --colors-glBlueLight: hsl(222, 68%, 78%);
+    --colors-glBluePrimary: hsl(222, 56%, 55%);
+    --colors-glBlueDark: hsl(222, 35%, 43%);
+    --space-0: 0.125rem;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 2rem;
+    --space-6: 2.5rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-9: 5rem;
+    --space-24: 1.5rem;
+    --fontSizes-xs: 0.75rem;
+    --fontSizes-sm: 0.875rem;
+    --fontSizes-md: 1rem;
+    --fontSizes-lg: 1.3125rem;
+    --fontSizes-xl: 1.75rem;
+    --fontSizes-2xl: 2.3125rem;
+    --fontSizes-3xl: 3.125rem;
+    --fontSizes-4xl: 5.625rem;
+    --fonts-sans: system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-mono: 'SFMono-Regular', Consolas, Menlo, monospace;
+    --fonts-display: 'Space Grotesk', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-body: 'Inter', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --sizes-0: 0.5rem;
+    --sizes-1: 1rem;
+    --sizes-2: 1.5rem;
+    --sizes-3: 2rem;
+    --sizes-4: 2.5rem;
+    --sizes-5: 3rem;
+    --sizes-6: 4rem;
+    --sizes-7: 6rem;
+    --sizes-8: 8rem;
+    --radii-0: 0.25rem;
+    --radii-1: 0.5rem;
+    --radii-2: 0.75rem;
+    --radii-3: 1rem;
+    --radii-round: 100rem;
+    --shadows-0: 0 1px 3px hsla(0, 0%, 20%, 0.1), 0 1px 2px hsla(0, 0%, 20%, 0.15);
+    --shadows-1: 0 3px 6px hsla(0, 0%, 20%, 0.1), 0 3px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-2: 0 10px 20px hsla(0, 0%, 20%, 0.1), 0 6px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-3: 0 14px 28px hsla(0, 0%, 20%, 0.15), 0 10px 10px hsla(0, 0%, 20%, 0.1);
+    --ratios-16-9: 16/9;
+    --ratios-3-2: 3/2;
+    --ratios-4-3: 4/3;
+    --ratios-1-1: 1/1;
+    --ratios-3-4: 3/4;
+  }
+
+  .t-iIBSzF {
+    --colors-text: var(--colors-tonal400);
+    --colors-background: white;
+    --colors-backgroundHover: var(--colors-tonal50);
+    --colors-textHover: var(--colors-tonal600);
+    --colors-backgroundActive: var(--colors-tonal100);
+    --colors-textActive: var(--colors-tonal600);
+    --colors-backgroundDataActive: var(--colors-primaryLight);
+    --colors-dataActiveText: var(--colors-primary);
+    --colors-dataActiveTextHover: var(--colors-primary);
+    --colors-dataActivePressedText: var(--colors-primary);
+    --colors-dataActiveFocus: var(--colors-primary);
+    --colors-dataActiveBackgroundHover: var(--colors-tonal50);
+    --colors-dataActiveBackground: var(--colors-tonal100);
+    --colors-activeItemColor: var(--colors-tonal500);
+    --colors-activeItemBackgroundColor: var(--colors-tonal500);
+    --colors-triggerOpenBackground: var(--colors-tonal100);
+    --colors-navigationDropdown: white;
+  }
+}
+
+@media  {
+  .c-gvhYwV {
     all: unset;
     position: relative;
-    color: var(--colors-tonal400);
+    color: var(--colors-text);
     outline: none;
     cursor: pointer;
     font-family: var(--fonts-body);
@@ -13,25 +278,26 @@ exports[`Nav component renders 1`] = `
     user-select: none;
     padding: var(--space-3);
     border-radius: var(--radii-1);
+    background: var(--colors-background);
   }
 
-  .c-dIYQCX:hover {
-    background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+  .c-gvhYwV:hover {
+    background: var(--colors-backgroundHover);
+    color: var(--colors-textHover);
   }
 
-  .c-dIYQCX:active {
-    background: var(--colors-tonal100);
-    color: var(--colors-tonal600);
+  .c-gvhYwV:active {
+    background: var(--colors-backgroundActive);
+    color: var(--colors-textActive);
   }
 
-  .c-dIYQCX:focus-visible {
+  .c-gvhYwV:focus-visible {
     box-shadow: inset 0 0 0 2px var(--colors-primary);
   }
 
-  .c-dIYQCX:disabled {
+  .c-gvhYwV:disabled {
     background: none;
-    color: var(--colors-tonal400);
+    color: var(--colors-text);
     opacity: 30%;
     cursor: default;
   }
@@ -51,20 +317,20 @@ exports[`Nav component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-DeiGT {
+  .c-efUzPc {
     display: flex;
     align-items: center;
     border-radius: var(--radii-1);
     justify-content: space-between;
   }
 
-  .c-DeiGT[data-state="open"] {
-    background: var(--colors-tonal100);
+  .c-efUzPc[data-state="open"] {
+    background: var(--colors-triggerOpenBackground);
   }
 
-  .c-jYBZds {
+  .c-WZtCm {
     padding: var(--space-3);
-    background: white;
+    background: var(--colors-navigationDropdown);
     margin-top: 4px;
     box-shadow: var(--shadows-1);
     border-radius: var(--radii-1);
@@ -124,10 +390,10 @@ exports[`Nav component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-iXImxE {
+  .c-kYWBdY {
     all: unset;
     position: relative;
-    color: var(--colors-tonal400);
+    color: var(--colors-text);
     outline: none;
     cursor: default;
     font-family: var(--fonts-body);
@@ -135,43 +401,43 @@ exports[`Nav component renders 1`] = `
     user-select: none;
     padding: var(--space-3);
     border-radius: var(--radii-1);
+    background: none;
   }
 
-  .c-iXImxE:hover {
-    background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+  .c-kYWBdY:hover {
+    background: var(--colors-backgroundHover);
+    color: var(--colors-textHover);
   }
 
-  .c-iXImxE:active {
-    background: var(--colors-tonal100);
-    color: var(--colors-tonal600);
+  .c-kYWBdY:active {
+    background: var(--colors-backgroundActive);
+    color: var(--colors-textActive);
   }
 
-  .c-iXImxE:focus-visible {
+  .c-kYWBdY:focus-visible {
     box-shadow: inset 0 0 0 2px var(--colors-primary);
   }
 
-  .c-iXImxE:disabled {
+  .c-kYWBdY:disabled {
     background: none;
-    color: var(--colors-tonal400);
+    color: var(--colors-text);
     opacity: 30%;
     cursor: default;
   }
 
-  .c-iXImxE {
-    background: none;
+  .c-kYWBdY {
     opacity: 30%;
   }
 }
 
 @media  {
-  .c-govTNd-icyDJD-elementType-link[data-active] {
+  .c-govTNd-cVGRl-elementType-link[data-active] {
     font-weight: 600;
-    color: var(--colors-tonal500);
+    color: var(--colors-activeItemColor);
   }
 
-  .c-govTNd-icyDJD-elementType-link[data-active]::after {
-    background-color: var(--colors-tonal500);
+  .c-govTNd-cVGRl-elementType-link[data-active]::after {
+    background-color: var(--colors-activeItemBackgroundColor);
     border-radius: var(--radii-1);
     bottom: 0;
     content: "";
@@ -206,25 +472,24 @@ exports[`Nav component renders 1`] = `
     display: table;
   }
 
-  .c-govTNd-gkgtJA-elementType-dropdownItem[data-active] {
-    background: var(--colors-primaryLight);
-    color: var(--colors-primary);
+  .c-govTNd-lLlCt-elementType-dropdownItem[data-active] {
+    background: var(--colors-backgroundDataActive);
+    color: var(--colors-dataActiveText);
   }
 
-  .c-govTNd-gkgtJA-elementType-dropdownItem[data-active] * {
-    color: var(--colors-primary);
+  .c-govTNd-lLlCt-elementType-dropdownItem[data-active]:hover {
+    background: var(--colors-dataActiveBackgroundHover);
+    color: var(--colors-dataActiveTextHover);
   }
 
-  .c-govTNd-gkgtJA-elementType-dropdownItem[data-active]:hover {
-    background: var(--colors-tonal50);
+  .c-govTNd-lLlCt-elementType-dropdownItem[data-active]:active {
+    background: var(--colors-dataActiveBackground);
+    color: var(--colors-dataActivePressedText);
   }
 
-  .c-govTNd-gkgtJA-elementType-dropdownItem[data-active]:active {
-    background: var(--colors-tonal100);
-  }
-
-  .c-govTNd-gkgtJA-elementType-dropdownItem[data-active]:focus-visible {
+  .c-govTNd-lLlCt-elementType-dropdownItem[data-active]:focus-visible {
     box-shadow: 0 0 0 2px var(--colors-primary);
+    color: var(--colors-dataActiveFocus);
   }
 }
 
@@ -263,7 +528,7 @@ exports[`Nav component renders 1`] = `
 <body>
   <nav
     aria-label="Main"
-    class="c-eZxssT"
+    class="c-eZxssT t-iIBSzF"
     data-orientation="horizontal"
     dir="ltr"
   >
@@ -279,7 +544,7 @@ exports[`Nav component renders 1`] = `
           class="PJLV"
         >
           <a
-            class="c-dIYQCX c-govTNd c-govTNd-icyDJD-elementType-link"
+            class="c-gvhYwV c-govTNd c-govTNd-cVGRl-elementType-link"
             data-radix-collection-item=""
             href="/introduction"
           >
@@ -290,7 +555,7 @@ exports[`Nav component renders 1`] = `
           <button
             aria-controls="radix-2-content-1"
             aria-expanded="true"
-            class="c-dIYQCX c-DeiGT"
+            class="c-gvhYwV c-efUzPc"
             data-radix-collection-item=""
             data-state="open"
             id="radix-2-trigger-1"
@@ -328,7 +593,7 @@ exports[`Nav component renders 1`] = `
       >
         <div
           aria-labelledby="radix-2-trigger-1"
-          class="c-jYBZds"
+          class="c-WZtCm"
           data-orientation="horizontal"
           dir="ltr"
           id="radix-2-content-1"
@@ -340,7 +605,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <a
-                class="c-dIYQCX c-govTNd c-govTNd-gkgtJA-elementType-dropdownItem"
+                class="c-gvhYwV c-govTNd c-govTNd-lLlCt-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/colours"
                 rel="noopener noreferrer"
@@ -366,7 +631,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <a
-                class="c-dIYQCX c-govTNd c-govTNd-gkgtJA-elementType-dropdownItem"
+                class="c-gvhYwV c-govTNd c-govTNd-lLlCt-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/effects"
                 rel="noopener noreferrer"
@@ -379,7 +644,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <a
-                class="c-dIYQCX c-govTNd c-govTNd-gkgtJA-elementType-dropdownItem"
+                class="c-gvhYwV c-govTNd c-govTNd-lLlCt-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/icons"
                 rel="noopener noreferrer"
@@ -392,7 +657,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <button
-                class="c-iXImxE"
+                class="c-kYWBdY"
                 disabled=""
               >
                 Icons

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -245,24 +245,24 @@ exports[`Nav component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .t-iIBSzF {
-    --colors-text: var(--colors-tonal400);
+  .t-cXoNrd {
+    --colors-text: var(--colors-textSubtle);
     --colors-background: white;
-    --colors-backgroundHover: var(--colors-tonal50);
-    --colors-textHover: var(--colors-tonal600);
-    --colors-backgroundActive: var(--colors-tonal100);
-    --colors-textActive: var(--colors-tonal600);
-    --colors-backgroundDataActive: var(--colors-primaryLight);
-    --colors-dataActiveText: var(--colors-primary);
-    --colors-dataActiveTextHover: var(--colors-primary);
-    --colors-dataActivePressedText: var(--colors-primary);
-    --colors-dataActiveFocus: var(--colors-primary);
-    --colors-dataActiveBackgroundHover: var(--colors-tonal50);
-    --colors-dataActiveBackground: var(--colors-tonal100);
-    --colors-activeItemColor: var(--colors-tonal500);
-    --colors-activeItemBackgroundColor: var(--colors-tonal500);
-    --colors-triggerOpenBackground: var(--colors-tonal100);
-    --colors-navigationDropdown: white;
+    --colors-backgroundHover: var(--colors-grey100);
+    --colors-textHover: var(--colors-textForeground);
+    --colors-backgroundActive: var(--colors-grey200);
+    --colors-textActive: var(--colors-grey1000);
+    --colors-backgroundSelected: var(--colors-blue100);
+    --colors-textSelected: var(--colors-blue800);
+    --colors-textSelectedHover: var(--colors-blue800);
+    --colors-textSelectedPressed: var(--colors-blue800);
+    --colors-textSelectedFocus: var(--colors-blue800);
+    --colors-backgroundSelectedHover: var(--colors-grey100);
+    --colors-backgroundSelectedPressed: var(--colors-grey200);
+    --colors-itemTextSelected: var(--colors-grey900);
+    --colors-itemBackgroundSelected: var(--colors-grey900);
+    --colors-triggerOpenBackground: var(--colors-grey200);
+    --colors-navigationDropdownBackground: white;
   }
 }
 
@@ -328,9 +328,9 @@ exports[`Nav component renders 1`] = `
     background: var(--colors-triggerOpenBackground);
   }
 
-  .c-WZtCm {
+  .c-icuOvE {
     padding: var(--space-3);
-    background: var(--colors-navigationDropdown);
+    background: var(--colors-navigationDropdownBackground);
     margin-top: 4px;
     box-shadow: var(--shadows-1);
     border-radius: var(--radii-1);
@@ -431,13 +431,13 @@ exports[`Nav component renders 1`] = `
 }
 
 @media  {
-  .c-govTNd-cVGRl-elementType-link[data-active] {
+  .c-govTNd-dvXUYs-elementType-link[data-active] {
     font-weight: 600;
-    color: var(--colors-activeItemColor);
+    color: var(--colors-itemTextSelected);
   }
 
-  .c-govTNd-cVGRl-elementType-link[data-active]::after {
-    background-color: var(--colors-activeItemBackgroundColor);
+  .c-govTNd-dvXUYs-elementType-link[data-active]::after {
+    background-color: var(--colors-itemBackgroundSelected);
     border-radius: var(--radii-1);
     bottom: 0;
     content: "";
@@ -472,24 +472,24 @@ exports[`Nav component renders 1`] = `
     display: table;
   }
 
-  .c-govTNd-lLlCt-elementType-dropdownItem[data-active] {
-    background: var(--colors-backgroundDataActive);
-    color: var(--colors-dataActiveText);
+  .c-govTNd-vbUZb-elementType-dropdownItem[data-active] {
+    background: var(--colors-backgroundSelected);
+    color: var(--colors-textSelected);
   }
 
-  .c-govTNd-lLlCt-elementType-dropdownItem[data-active]:hover {
-    background: var(--colors-dataActiveBackgroundHover);
-    color: var(--colors-dataActiveTextHover);
+  .c-govTNd-vbUZb-elementType-dropdownItem[data-active]:hover {
+    background: var(--colors-backgroundSelectedHover);
+    color: var(--colors-textSelectedHover);
   }
 
-  .c-govTNd-lLlCt-elementType-dropdownItem[data-active]:active {
-    background: var(--colors-dataActiveBackground);
-    color: var(--colors-dataActivePressedText);
+  .c-govTNd-vbUZb-elementType-dropdownItem[data-active]:active {
+    background: var(--colors-backgroundSelectedPressed);
+    color: var(--colors-textSelectedPressed);
   }
 
-  .c-govTNd-lLlCt-elementType-dropdownItem[data-active]:focus-visible {
+  .c-govTNd-vbUZb-elementType-dropdownItem[data-active]:focus-visible {
     box-shadow: 0 0 0 2px var(--colors-primary);
-    color: var(--colors-dataActiveFocus);
+    color: var(--colors-textSelectedFocus);
   }
 }
 
@@ -528,7 +528,7 @@ exports[`Nav component renders 1`] = `
 <body>
   <nav
     aria-label="Main"
-    class="c-eZxssT t-iIBSzF"
+    class="c-eZxssT t-cXoNrd"
     data-orientation="horizontal"
     dir="ltr"
   >
@@ -544,7 +544,7 @@ exports[`Nav component renders 1`] = `
           class="PJLV"
         >
           <a
-            class="c-gvhYwV c-govTNd c-govTNd-cVGRl-elementType-link"
+            class="c-gvhYwV c-govTNd c-govTNd-dvXUYs-elementType-link"
             data-radix-collection-item=""
             href="/introduction"
           >
@@ -593,7 +593,7 @@ exports[`Nav component renders 1`] = `
       >
         <div
           aria-labelledby="radix-2-trigger-1"
-          class="c-WZtCm"
+          class="c-icuOvE"
           data-orientation="horizontal"
           dir="ltr"
           id="radix-2-content-1"
@@ -605,7 +605,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <a
-                class="c-gvhYwV c-govTNd c-govTNd-lLlCt-elementType-dropdownItem"
+                class="c-gvhYwV c-govTNd c-govTNd-vbUZb-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/colours"
                 rel="noopener noreferrer"
@@ -631,7 +631,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <a
-                class="c-gvhYwV c-govTNd c-govTNd-lLlCt-elementType-dropdownItem"
+                class="c-gvhYwV c-govTNd c-govTNd-vbUZb-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/effects"
                 rel="noopener noreferrer"
@@ -644,7 +644,7 @@ exports[`Nav component renders 1`] = `
               class="PJLV"
             >
               <a
-                class="c-gvhYwV c-govTNd c-govTNd-lLlCt-elementType-dropdownItem"
+                class="c-gvhYwV c-govTNd c-govTNd-vbUZb-elementType-dropdownItem"
                 data-radix-collection-item=""
                 href="https://app.atomlearning.co.uk/icons"
                 rel="noopener noreferrer"

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`Nav component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .t-cXoNrd {
+  .t-eWhWlr {
     --colors-text: var(--colors-textSubtle);
     --colors-background: white;
     --colors-backgroundHover: var(--colors-grey100);
@@ -261,8 +261,8 @@ exports[`Nav component renders 1`] = `
     --colors-backgroundSelectedPressed: var(--colors-grey200);
     --colors-itemTextSelected: var(--colors-grey900);
     --colors-itemBackgroundSelected: var(--colors-grey900);
-    --colors-triggerOpenBackground: var(--colors-grey200);
-    --colors-navigationDropdownBackground: white;
+    --colors-triggerBackgroundOpen: var(--colors-grey200);
+    --colors-dropdownBackground: white;
   }
 }
 
@@ -317,20 +317,20 @@ exports[`Nav component renders 1`] = `
     vertical-align: middle;
   }
 
-  .c-efUzPc {
+  .c-lfFbYU {
     display: flex;
     align-items: center;
     border-radius: var(--radii-1);
     justify-content: space-between;
   }
 
-  .c-efUzPc[data-state="open"] {
-    background: var(--colors-triggerOpenBackground);
+  .c-lfFbYU[data-state="open"] {
+    background: var(--colors-triggerBackgroundOpen);
   }
 
-  .c-icuOvE {
+  .c-dblJlC {
     padding: var(--space-3);
-    background: var(--colors-navigationDropdownBackground);
+    background: var(--colors-dropdownBackground);
     margin-top: 4px;
     box-shadow: var(--shadows-1);
     border-radius: var(--radii-1);
@@ -528,7 +528,7 @@ exports[`Nav component renders 1`] = `
 <body>
   <nav
     aria-label="Main"
-    class="c-eZxssT t-cXoNrd"
+    class="c-eZxssT t-eWhWlr"
     data-orientation="horizontal"
     dir="ltr"
   >
@@ -555,7 +555,7 @@ exports[`Nav component renders 1`] = `
           <button
             aria-controls="radix-2-content-1"
             aria-expanded="true"
-            class="c-gvhYwV c-efUzPc"
+            class="c-gvhYwV c-lfFbYU"
             data-radix-collection-item=""
             data-state="open"
             id="radix-2-trigger-1"
@@ -593,7 +593,7 @@ exports[`Nav component renders 1`] = `
       >
         <div
           aria-labelledby="radix-2-trigger-1"
-          class="c-icuOvE"
+          class="c-dblJlC"
           data-orientation="horizontal"
           dir="ltr"
           id="radix-2-content-1"

--- a/lib/src/components/navigation/stitches.navigationMenu.colorscheme.config.ts
+++ b/lib/src/components/navigation/stitches.navigationMenu.colorscheme.config.ts
@@ -2,23 +2,23 @@ import { createTheme } from '~/stitches'
 
 const light = createTheme({
   colors: {
-    text: '$tonal400',
+    text: '$textSubtle',
     background: 'white',
-    backgroundHover: '$tonal50',
-    textHover: '$tonal600',
-    backgroundActive: '$tonal100',
-    textActive: '$tonal600',
-    backgroundDataActive: '$primaryLight',
-    dataActiveText: '$primary',
-    dataActiveTextHover: '$primary',
-    dataActivePressedText: '$primary',
-    dataActiveFocus: '$primary',
-    dataActiveBackgroundHover: '$tonal50',
-    dataActiveBackground: '$tonal100',
-    activeItemColor: '$tonal500',
-    activeItemBackgroundColor: '$tonal500',
-    triggerOpenBackground: '$tonal100',
-    navigationDropdown: 'white'
+    backgroundHover: '$grey100',
+    textHover: '$textForeground',
+    backgroundActive: '$grey200',
+    textActive: '$grey1000',
+    backgroundSelected: '$blue100',
+    textSelected: '$blue800',
+    textSelectedHover: '$blue800',
+    textSelectedPressed: '$blue800',
+    textSelectedFocus: '$blue800',
+    backgroundSelectedHover: '$grey100',
+    backgroundSelectedPressed: '$grey200',
+    itemTextSelected: '$grey900',
+    itemBackgroundSelected: '$grey900',
+    triggerOpenBackground: '$grey200',
+    navigationDropdownBackground: 'white'
   }
 })
 

--- a/lib/src/components/navigation/stitches.navigationMenu.colorscheme.config.ts
+++ b/lib/src/components/navigation/stitches.navigationMenu.colorscheme.config.ts
@@ -1,0 +1,27 @@
+import { createTheme } from '~/stitches'
+
+const light = createTheme({
+  colors: {
+    text: '$tonal400',
+    background: 'white',
+    backgroundHover: '$tonal50',
+    textHover: '$tonal600',
+    backgroundActive: '$tonal100',
+    textActive: '$tonal600',
+    backgroundDataActive: '$primaryLight',
+    dataActiveText: '$primary',
+    dataActiveTextHover: '$primary',
+    dataActivePressedText: '$primary',
+    dataActiveFocus: '$primary',
+    dataActiveBackgroundHover: '$tonal50',
+    dataActiveBackground: '$tonal100',
+    activeItemColor: '$tonal500',
+    activeItemBackgroundColor: '$tonal500',
+    triggerOpenBackground: '$tonal100',
+    navigationDropdown: 'white'
+  }
+})
+
+export const colorSchemes = {
+  light
+}

--- a/lib/src/components/navigation/stitches.navigationMenu.colorscheme.config.ts
+++ b/lib/src/components/navigation/stitches.navigationMenu.colorscheme.config.ts
@@ -17,8 +17,8 @@ const light = createTheme({
     backgroundSelectedPressed: '$grey200',
     itemTextSelected: '$grey900',
     itemBackgroundSelected: '$grey900',
-    triggerOpenBackground: '$grey200',
-    navigationDropdownBackground: 'white'
+    triggerBackgroundOpen: '$grey200',
+    dropdownBackground: 'white'
   }
 })
 

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -5,6 +5,7 @@ import { useWindowScrollPosition } from '~/utilities/hooks/useWindowScrollPositi
 
 import { Divider } from '../divider'
 import { Flex } from '../flex'
+import { colorSchemes as topBarColorSchemes } from './stitches.topBar.colorscheme.config'
 import { TopBarActionIcon } from './TopBarActionIcon'
 import { TopBarBrand, TopBarBrandLogo, TopBarBrandName } from './TopBarBrand'
 
@@ -17,18 +18,21 @@ interface TopBarSubComponents {
 }
 
 const TopBarDivider = () => (
-  <Divider orientation="vertical" css={{ height: '$2', bg: '$tonal100' }} />
+  <Divider
+    orientation="vertical"
+    css={{ height: '$2', bg: '$dividerBackground' }}
+  />
 )
 
 const StyledRoot = styled('div', {
-  bg: 'white',
+  bg: '$background',
   position: 'sticky',
   display: 'flex',
   alignItems: 'center',
   width: '100vw',
   top: '0',
   zIndex: 1,
-  borderBottom: '1px solid $tonal100',
+  borderBottom: '1px solid $borderBottomBackground',
   transition: 'box-shadow .2s ease-out',
   variants: {
     hasScrolled: {
@@ -73,16 +77,22 @@ type StyledRootProps = React.ComponentProps<typeof StyledRoot>
 
 interface TopBarProps extends StyledRootProps {
   css?: CSS
+  className?: string
 }
 
 export const TopBar: React.FC<TopBarProps> & TopBarSubComponents = ({
   size = 'md',
+  className = topBarColorSchemes['light'],
   ...props
 }) => {
   const { y: scrollPositionY } = useWindowScrollPosition()
 
   return (
-    <StyledRoot hasScrolled={!!scrollPositionY} size={size}>
+    <StyledRoot
+      className={className}
+      hasScrolled={!!scrollPositionY}
+      size={size}
+    >
       <Container {...props} />
     </StyledRoot>
   )

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -18,10 +18,7 @@ interface TopBarSubComponents {
 }
 
 const TopBarDivider = () => (
-  <Divider
-    orientation="vertical"
-    css={{ height: '$2', bg: '$dividerBackground' }}
-  />
+  <Divider orientation="vertical" css={{ height: '$2', bg: '$divider' }} />
 )
 
 const StyledRoot = styled('div', {
@@ -32,7 +29,7 @@ const StyledRoot = styled('div', {
   width: '100vw',
   top: '0',
   zIndex: 1,
-  borderBottom: '1px solid $borderBottomBackground',
+  borderBottom: '1px solid $borderBottom',
   transition: 'box-shadow .2s ease-out',
   variants: {
     hasScrolled: {

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -2,15 +2,266 @@
 
 exports[`TopBar component renders 1`] = `
 @media  {
-  .c-glwkin {
-    background: white;
+  :root,
+  .t-kAUxbu {
+    --default-colors: [object Object];
+    --default-space: [object Object];
+    --default-fontSizes: [object Object];
+    --default-fonts: [object Object];
+    --default-sizes: [object Object];
+    --default-radii: [object Object];
+    --default-shadows: [object Object];
+    --default-ratios: [object Object];
+    --colors-textForeground: hsl(0, 0%, 12%);
+    --colors-textSubtle: hsl(0, 0%, 33%);
+    --colors-textPlaceholder: hsl(0, 0%, 46%);
+    --colors-background: hsl(0, 0%, 96%);
+    --colors-backgroundAccent: hsl(215, 100%, 98%);
+    --colors-grey100: hsl(0, 0%, 96%);
+    --colors-grey200: hsl(0, 0%, 92%);
+    --colors-grey300: hsl(0, 0%, 88%);
+    --colors-grey400: hsl(0, 0%, 81%);
+    --colors-grey500: hsl(0, 0%, 73%);
+    --colors-grey600: hsl(0, 0%, 62%);
+    --colors-grey700: hsl(0, 0%, 46%);
+    --colors-grey800: hsl(0, 0%, 33%);
+    --colors-grey900: hsl(0, 0%, 20%);
+    --colors-grey1000: hsl(0, 0%, 12%);
+    --colors-grey1100: hsl(0, 0%, 10%);
+    --colors-grey1200: hsl(0, 0%, 6%);
+    --colors-blue100: hsl(215, 100%, 98%);
+    --colors-blue200: hsl(212, 100%, 95%);
+    --colors-blue300: hsl(211, 100%, 92%);
+    --colors-blue400: hsl(211, 100%, 88%);
+    --colors-blue500: hsl(212, 100%, 80%);
+    --colors-blue600: hsl(213, 100%, 71%);
+    --colors-blue700: hsl(214, 100%, 58%);
+    --colors-blue800: hsl(217, 92%, 51%);
+    --colors-blue900: hsl(223, 78%, 44%);
+    --colors-blue1000: hsl(228, 82%, 35%);
+    --colors-blue1100: hsl(228, 63%, 23%);
+    --colors-blue1200: hsl(227, 57%, 11%);
+    --colors-purple100: hsl(282, 100%, 98%);
+    --colors-purple200: hsl(270, 100%, 95%);
+    --colors-purple300: hsl(271, 100%, 92%);
+    --colors-purple400: hsl(270, 100%, 89%);
+    --colors-purple500: hsl(270, 90%, 81%);
+    --colors-purple600: hsl(271, 97%, 69%);
+    --colors-purple700: hsl(273, 84%, 47%);
+    --colors-purple800: hsl(273, 94%, 48%);
+    --colors-purple900: hsl(268, 79%, 42%);
+    --colors-purple1000: hsl(266, 82%, 32%);
+    --colors-purple1100: hsl(265, 63%, 23%);
+    --colors-purple1200: hsl(265, 61%, 14%);
+    --colors-cyan100: hsl(198, 100%, 97%);
+    --colors-cyan200: hsl(199, 100%, 94%);
+    --colors-cyan300: hsl(201, 100%, 89%);
+    --colors-cyan400: hsl(200, 100%, 84%);
+    --colors-cyan500: hsl(201, 96%, 73%);
+    --colors-cyan600: hsl(202, 85%, 60%);
+    --colors-cyan700: hsl(204, 81%, 46%);
+    --colors-cyan800: hsl(205, 100%, 38%);
+    --colors-cyan900: hsl(206, 100%, 30%);
+    --colors-cyan1000: hsl(205, 100%, 21%);
+    --colors-cyan1100: hsl(206, 97%, 15%);
+    --colors-cyan1200: hsl(207, 73%, 9%);
+    --colors-green100: hsl(135, 80%, 96%);
+    --colors-green200: hsl(135, 72%, 92%);
+    --colors-green300: hsl(135, 68%, 83%);
+    --colors-green400: hsl(135, 65%, 76%);
+    --colors-green500: hsl(136, 56%, 62%);
+    --colors-green600: hsl(137, 42%, 49%);
+    --colors-green700: hsl(138, 51%, 35%);
+    --colors-green800: hsl(138, 68%, 29%);
+    --colors-green900: hsl(138, 74%, 21%);
+    --colors-green1000: hsl(138, 89%, 14%);
+    --colors-green1100: hsl(135, 91%, 9%);
+    --colors-green1200: hsl(123, 56%, 6%);
+    --colors-magenta100: hsl(330, 100%, 99%);
+    --colors-magenta200: hsl(329, 100%, 96%);
+    --colors-magenta300: hsl(332, 100%, 92%);
+    --colors-magenta400: hsl(333, 100%, 90%);
+    --colors-magenta500: hsl(333, 90%, 80%);
+    --colors-magenta600: hsl(333, 87%, 72%);
+    --colors-magenta700: hsl(333, 75%, 59%);
+    --colors-magenta800: hsl(333, 69%, 49%);
+    --colors-magenta900: hsl(333, 74%, 36%);
+    --colors-magenta1000: hsl(333, 86%, 25%);
+    --colors-magenta1100: hsl(333, 95%, 16%);
+    --colors-magenta1200: hsl(334, 62%, 10%);
+    --colors-red100: hsl(0, 100%, 99%);
+    --colors-red200: hsl(0, 100%, 96%);
+    --colors-red300: hsl(357, 100%, 93%);
+    --colors-red400: hsl(356, 100%, 90%);
+    --colors-red500: hsl(356, 96%, 83%);
+    --colors-red600: hsl(357, 90%, 73%);
+    --colors-red700: hsl(357, 80%, 59%);
+    --colors-red800: hsl(357, 76%, 49%);
+    --colors-red900: hsl(357, 73%, 37%);
+    --colors-red1000: hsl(357, 79%, 26%);
+    --colors-red1100: hsl(357, 91%, 17%);
+    --colors-red1200: hsl(357, 73%, 10%);
+    --colors-teal100: hsl(180, 83%, 95%);
+    --colors-teal200: hsl(180, 75%, 88%);
+    --colors-teal300: hsl(180, 71%, 78%);
+    --colors-teal400: hsl(179, 70%, 71%);
+    --colors-teal500: hsl(179, 65%, 52%);
+    --colors-teal600: hsl(179, 76%, 41%);
+    --colors-teal700: hsl(179, 91%, 31%);
+    --colors-teal800: hsl(178, 100%, 25%);
+    --colors-teal900: hsl(180, 100%, 18%);
+    --colors-teal1000: hsl(183, 100%, 13%);
+    --colors-teal1100: hsl(187, 92%, 10%);
+    --colors-teal1200: hsl(186, 56%, 7%);
+    --colors-orange100: hsl(38, 100%, 95%);
+    --colors-orange200: hsl(38, 100%, 90%);
+    --colors-orange300: hsl(37, 100%, 84%);
+    --colors-orange400: hsl(36, 96%, 78%);
+    --colors-orange500: hsl(33, 100%, 67%);
+    --colors-orange600: hsl(31, 97%, 57%);
+    --colors-orange700: hsl(30, 92%, 46%);
+    --colors-orange800: hsl(29, 100%, 43%);
+    --colors-orange900: hsl(27, 100%, 36%);
+    --colors-orange1000: hsl(24, 100%, 26%);
+    --colors-orange1100: hsl(20, 97%, 15%);
+    --colors-orange1200: hsl(20, 96%, 11%);
+    --colors-yellow100: hsl(53, 94%, 93%);
+    --colors-yellow200: hsl(54, 92%, 85%);
+    --colors-yellow300: hsl(54, 92%, 75%);
+    --colors-yellow400: hsl(52, 97%, 63%);
+    --colors-yellow500: hsl(51, 100%, 46%);
+    --colors-yellow600: hsl(49, 100%, 39%);
+    --colors-yellow700: hsl(48, 100%, 35%);
+    --colors-yellow800: hsl(46, 100%, 30%);
+    --colors-yellow900: hsl(44, 100%, 22%);
+    --colors-yellow1000: hsl(44, 100%, 18%);
+    --colors-yellow1100: hsl(41, 100%, 11%);
+    --colors-yellow1200: hsl(39, 100%, 8%);
+    --colors-lime100: hsl(73, 94%, 93%);
+    --colors-lime200: hsl(73, 94%, 87%);
+    --colors-lime300: hsl(73, 90%, 77%);
+    --colors-lime400: hsl(74, 82%, 69%);
+    --colors-lime500: hsl(74, 68%, 58%);
+    --colors-lime600: hsl(74, 77%, 41%);
+    --colors-lime700: hsl(75, 100%, 31%);
+    --colors-lime800: hsl(75, 100%, 27%);
+    --colors-lime900: hsl(75, 100%, 19%);
+    --colors-lime1000: hsl(75, 100%, 15%);
+    --colors-lime1100: hsl(75, 100%, 9%);
+    --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-tonal50: hsl(0, 0%, 96%);
+    --colors-tonal100: hsl(0, 0%, 92%);
+    --colors-tonal200: hsl(0, 0%, 62%);
+    --colors-tonal300: hsl(0, 0%, 46%);
+    --colors-tonal400: hsl(0, 0%, 33%);
+    --colors-tonal500: hsl(0, 0%, 20%);
+    --colors-tonal600: hsl(0, 0%, 12%);
+    --colors-alpha100: hsla(0, 0%, 20%, 0.1);
+    --colors-alpha150: hsla(0, 0%, 20%, 0.15);
+    --colors-alpha200: hsla(0, 0%, 20%, 0.2);
+    --colors-alpha250: hsla(0, 0%, 20%, 0.25);
+    --colors-alpha600: hsla(0, 0%, 20%, 0.6);
+    --colors-primaryLight: hsl(215, 100%, 98%);
+    --colors-primary: hsl(217, 92%, 51%);
+    --colors-primaryMid: hsl(223, 78%, 44%);
+    --colors-primaryDark: hsl(228, 82%, 35%);
+    --colors-secondary: hsl(204, 100%, 72%);
+    --colors-brandRed: hsl(0, 91%, 64%);
+    --colors-brandRedAccent: hsl(14, 100%, 71%);
+    --colors-brandGreen: hsl(128, 47%, 53%);
+    --colors-brandGreenAccent: hsl(168, 100%, 20%);
+    --colors-brandPurple: hsl(256, 65%, 62%);
+    --colors-brandPurpleAccent: hsl(256, 93%, 35%);
+    --colors-brandYellow: hsl(41, 100%, 55%);
+    --colors-brandYellowAccent: hsl(33, 100%, 50%);
+    --colors-successLight: hsl(119, 44%, 94%);
+    --colors-success: hsl(119, 100%, 27%);
+    --colors-successMid: hsl(124, 100%, 22%);
+    --colors-successDark: hsl(126, 100%, 17%);
+    --colors-dangerLight: hsl(0, 77%, 95%);
+    --colors-danger: hsl(0, 96%, 48%);
+    --colors-dangerMid: hsl(0, 96%, 41%);
+    --colors-dangerDark: hsl(0, 97%, 34%);
+    --colors-warningLight: hsl(39, 100%, 94%);
+    --colors-warning: hsl(41, 100%, 55%);
+    --colors-warningMid: hsl(41, 89%, 48%);
+    --colors-warningDark: hsl(41, 100%, 41%);
+    --colors-warningText: hsl(24, 100%, 37%);
+    --colors-subjectEnglish: hsl(0, 91%, 64%);
+    --colors-subjectMaths: hsl(217, 92%, 51%);
+    --colors-subjectScience: hsl(256, 65%, 62%);
+    --colors-subjectVerbalReasoning: hsl(128, 47%, 53%);
+    --colors-subjectNonVerbalReasoning: hsl(41, 100%, 55%);
+    --colors-subjectCreativeWriting: hsl(33, 100%, 50%);
+    --colors-subjectExamSkills: hsl(256, 93%, 35%);
+    --colors-glBlueLight: hsl(222, 68%, 78%);
+    --colors-glBluePrimary: hsl(222, 56%, 55%);
+    --colors-glBlueDark: hsl(222, 35%, 43%);
+    --space-0: 0.125rem;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 2rem;
+    --space-6: 2.5rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-9: 5rem;
+    --space-24: 1.5rem;
+    --fontSizes-xs: 0.75rem;
+    --fontSizes-sm: 0.875rem;
+    --fontSizes-md: 1rem;
+    --fontSizes-lg: 1.3125rem;
+    --fontSizes-xl: 1.75rem;
+    --fontSizes-2xl: 2.3125rem;
+    --fontSizes-3xl: 3.125rem;
+    --fontSizes-4xl: 5.625rem;
+    --fonts-sans: system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-mono: 'SFMono-Regular', Consolas, Menlo, monospace;
+    --fonts-display: 'Space Grotesk', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-body: 'Inter', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --sizes-0: 0.5rem;
+    --sizes-1: 1rem;
+    --sizes-2: 1.5rem;
+    --sizes-3: 2rem;
+    --sizes-4: 2.5rem;
+    --sizes-5: 3rem;
+    --sizes-6: 4rem;
+    --sizes-7: 6rem;
+    --sizes-8: 8rem;
+    --radii-0: 0.25rem;
+    --radii-1: 0.5rem;
+    --radii-2: 0.75rem;
+    --radii-3: 1rem;
+    --radii-round: 100rem;
+    --shadows-0: 0 1px 3px hsla(0, 0%, 20%, 0.1), 0 1px 2px hsla(0, 0%, 20%, 0.15);
+    --shadows-1: 0 3px 6px hsla(0, 0%, 20%, 0.1), 0 3px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-2: 0 10px 20px hsla(0, 0%, 20%, 0.1), 0 6px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-3: 0 14px 28px hsla(0, 0%, 20%, 0.15), 0 10px 10px hsla(0, 0%, 20%, 0.1);
+    --ratios-16-9: 16/9;
+    --ratios-3-2: 3/2;
+    --ratios-4-3: 4/3;
+    --ratios-1-1: 1/1;
+    --ratios-3-4: 3/4;
+  }
+
+  .t-cOULKG {
+    --colors-background: white;
+    --colors-dividerBackground: var(--colors-tonal100);
+    --colors-borderBottomBackground: var(--colors-tonal100);
+  }
+}
+
+@media  {
+  .c-bhzmuu {
+    background: var(--colors-background);
     position: sticky;
     display: flex;
     align-items: center;
     width: 100vw;
     top: 0;
     z-index: 1;
-    border-bottom: 1px solid var(--colors-tonal100);
+    border-bottom: 1px solid var(--colors-borderBottomBackground);
     transition: box-shadow .2s ease-out;
   }
 
@@ -139,11 +390,11 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-glwkin-daNQNf-size-md {
+  .c-bhzmuu-daNQNf-size-md {
     height: var(--sizes-6);
   }
 
-  .c-glwkin-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
+  .c-bhzmuu-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
     height: 24px;
     width: auto;
   }
@@ -209,15 +460,15 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-fNKiiB-ieFaPrQ-css {
+  .c-fNKiiB-ihKiNay-css {
     height: var(--sizes-2);
-    background: var(--colors-tonal100);
+    background: var(--colors-dividerBackground);
   }
 }
 
 <body>
   <div
-    class="c-glwkin c-glwkin-daNQNf-size-md"
+    class="c-bhzmuu c-bhzmuu-daNQNf-size-md t-cOULKG"
   >
     <div
       class="c-dhzjXW c-ftiHlK"
@@ -255,7 +506,7 @@ exports[`TopBar component renders 1`] = `
         </svg>
       </button>
       <hr
-        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ieFaPrQ-css"
+        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ihKiNay-css"
       />
       <button
         aria-label="Light/Dark mode"
@@ -286,15 +537,266 @@ exports[`TopBar component renders 1`] = `
 
 exports[`TopBar component renders the lg variant 1`] = `
 @media  {
-  .c-glwkin {
-    background: white;
+  :root,
+  .t-kAUxbu {
+    --default-colors: [object Object];
+    --default-space: [object Object];
+    --default-fontSizes: [object Object];
+    --default-fonts: [object Object];
+    --default-sizes: [object Object];
+    --default-radii: [object Object];
+    --default-shadows: [object Object];
+    --default-ratios: [object Object];
+    --colors-textForeground: hsl(0, 0%, 12%);
+    --colors-textSubtle: hsl(0, 0%, 33%);
+    --colors-textPlaceholder: hsl(0, 0%, 46%);
+    --colors-background: hsl(0, 0%, 96%);
+    --colors-backgroundAccent: hsl(215, 100%, 98%);
+    --colors-grey100: hsl(0, 0%, 96%);
+    --colors-grey200: hsl(0, 0%, 92%);
+    --colors-grey300: hsl(0, 0%, 88%);
+    --colors-grey400: hsl(0, 0%, 81%);
+    --colors-grey500: hsl(0, 0%, 73%);
+    --colors-grey600: hsl(0, 0%, 62%);
+    --colors-grey700: hsl(0, 0%, 46%);
+    --colors-grey800: hsl(0, 0%, 33%);
+    --colors-grey900: hsl(0, 0%, 20%);
+    --colors-grey1000: hsl(0, 0%, 12%);
+    --colors-grey1100: hsl(0, 0%, 10%);
+    --colors-grey1200: hsl(0, 0%, 6%);
+    --colors-blue100: hsl(215, 100%, 98%);
+    --colors-blue200: hsl(212, 100%, 95%);
+    --colors-blue300: hsl(211, 100%, 92%);
+    --colors-blue400: hsl(211, 100%, 88%);
+    --colors-blue500: hsl(212, 100%, 80%);
+    --colors-blue600: hsl(213, 100%, 71%);
+    --colors-blue700: hsl(214, 100%, 58%);
+    --colors-blue800: hsl(217, 92%, 51%);
+    --colors-blue900: hsl(223, 78%, 44%);
+    --colors-blue1000: hsl(228, 82%, 35%);
+    --colors-blue1100: hsl(228, 63%, 23%);
+    --colors-blue1200: hsl(227, 57%, 11%);
+    --colors-purple100: hsl(282, 100%, 98%);
+    --colors-purple200: hsl(270, 100%, 95%);
+    --colors-purple300: hsl(271, 100%, 92%);
+    --colors-purple400: hsl(270, 100%, 89%);
+    --colors-purple500: hsl(270, 90%, 81%);
+    --colors-purple600: hsl(271, 97%, 69%);
+    --colors-purple700: hsl(273, 84%, 47%);
+    --colors-purple800: hsl(273, 94%, 48%);
+    --colors-purple900: hsl(268, 79%, 42%);
+    --colors-purple1000: hsl(266, 82%, 32%);
+    --colors-purple1100: hsl(265, 63%, 23%);
+    --colors-purple1200: hsl(265, 61%, 14%);
+    --colors-cyan100: hsl(198, 100%, 97%);
+    --colors-cyan200: hsl(199, 100%, 94%);
+    --colors-cyan300: hsl(201, 100%, 89%);
+    --colors-cyan400: hsl(200, 100%, 84%);
+    --colors-cyan500: hsl(201, 96%, 73%);
+    --colors-cyan600: hsl(202, 85%, 60%);
+    --colors-cyan700: hsl(204, 81%, 46%);
+    --colors-cyan800: hsl(205, 100%, 38%);
+    --colors-cyan900: hsl(206, 100%, 30%);
+    --colors-cyan1000: hsl(205, 100%, 21%);
+    --colors-cyan1100: hsl(206, 97%, 15%);
+    --colors-cyan1200: hsl(207, 73%, 9%);
+    --colors-green100: hsl(135, 80%, 96%);
+    --colors-green200: hsl(135, 72%, 92%);
+    --colors-green300: hsl(135, 68%, 83%);
+    --colors-green400: hsl(135, 65%, 76%);
+    --colors-green500: hsl(136, 56%, 62%);
+    --colors-green600: hsl(137, 42%, 49%);
+    --colors-green700: hsl(138, 51%, 35%);
+    --colors-green800: hsl(138, 68%, 29%);
+    --colors-green900: hsl(138, 74%, 21%);
+    --colors-green1000: hsl(138, 89%, 14%);
+    --colors-green1100: hsl(135, 91%, 9%);
+    --colors-green1200: hsl(123, 56%, 6%);
+    --colors-magenta100: hsl(330, 100%, 99%);
+    --colors-magenta200: hsl(329, 100%, 96%);
+    --colors-magenta300: hsl(332, 100%, 92%);
+    --colors-magenta400: hsl(333, 100%, 90%);
+    --colors-magenta500: hsl(333, 90%, 80%);
+    --colors-magenta600: hsl(333, 87%, 72%);
+    --colors-magenta700: hsl(333, 75%, 59%);
+    --colors-magenta800: hsl(333, 69%, 49%);
+    --colors-magenta900: hsl(333, 74%, 36%);
+    --colors-magenta1000: hsl(333, 86%, 25%);
+    --colors-magenta1100: hsl(333, 95%, 16%);
+    --colors-magenta1200: hsl(334, 62%, 10%);
+    --colors-red100: hsl(0, 100%, 99%);
+    --colors-red200: hsl(0, 100%, 96%);
+    --colors-red300: hsl(357, 100%, 93%);
+    --colors-red400: hsl(356, 100%, 90%);
+    --colors-red500: hsl(356, 96%, 83%);
+    --colors-red600: hsl(357, 90%, 73%);
+    --colors-red700: hsl(357, 80%, 59%);
+    --colors-red800: hsl(357, 76%, 49%);
+    --colors-red900: hsl(357, 73%, 37%);
+    --colors-red1000: hsl(357, 79%, 26%);
+    --colors-red1100: hsl(357, 91%, 17%);
+    --colors-red1200: hsl(357, 73%, 10%);
+    --colors-teal100: hsl(180, 83%, 95%);
+    --colors-teal200: hsl(180, 75%, 88%);
+    --colors-teal300: hsl(180, 71%, 78%);
+    --colors-teal400: hsl(179, 70%, 71%);
+    --colors-teal500: hsl(179, 65%, 52%);
+    --colors-teal600: hsl(179, 76%, 41%);
+    --colors-teal700: hsl(179, 91%, 31%);
+    --colors-teal800: hsl(178, 100%, 25%);
+    --colors-teal900: hsl(180, 100%, 18%);
+    --colors-teal1000: hsl(183, 100%, 13%);
+    --colors-teal1100: hsl(187, 92%, 10%);
+    --colors-teal1200: hsl(186, 56%, 7%);
+    --colors-orange100: hsl(38, 100%, 95%);
+    --colors-orange200: hsl(38, 100%, 90%);
+    --colors-orange300: hsl(37, 100%, 84%);
+    --colors-orange400: hsl(36, 96%, 78%);
+    --colors-orange500: hsl(33, 100%, 67%);
+    --colors-orange600: hsl(31, 97%, 57%);
+    --colors-orange700: hsl(30, 92%, 46%);
+    --colors-orange800: hsl(29, 100%, 43%);
+    --colors-orange900: hsl(27, 100%, 36%);
+    --colors-orange1000: hsl(24, 100%, 26%);
+    --colors-orange1100: hsl(20, 97%, 15%);
+    --colors-orange1200: hsl(20, 96%, 11%);
+    --colors-yellow100: hsl(53, 94%, 93%);
+    --colors-yellow200: hsl(54, 92%, 85%);
+    --colors-yellow300: hsl(54, 92%, 75%);
+    --colors-yellow400: hsl(52, 97%, 63%);
+    --colors-yellow500: hsl(51, 100%, 46%);
+    --colors-yellow600: hsl(49, 100%, 39%);
+    --colors-yellow700: hsl(48, 100%, 35%);
+    --colors-yellow800: hsl(46, 100%, 30%);
+    --colors-yellow900: hsl(44, 100%, 22%);
+    --colors-yellow1000: hsl(44, 100%, 18%);
+    --colors-yellow1100: hsl(41, 100%, 11%);
+    --colors-yellow1200: hsl(39, 100%, 8%);
+    --colors-lime100: hsl(73, 94%, 93%);
+    --colors-lime200: hsl(73, 94%, 87%);
+    --colors-lime300: hsl(73, 90%, 77%);
+    --colors-lime400: hsl(74, 82%, 69%);
+    --colors-lime500: hsl(74, 68%, 58%);
+    --colors-lime600: hsl(74, 77%, 41%);
+    --colors-lime700: hsl(75, 100%, 31%);
+    --colors-lime800: hsl(75, 100%, 27%);
+    --colors-lime900: hsl(75, 100%, 19%);
+    --colors-lime1000: hsl(75, 100%, 15%);
+    --colors-lime1100: hsl(75, 100%, 9%);
+    --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-tonal50: hsl(0, 0%, 96%);
+    --colors-tonal100: hsl(0, 0%, 92%);
+    --colors-tonal200: hsl(0, 0%, 62%);
+    --colors-tonal300: hsl(0, 0%, 46%);
+    --colors-tonal400: hsl(0, 0%, 33%);
+    --colors-tonal500: hsl(0, 0%, 20%);
+    --colors-tonal600: hsl(0, 0%, 12%);
+    --colors-alpha100: hsla(0, 0%, 20%, 0.1);
+    --colors-alpha150: hsla(0, 0%, 20%, 0.15);
+    --colors-alpha200: hsla(0, 0%, 20%, 0.2);
+    --colors-alpha250: hsla(0, 0%, 20%, 0.25);
+    --colors-alpha600: hsla(0, 0%, 20%, 0.6);
+    --colors-primaryLight: hsl(215, 100%, 98%);
+    --colors-primary: hsl(217, 92%, 51%);
+    --colors-primaryMid: hsl(223, 78%, 44%);
+    --colors-primaryDark: hsl(228, 82%, 35%);
+    --colors-secondary: hsl(204, 100%, 72%);
+    --colors-brandRed: hsl(0, 91%, 64%);
+    --colors-brandRedAccent: hsl(14, 100%, 71%);
+    --colors-brandGreen: hsl(128, 47%, 53%);
+    --colors-brandGreenAccent: hsl(168, 100%, 20%);
+    --colors-brandPurple: hsl(256, 65%, 62%);
+    --colors-brandPurpleAccent: hsl(256, 93%, 35%);
+    --colors-brandYellow: hsl(41, 100%, 55%);
+    --colors-brandYellowAccent: hsl(33, 100%, 50%);
+    --colors-successLight: hsl(119, 44%, 94%);
+    --colors-success: hsl(119, 100%, 27%);
+    --colors-successMid: hsl(124, 100%, 22%);
+    --colors-successDark: hsl(126, 100%, 17%);
+    --colors-dangerLight: hsl(0, 77%, 95%);
+    --colors-danger: hsl(0, 96%, 48%);
+    --colors-dangerMid: hsl(0, 96%, 41%);
+    --colors-dangerDark: hsl(0, 97%, 34%);
+    --colors-warningLight: hsl(39, 100%, 94%);
+    --colors-warning: hsl(41, 100%, 55%);
+    --colors-warningMid: hsl(41, 89%, 48%);
+    --colors-warningDark: hsl(41, 100%, 41%);
+    --colors-warningText: hsl(24, 100%, 37%);
+    --colors-subjectEnglish: hsl(0, 91%, 64%);
+    --colors-subjectMaths: hsl(217, 92%, 51%);
+    --colors-subjectScience: hsl(256, 65%, 62%);
+    --colors-subjectVerbalReasoning: hsl(128, 47%, 53%);
+    --colors-subjectNonVerbalReasoning: hsl(41, 100%, 55%);
+    --colors-subjectCreativeWriting: hsl(33, 100%, 50%);
+    --colors-subjectExamSkills: hsl(256, 93%, 35%);
+    --colors-glBlueLight: hsl(222, 68%, 78%);
+    --colors-glBluePrimary: hsl(222, 56%, 55%);
+    --colors-glBlueDark: hsl(222, 35%, 43%);
+    --space-0: 0.125rem;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 2rem;
+    --space-6: 2.5rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-9: 5rem;
+    --space-24: 1.5rem;
+    --fontSizes-xs: 0.75rem;
+    --fontSizes-sm: 0.875rem;
+    --fontSizes-md: 1rem;
+    --fontSizes-lg: 1.3125rem;
+    --fontSizes-xl: 1.75rem;
+    --fontSizes-2xl: 2.3125rem;
+    --fontSizes-3xl: 3.125rem;
+    --fontSizes-4xl: 5.625rem;
+    --fonts-sans: system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-mono: 'SFMono-Regular', Consolas, Menlo, monospace;
+    --fonts-display: 'Space Grotesk', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-body: 'Inter', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --sizes-0: 0.5rem;
+    --sizes-1: 1rem;
+    --sizes-2: 1.5rem;
+    --sizes-3: 2rem;
+    --sizes-4: 2.5rem;
+    --sizes-5: 3rem;
+    --sizes-6: 4rem;
+    --sizes-7: 6rem;
+    --sizes-8: 8rem;
+    --radii-0: 0.25rem;
+    --radii-1: 0.5rem;
+    --radii-2: 0.75rem;
+    --radii-3: 1rem;
+    --radii-round: 100rem;
+    --shadows-0: 0 1px 3px hsla(0, 0%, 20%, 0.1), 0 1px 2px hsla(0, 0%, 20%, 0.15);
+    --shadows-1: 0 3px 6px hsla(0, 0%, 20%, 0.1), 0 3px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-2: 0 10px 20px hsla(0, 0%, 20%, 0.1), 0 6px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-3: 0 14px 28px hsla(0, 0%, 20%, 0.15), 0 10px 10px hsla(0, 0%, 20%, 0.1);
+    --ratios-16-9: 16/9;
+    --ratios-3-2: 3/2;
+    --ratios-4-3: 4/3;
+    --ratios-1-1: 1/1;
+    --ratios-3-4: 3/4;
+  }
+
+  .t-cOULKG {
+    --colors-background: white;
+    --colors-dividerBackground: var(--colors-tonal100);
+    --colors-borderBottomBackground: var(--colors-tonal100);
+  }
+}
+
+@media  {
+  .c-bhzmuu {
+    background: var(--colors-background);
     position: sticky;
     display: flex;
     align-items: center;
     width: 100vw;
     top: 0;
     z-index: 1;
-    border-bottom: 1px solid var(--colors-tonal100);
+    border-bottom: 1px solid var(--colors-borderBottomBackground);
     transition: box-shadow .2s ease-out;
   }
 
@@ -423,11 +925,11 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-glwkin-daNQNf-size-md {
+  .c-bhzmuu-daNQNf-size-md {
     height: var(--sizes-6);
   }
 
-  .c-glwkin-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
+  .c-bhzmuu-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
     height: 24px;
     width: auto;
   }
@@ -470,11 +972,11 @@ exports[`TopBar component renders the lg variant 1`] = `
     min-height: var(--sizes-3);
   }
 
-  .c-glwkin-lcsdih-size-lg {
+  .c-bhzmuu-lcsdih-size-lg {
     height: var(--sizes-7);
   }
 
-  .c-glwkin-lcsdih-size-lg .topbar-brand-logo[src$=".svg"] {
+  .c-bhzmuu-lcsdih-size-lg .topbar-brand-logo[src$=".svg"] {
     height: 32px;
     width: auto;
   }
@@ -502,15 +1004,15 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-fNKiiB-ieFaPrQ-css {
+  .c-fNKiiB-ihKiNay-css {
     height: var(--sizes-2);
-    background: var(--colors-tonal100);
+    background: var(--colors-dividerBackground);
   }
 }
 
 <body>
   <div
-    class="c-glwkin c-glwkin-lcsdih-size-lg"
+    class="c-bhzmuu c-bhzmuu-lcsdih-size-lg t-cOULKG"
   >
     <div
       class="c-dhzjXW c-ftiHlK"
@@ -548,7 +1050,7 @@ exports[`TopBar component renders the lg variant 1`] = `
         </svg>
       </button>
       <hr
-        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ieFaPrQ-css"
+        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ihKiNay-css"
       />
       <button
         aria-label="Light/Dark mode"

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -245,15 +245,15 @@ exports[`TopBar component renders 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .t-cOULKG {
+  .t-fvKGSq {
     --colors-background: white;
-    --colors-dividerBackground: var(--colors-tonal100);
-    --colors-borderBottomBackground: var(--colors-tonal100);
+    --colors-divider: var(--colors-grey200);
+    --colors-borderBottom: var(--colors-grey200);
   }
 }
 
 @media  {
-  .c-bhzmuu {
+  .c-eplmKA {
     background: var(--colors-background);
     position: sticky;
     display: flex;
@@ -261,7 +261,7 @@ exports[`TopBar component renders 1`] = `
     width: 100vw;
     top: 0;
     z-index: 1;
-    border-bottom: 1px solid var(--colors-borderBottomBackground);
+    border-bottom: 1px solid var(--colors-borderBottom);
     transition: box-shadow .2s ease-out;
   }
 
@@ -390,11 +390,11 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-bhzmuu-daNQNf-size-md {
+  .c-eplmKA-daNQNf-size-md {
     height: var(--sizes-6);
   }
 
-  .c-bhzmuu-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
+  .c-eplmKA-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
     height: 24px;
     width: auto;
   }
@@ -460,15 +460,15 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-fNKiiB-ihKiNay-css {
+  .c-fNKiiB-ijUXxeg-css {
     height: var(--sizes-2);
-    background: var(--colors-dividerBackground);
+    background: var(--colors-divider);
   }
 }
 
 <body>
   <div
-    class="c-bhzmuu c-bhzmuu-daNQNf-size-md t-cOULKG"
+    class="c-eplmKA c-eplmKA-daNQNf-size-md t-fvKGSq"
   >
     <div
       class="c-dhzjXW c-ftiHlK"
@@ -506,7 +506,7 @@ exports[`TopBar component renders 1`] = `
         </svg>
       </button>
       <hr
-        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ihKiNay-css"
+        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ijUXxeg-css"
       />
       <button
         aria-label="Light/Dark mode"
@@ -780,15 +780,15 @@ exports[`TopBar component renders the lg variant 1`] = `
     --ratios-3-4: 3/4;
   }
 
-  .t-cOULKG {
+  .t-fvKGSq {
     --colors-background: white;
-    --colors-dividerBackground: var(--colors-tonal100);
-    --colors-borderBottomBackground: var(--colors-tonal100);
+    --colors-divider: var(--colors-grey200);
+    --colors-borderBottom: var(--colors-grey200);
   }
 }
 
 @media  {
-  .c-bhzmuu {
+  .c-eplmKA {
     background: var(--colors-background);
     position: sticky;
     display: flex;
@@ -796,7 +796,7 @@ exports[`TopBar component renders the lg variant 1`] = `
     width: 100vw;
     top: 0;
     z-index: 1;
-    border-bottom: 1px solid var(--colors-borderBottomBackground);
+    border-bottom: 1px solid var(--colors-borderBottom);
     transition: box-shadow .2s ease-out;
   }
 
@@ -925,11 +925,11 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-bhzmuu-daNQNf-size-md {
+  .c-eplmKA-daNQNf-size-md {
     height: var(--sizes-6);
   }
 
-  .c-bhzmuu-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
+  .c-eplmKA-daNQNf-size-md .topbar-brand-logo[src$=".svg"] {
     height: 24px;
     width: auto;
   }
@@ -972,11 +972,11 @@ exports[`TopBar component renders the lg variant 1`] = `
     min-height: var(--sizes-3);
   }
 
-  .c-bhzmuu-lcsdih-size-lg {
+  .c-eplmKA-lcsdih-size-lg {
     height: var(--sizes-7);
   }
 
-  .c-bhzmuu-lcsdih-size-lg .topbar-brand-logo[src$=".svg"] {
+  .c-eplmKA-lcsdih-size-lg .topbar-brand-logo[src$=".svg"] {
     height: 32px;
     width: auto;
   }
@@ -1004,15 +1004,15 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-fNKiiB-ihKiNay-css {
+  .c-fNKiiB-ijUXxeg-css {
     height: var(--sizes-2);
-    background: var(--colors-dividerBackground);
+    background: var(--colors-divider);
   }
 }
 
 <body>
   <div
-    class="c-bhzmuu c-bhzmuu-lcsdih-size-lg t-cOULKG"
+    class="c-eplmKA c-eplmKA-lcsdih-size-lg t-fvKGSq"
   >
     <div
       class="c-dhzjXW c-ftiHlK"
@@ -1050,7 +1050,7 @@ exports[`TopBar component renders the lg variant 1`] = `
         </svg>
       </button>
       <hr
-        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ihKiNay-css"
+        class="c-fNKiiB c-fNKiiB-fKZlxR-orientation-vertical c-fNKiiB-ijUXxeg-css"
       />
       <button
         aria-label="Light/Dark mode"

--- a/lib/src/components/top-bar/stitches.topBar.colorscheme.config.ts
+++ b/lib/src/components/top-bar/stitches.topBar.colorscheme.config.ts
@@ -1,0 +1,13 @@
+import { createTheme } from '~/stitches'
+
+const light = createTheme({
+  colors: {
+    background: 'white',
+    dividerBackground: '$tonal100',
+    borderBottomBackground: '$tonal100'
+  }
+})
+
+export const colorSchemes = {
+  light
+}

--- a/lib/src/components/top-bar/stitches.topBar.colorscheme.config.ts
+++ b/lib/src/components/top-bar/stitches.topBar.colorscheme.config.ts
@@ -3,8 +3,8 @@ import { createTheme } from '~/stitches'
 const light = createTheme({
   colors: {
     background: 'white',
-    dividerBackground: '$tonal100',
-    borderBottomBackground: '$tonal100'
+    divider: '$grey200',
+    borderBottom: '$grey200'
   }
 })
 


### PR DESCRIPTION
The goal of this PR is to allow the ability to add custom theming to the `NavigationMenu` , `NavigationMenuVertical`  and the `Topbar` components, so that in the marketing site we can add our own "dark version" of the above components, without having to resort to the messy method of overriding every state e.g focus, hover, active etc.

