### PR TITLE
fix: need to omit defaultChecked from Box so HTMLElement boolean type…

### DIFF
--- a/lib/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/lib/src/components/checkbox-group/CheckboxGroup.tsx
@@ -13,7 +13,7 @@ import { CheckboxGroupAllItem } from './CheckboxGroupAllItem'
 import { CheckboxGroupItem } from './CheckboxGroupItem'
 import { CheckboxGroupSub } from './CheckboxGroupSub'
 
-type CheckboxGroupRootProps = React.ComponentProps<typeof Box> & {
+type CheckboxGroupRootProps = Omit<React.ComponentProps<typeof Box>, 'defaultChecked'> & {
   checked?: CheckboxGroupItemValue[]
   onCheckedChange?: (checked: CheckboxGroupItemValue[]) => void
   defaultChecked?: CheckboxGroupItemValue[]


### PR DESCRIPTION
… is not picked up

I love typescript and nothing suspicious is happening with types at all. Anyway this fixes this wrong type:

testing via:
`type Test = CheckboxGroupRootProps['defaultChecked']`

**before:**
<img width="536" alt="Screenshot 2024-01-10 at 13 40 03" src="https://github.com/Atom-Learning/components/assets/6905473/8c154c3c-be05-439d-a315-3b96e6539386">

**after:**
<img width="556" alt="Screenshot 2024-01-10 at 13 39 43" src="https://github.com/Atom-Learning/components/assets/6905473/0673ce09-0600-4ff9-be11-9b14c564359c">
