### PR TITLE
Dismissible tweaks

### DIFF
--- a/documentation/content/components.content.banner-regular.md
+++ b/documentation/content/components.content.banner-regular.md
@@ -42,7 +42,6 @@ tabs:
       <CodeBlock live={true} preview={true} code={`<BannerRegular
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
-        value=""
       >
         <BannerRegular.Content>
           <BannerRegular.Text>
@@ -66,7 +65,6 @@ tabs:
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
         size="sm"
-        value=""
       >
         <BannerRegular.Content>
           <BannerRegular.Heading>Example Heading</BannerRegular.Heading>
@@ -92,7 +90,6 @@ tabs:
         colorScheme={{ base: 'blue1' }}
         emphasis="subtle"
         size="md"
-        value=""
       >
         <BannerRegular.Content>
           <BannerRegular.Heading>Example Heading</BannerRegular.Heading>
@@ -121,7 +118,6 @@ tabs:
         colorScheme={{ base: 'blue2' }}
         emphasis="subtle"
         size="md"
-        value=""
         onDismiss={() => console.log('Dismissed')}>
 
         <BannerRegular.Content>

--- a/documentation/content/components.content.banner-slim.md
+++ b/documentation/content/components.content.banner-slim.md
@@ -42,7 +42,6 @@ tabs:
       <CodeBlock live={true} preview={true} code={`<BannerSlim
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
-        value=""
       >
         <BannerSlim.Content>
           <BannerSlim.Image src="https://picsum.photos/400/400" />
@@ -66,7 +65,6 @@ tabs:
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
         size="sm"
-        value=""
       >
         <BannerSlim.Content>
           <BannerSlim.Image src="https://picsum.photos/400/400" />
@@ -91,7 +89,6 @@ tabs:
         colorScheme={{ base: 'blue1' }}
         emphasis="subtle"
         size="md"
-        value=""
       >
         <BannerSlim.Content>
           <BannerSlim.Image src="https://picsum.photos/400/400" />
@@ -119,7 +116,6 @@ tabs:
         colorScheme={{ base: 'blue2' }}
         emphasis="subtle"
         size="md"
-        value=""
         onDismiss={() => console.log('Dismissed')}
       >
         <BannerSlim.Content>
@@ -146,7 +142,6 @@ tabs:
         colorScheme={{ base: 'blue2' }}
         emphasis="subtle"
         size="sm"
-        value=""
         onDismiss={() => console.log('Dismissed')}
       >
         <BannerSlim.Content>

--- a/documentation/content/components.primitives.dismissible.md
+++ b/documentation/content/components.primitives.dismissible.md
@@ -13,9 +13,8 @@ tabs:
 
 
       <CodeBlock live={true} preview={true} code={`<Dismissible
-        value="a"
-        onDismiss={(value) => {
-          alert(\`dismiss $\{value\}\`)
+        onDismiss={() => {
+          alert(\`dismiss a\`)
         }}
       >
         Press the trigger to dismiss this ->
@@ -24,9 +23,8 @@ tabs:
 
 
       <CodeBlock live={true} preview={true} code={`<Dismissible
-        value="custom"
-        onDismiss={(value) => {
-          alert(\`dismiss $\{value\}\`)
+        onDismiss={() => {
+          alert(\`dismiss custom\`)
         }}
         asChild
       >

--- a/lib/src/components/banner/BannerContainer.tsx
+++ b/lib/src/components/banner/BannerContainer.tsx
@@ -45,15 +45,15 @@ export type TBannerContainerProps = React.ComponentProps<
 
 export const BannerContainer = ({
   colorScheme = {},
-  value,
   onDismiss,
+  dismissed,
   ...props
 }: TBannerContainerProps): JSX.Element => {
   const { emphasis } = useBannerContext()
 
   return (
     <ColorScheme {...colorScheme} asChild>
-      <Dismissible asChild value={value} onDismiss={onDismiss}>
+      <Dismissible asChild onDismiss={onDismiss} dismissed={dismissed}>
         <StyledBannerContainer role="banner" emphasis={emphasis} {...props} />
       </Dismissible>
     </ColorScheme>

--- a/lib/src/components/banner/banner-regular/BannerRegular.test.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegular.test.tsx
@@ -52,7 +52,6 @@ describe(`BannerRegular component`, () => {
       <BannerRegularDismissibleImplementation
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
-        value="dismissible-sm-variant"
         onDismiss={onDismiss}
       />
     )
@@ -70,7 +69,6 @@ describe(`BannerRegular component`, () => {
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
         size="sm"
-        value="dismissible-sm-variant"
         onDismiss={jest.fn()}
       />
     )

--- a/lib/src/components/banner/banner-regular/BannerRegular.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegular.tsx
@@ -20,12 +20,11 @@ export const BannerRegular: React.FC<
   Image: typeof BannerRegularImage
   Button: typeof BannerRegularButton
   Dismiss: typeof BannerRegularDismiss
-} = ({ colorScheme, size, emphasis, value, onDismiss, ...rest }) => {
+} = ({ colorScheme, size, emphasis, onDismiss, ...rest }) => {
   return (
     <Banner size={size} emphasis={emphasis}>
       <BannerRegularContainer
         colorScheme={colorScheme}
-        value={value}
         onDismiss={onDismiss}
         {...rest}
       />

--- a/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
+++ b/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
@@ -1227,7 +1227,6 @@ exports[`BannerRegular component renders dismissible variant 1`] = `
   <div
     class="c-dhzjXW c-bRupYu c-bRupYu-cobKBi-emphasis-bold t-grLKLB"
     role="banner"
-    value="dismissible-sm-variant"
   >
     <div
       class="c-PJLV c-gjbGPV c-gjbGPV-lppGPL-size-sm c-gjbGPV-iOglxG-size-md"

--- a/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
+++ b/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
@@ -1227,6 +1227,7 @@ exports[`BannerRegular component renders dismissible variant 1`] = `
   <div
     class="c-dhzjXW c-bRupYu c-bRupYu-cobKBi-emphasis-bold t-grLKLB"
     role="banner"
+    value="dismissible-sm-variant"
   >
     <div
       class="c-PJLV c-gjbGPV c-gjbGPV-lppGPL-size-sm c-gjbGPV-iOglxG-size-md"

--- a/lib/src/components/banner/banner-slim/BannerSlim.test.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlim.test.tsx
@@ -8,7 +8,7 @@ import { BannerSlim } from './'
 const BannerSlimImplementation: React.FC<
   React.ComponentProps<typeof BannerSlim>
 > = ({ children, ...props }) => (
-  <BannerSlim value="" {...props}>
+  <BannerSlim {...props}>
     <BannerSlim.Content>
       <BannerSlim.Image src="https://picsum.photos/400/400" alt="image" />
       <BannerSlim.Text>
@@ -48,7 +48,6 @@ describe(`BannerSlim component`, () => {
       <BannerSlimDismissibleImplementation
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
-        value="dismissible-sm-variant"
         onDismiss={onDismiss}
       />
     )
@@ -66,7 +65,6 @@ describe(`BannerSlim component`, () => {
         colorScheme={{ base: 'purple1' }}
         size="sm"
         emphasis="bold"
-        value="sm-variant"
       />
     )
     expect(container).toMatchSnapshot()
@@ -78,7 +76,6 @@ describe(`BannerSlim component`, () => {
         colorScheme={{ base: 'purple1' }}
         emphasis="bold"
         size="sm"
-        value="dismissible-sm-variant"
         onDismiss={jest.fn()}
       />
     )

--- a/lib/src/components/banner/banner-slim/BannerSlim.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlim.tsx
@@ -20,12 +20,11 @@ export const BannerSlim: React.FC<
   Button: typeof BannerSlimButton
   Dismiss: typeof BannerSlimDismiss
   Actions: typeof BannerSlimActions
-} = ({ colorScheme, size, emphasis, value, onDismiss, ...rest }) => {
+} = ({ colorScheme, size, emphasis, onDismiss, ...rest }) => {
   return (
     <Banner size={size} emphasis={emphasis}>
       <BannerSlimContainer
         colorScheme={colorScheme}
-        value={value}
         onDismiss={onDismiss}
         {...rest}
       />

--- a/lib/src/components/dismissible-group/DismissibleGroupItem.tsx
+++ b/lib/src/components/dismissible-group/DismissibleGroupItem.tsx
@@ -7,11 +7,13 @@ import { DismissibleGroupContext } from './DismissibleGroupRoot'
 export type TDismissibleGroupItemProps = React.ComponentProps<
   typeof Dismissible
 > & {
+  value: React.ReactText
   disabled?: boolean
 }
 
 export const DismissibleGroupItem: React.FC<TDismissibleGroupItemProps> = ({
   children,
+  value,
   disabled: itemDisabled = false,
   ...rest
 }) => {
@@ -25,7 +27,7 @@ export const DismissibleGroupItem: React.FC<TDismissibleGroupItemProps> = ({
   return (
     <Dismissible
       disabled={groupDisabled || itemDisabled}
-      onDismiss={onDismiss}
+      onDismiss={() => onDismiss(value)}
       {...rest}
     >
       {children}

--- a/lib/src/components/dismissible-group/DismissibleGroupItem.tsx
+++ b/lib/src/components/dismissible-group/DismissibleGroupItem.tsx
@@ -27,8 +27,8 @@ export const DismissibleGroupItem: React.FC<TDismissibleGroupItemProps> = ({
   return (
     <Dismissible
       disabled={groupDisabled || itemDisabled}
-      onDismiss={() => onDismiss(value)}
       {...rest}
+      onDismiss={() => onDismiss(value)}
     >
       {children}
     </Dismissible>

--- a/lib/src/components/dismissible/Dismissible.test.tsx
+++ b/lib/src/components/dismissible/Dismissible.test.tsx
@@ -5,17 +5,17 @@ import * as React from 'react'
 
 import { Dismissible } from '.'
 
-const mockOnDismiss = jest.fn((value) => null)
+const mockOnDismiss = jest.fn(() => null)
 
 const DismissibleImplementation = () => (
-  <Dismissible value="a" onDismiss={mockOnDismiss} data-testid="root">
+  <Dismissible onDismiss={mockOnDismiss} data-testid="root">
     A
     <Dismissible.Trigger data-testid="trigger" />
   </Dismissible>
 )
 
 const DismissibleImplementationCustomOverrides = () => (
-  <Dismissible value="a" onDismiss={mockOnDismiss} asChild>
+  <Dismissible onDismiss={mockOnDismiss} asChild>
     <div data-testid="custom-root">
       A
       <Dismissible.Trigger asChild>
@@ -56,13 +56,13 @@ describe('Dismissible component', () => {
     expect(root).not.toBeVisible()
   })
 
-  it('when dismissed calls the onDismiss function with the correct value', async () => {
+  it('when dismissed calls the onDismiss function', async () => {
     render(<DismissibleImplementation />)
 
     const trigger = screen.getByTestId('trigger')
     if (trigger) fireEvent.click(trigger)
 
-    expect(mockOnDismiss).toBeCalledWith('a')
+    expect(mockOnDismiss).toBeCalled()
   })
 
   describe('when it is using custom component overrides', () => {

--- a/lib/src/components/dismissible/DismissibleRoot.tsx
+++ b/lib/src/components/dismissible/DismissibleRoot.tsx
@@ -33,7 +33,9 @@ export const DismissibleRootProvider: React.FC<IDismissibleRootProps> = ({
     const isControlled = typeof controlledIsDismissed === 'boolean'
     return {
       disabled,
-      isDismissed: isControlled ? controlledIsDismissed : isDismissed,
+      isDismissed: isControlled
+        ? (controlledIsDismissed as boolean)
+        : isDismissed,
       setIsDismissed: isControlled ? () => null : setIsDismissed,
       onDismiss
     }
@@ -46,12 +48,12 @@ export const DismissibleRootProvider: React.FC<IDismissibleRootProps> = ({
   )
 }
 
-export interface IDismissibleGroupItemProps {
+export interface IDismissibleProps {
   asChild?: boolean
   onDismiss?: () => void
 }
 
-const DismissibleRootInternal: React.FC<IDismissibleGroupItemProps> = ({
+const DismissibleRootInternal: React.FC<IDismissibleProps> = ({
   asChild = false,
   ...rest
 }) => {
@@ -67,7 +69,7 @@ const DismissibleRootInternal: React.FC<IDismissibleGroupItemProps> = ({
 }
 
 export const DismissibleRoot: React.FC<
-  IDismissibleGroupItemProps & IDismissibleRootProps
+  IDismissibleProps & IDismissibleRootProps
 > = ({ disabled = false, dismissed, onDismiss, ...rest }) => (
   <DismissibleRootProvider
     dismissed={dismissed}

--- a/lib/src/components/dismissible/DismissibleRoot.tsx
+++ b/lib/src/components/dismissible/DismissibleRoot.tsx
@@ -35,13 +35,11 @@ export const DismissibleRootProvider: React.FC<IDismissibleRootProps> = ({
 
 export interface IDismissibleGroupItemProps {
   asChild?: boolean
-  value: React.ReactText
-  onDismiss?: (value: React.ReactText) => void
+  onDismiss?: () => void
 }
 
 const DismissibleRootInternal: React.FC<IDismissibleGroupItemProps> = ({
   asChild = false,
-  value,
   onDismiss,
   ...rest
 }) => {
@@ -50,7 +48,7 @@ const DismissibleRootInternal: React.FC<IDismissibleGroupItemProps> = ({
   const { isDismissed, disabled } = rootContext
 
   React.useEffect(() => {
-    if (isDismissed) onDismiss?.(value)
+    if (isDismissed) onDismiss?.()
   }, [isDismissed])
 
   if (isDismissed) return null

--- a/lib/src/components/dismissible/DismissibleRoot.tsx
+++ b/lib/src/components/dismissible/DismissibleRoot.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 export interface IDismissibleRootContext {
   disabled?: boolean
   isDismissed: boolean
-  setIsDismissed: (boolean) => void,
+  setIsDismissed: (boolean) => void
   onDismiss: () => void
 }
 
@@ -16,8 +16,8 @@ export const DismissibleRootContext =
   })
 
 export interface IDismissibleRootProps {
-  disabled?: boolean,
-  dismissed?: boolean,
+  disabled?: boolean
+  dismissed?: boolean
   onDismiss: () => void
 }
 
@@ -28,17 +28,16 @@ export const DismissibleRootProvider: React.FC<IDismissibleRootProps> = ({
   onDismiss
 }) => {
   const [isDismissed, setIsDismissed] = React.useState(false)
-  const isControlled = typeof controlledIsDismissed === 'boolean'
 
-  const value = React.useMemo<IDismissibleRootContext>(
-    () => ({
+  const value = React.useMemo<IDismissibleRootContext>(() => {
+    const isControlled = typeof controlledIsDismissed === 'boolean'
+    return {
       disabled,
       isDismissed: isControlled ? controlledIsDismissed : isDismissed,
       setIsDismissed: isControlled ? () => null : setIsDismissed,
       onDismiss
-    }),
-    [disabled, isDismissed, onDismiss, controlledIsDismissed, isControlled]
-  )
+    }
+  }, [disabled, isDismissed, onDismiss, controlledIsDismissed])
 
   return (
     <DismissibleRootContext.Provider value={value}>
@@ -70,7 +69,11 @@ const DismissibleRootInternal: React.FC<IDismissibleGroupItemProps> = ({
 export const DismissibleRoot: React.FC<
   IDismissibleGroupItemProps & IDismissibleRootProps
 > = ({ disabled = false, dismissed, onDismiss, ...rest }) => (
-  <DismissibleRootProvider dismissed={dismissed} disabled={disabled} onDismiss={onDismiss}>
+  <DismissibleRootProvider
+    dismissed={dismissed}
+    disabled={disabled}
+    onDismiss={onDismiss}
+  >
     <DismissibleRootInternal {...rest} />
   </DismissibleRootProvider>
 )

--- a/lib/src/components/dismissible/DismissibleTrigger.tsx
+++ b/lib/src/components/dismissible/DismissibleTrigger.tsx
@@ -24,10 +24,11 @@ export const DismissibleTrigger: React.FC<IDismissibleTriggerProps> = ({
     )
   }
 
-  const { setIsDismissed, disabled } = context
+  const { setIsDismissed, disabled, onDismiss } = context
 
   const handleDismiss = () => {
     setIsDismissed(true)
+    onDismiss?.()
   }
 
   const props = {


### PR DESCRIPTION
A couple of tweaks to the Dismissible component:
* [as requested,](https://github.com/Atom-Learning/components/pull/600#pullrequestreview-1745767535) removes unnecessary prop of `value` from the base Dismissible
* ...but re-adds it on the DismissibleGroupItem where it actually makes sense
* allows Dismissible to be controlled: This is needed for the Banner component preview where we don't want editors to be dismissing the banner - well now with a prop we can keep it always there
* update components which use dismissible to new props setup

**No visual changes.**