### PR TITLE
fix: stray uses of color $primary which had not been replaced

### DIFF
--- a/lib/CONTRIBUTING.md
+++ b/lib/CONTRIBUTING.md
@@ -119,7 +119,7 @@ const ComposedComponent = ({ css }) => (
     <Box css={{ mb: '$3' }}>
       The styling of these boxes is ComposedComponent's responsibility
     </Box>
-    <Box css={{ color: '$primary' }}>
+    <Box css={{ color: '$primary800' }}>
       If we want to combine boxes differently, we can compose a new component
     </Box>
   </CSSWrapper>

--- a/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`Accordion component renders an accordion 1`] = `
     transform: rotate(0deg);
   }
 
-  .c-dkSJnW {
+  .c-cHXTzy {
     border: 0;
     padding-top: var(--space-3);
     padding-bottom: var(--space-3);
@@ -317,29 +317,29 @@ exports[`Accordion component renders an accordion 1`] = `
     color: var(--colors-interactiveForeground);
   }
 
-  .c-dkSJnW[data-disabled] {
+  .c-cHXTzy[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-dkSJnW:not([data-disabled]):active,
-  .c-dkSJnW:not([data-disabled]):hover,
-  .c-dkSJnW:not([data-disabled]):focus-visible {
+  .c-cHXTzy:not([data-disabled]):active,
+  .c-cHXTzy:not([data-disabled]):hover,
+  .c-cHXTzy:not([data-disabled]):focus-visible {
     background: var(--colors-interactive3);
   }
 
-  .c-dkSJnW:not([data-disabled]):focus-visible {
+  .c-cHXTzy:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-dkSJnW[data-state="open"] {
+  .c-cHXTzy[data-state="open"] {
     border-radius: var(--radii-0) var(--radii-0) 0 0;
   }
 
-  .c-dkSJnW[data-state="closed"] {
+  .c-cHXTzy[data-state="closed"] {
     border-radius: var(--radii-0);
   }
 
@@ -399,7 +399,7 @@ exports[`Accordion component renders an accordion 1`] = `
         aria-controls="radix-0"
         aria-disabled="true"
         aria-expanded="true"
-        class="c-dkSJnW t-dVJiaJ t-hwCMvs"
+        class="c-cHXTzy t-dVJiaJ t-hwCMvs"
         data-radix-collection-item=""
         data-state="open"
         id="radix-1"
@@ -435,7 +435,7 @@ exports[`Accordion component renders an accordion 1`] = `
       <button
         aria-controls="radix-2"
         aria-expanded="false"
-        class="c-dkSJnW t-dVJiaJ t-hwCMvs"
+        class="c-cHXTzy t-dVJiaJ t-hwCMvs"
         data-radix-collection-item=""
         data-state="closed"
         id="radix-3"

--- a/lib/src/components/chip-toggle-group/__snapshots__/ChipToggleGroup.test.tsx.snap
+++ b/lib/src/components/chip-toggle-group/__snapshots__/ChipToggleGroup.test.tsx.snap
@@ -53,35 +53,35 @@ exports[`ChipToggleGroup component renders 1`] = `
     margin-right: var(--space-1);
   }
 
-  .c-bJgJhs:not([disabled]) {
+  .c-bxUhlk:not([disabled]) {
     cursor: pointer;
   }
 
-  .c-bJgJhs:not([disabled]):hover {
+  .c-bxUhlk:not([disabled]):hover {
     background: var(--colors-tonal100);
     color: var(--colors-tonal600);
     border-color: currentColor;
   }
 
-  .c-bJgJhs:not([disabled]):focus-visible {
+  .c-bxUhlk:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-bJgJhs:not([disabled])[data-state="on"]:hover {
+  .c-bxUhlk:not([disabled])[data-state="on"]:hover {
     background: var(--colors-white);
     color: var(--colors-primary1000);
   }
 
-  .c-bJgJhs[data-state="off"] {
+  .c-bxUhlk[data-state="off"] {
     color: var(--colors-tonal400);
     background: var(--colors-tonal50);
     border-color: var(--colors-tonal200);
   }
 
-  .c-bJgJhs[data-state="on"] .c-kBYYkb {
+  .c-bxUhlk[data-state="on"] .c-kBYYkb {
     display: block;
   }
 }
@@ -135,7 +135,7 @@ exports[`ChipToggleGroup component renders 1`] = `
   >
     <button
       aria-pressed="true"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bJgJhs"
+      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bxUhlk"
       data-orientation="horizontal"
       data-radix-collection-item=""
       data-state="on"
@@ -160,7 +160,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bJgJhs"
+      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bxUhlk"
       data-disabled=""
       data-orientation="horizontal"
       data-radix-collection-item=""
@@ -187,7 +187,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bJgJhs"
+      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bxUhlk"
       data-orientation="horizontal"
       data-radix-collection-item=""
       data-state="off"
@@ -212,7 +212,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bJgJhs"
+      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-bxUhlk"
       data-disabled=""
       data-orientation="horizontal"
       data-radix-collection-item=""

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`NavigationMenuVertical renders 1`] = `
     line-height: 1.2;
   }
 
-  .c-bcEwPX {
+  .c-rTOZb {
     padding: var(--space-2);
     border: none;
     outline: none;
@@ -306,34 +306,34 @@ exports[`NavigationMenuVertical renders 1`] = `
     --navigation-menu-vertical-item-font-weight: 400;
   }
 
-  .c-bcEwPX[data-active] {
+  .c-rTOZb[data-active] {
     background: var(--colors-backgroundSelected);
     color: var(--colors-textSelected);
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-bcEwPX[data-state=open] {
+  .c-rTOZb[data-state=open] {
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-bcEwPX[data-disabled] {
+  .c-rTOZb[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bcEwPX:not([data-disabled]):hover {
+  .c-rTOZb:not([data-disabled]):hover {
     background: var(--colors-backgroundHover);
   }
 
-  .c-bcEwPX:not([data-disabled]):active {
+  .c-rTOZb:not([data-disabled]):active {
     background: var(--colors-backgroundActive);
   }
 
-  .c-bcEwPX:not([data-disabled]):focus-visible {
+  .c-rTOZb:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
   .c-hYRCfV {
@@ -390,7 +390,7 @@ exports[`NavigationMenuVertical renders 1`] = `
     display: table;
   }
 
-  .c-bcEwPX-jLELKD-size-lg {
+  .c-rTOZb-jLELKD-size-lg {
     min-height: var(--sizes-5);
   }
 }
@@ -414,7 +414,7 @@ exports[`NavigationMenuVertical renders 1`] = `
       >
         <button
           aria-current="page"
-          class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+          class="c-rTOZb c-rTOZb-jLELKD-size-lg"
           data-active=""
           data-radix-collection-item=""
           type="button"
@@ -434,7 +434,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+          class="c-rTOZb c-rTOZb-jLELKD-size-lg"
           data-radix-collection-item=""
           href="/somewhere"
         >
@@ -453,7 +453,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+          class="c-rTOZb c-rTOZb-jLELKD-size-lg"
           data-radix-collection-item=""
           href="http://google.com"
           rel="noopener noreferrer"
@@ -763,7 +763,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     line-height: 1.2;
   }
 
-  .c-bcEwPX {
+  .c-rTOZb {
     padding: var(--space-2);
     border: none;
     outline: none;
@@ -781,34 +781,34 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     --navigation-menu-vertical-item-font-weight: 400;
   }
 
-  .c-bcEwPX[data-active] {
+  .c-rTOZb[data-active] {
     background: var(--colors-backgroundSelected);
     color: var(--colors-textSelected);
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-bcEwPX[data-state=open] {
+  .c-rTOZb[data-state=open] {
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-bcEwPX[data-disabled] {
+  .c-rTOZb[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bcEwPX:not([data-disabled]):hover {
+  .c-rTOZb:not([data-disabled]):hover {
     background: var(--colors-backgroundHover);
   }
 
-  .c-bcEwPX:not([data-disabled]):active {
+  .c-rTOZb:not([data-disabled]):active {
     background: var(--colors-backgroundActive);
   }
 
-  .c-bcEwPX:not([data-disabled]):focus-visible {
+  .c-rTOZb:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
   .c-hYRCfV {
@@ -883,7 +883,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     display: table;
   }
 
-  .c-bcEwPX-jLELKD-size-lg {
+  .c-rTOZb-jLELKD-size-lg {
     min-height: var(--sizes-5);
   }
 
@@ -922,7 +922,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
         >
           <button
             aria-current="page"
-            class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+            class="c-rTOZb c-rTOZb-jLELKD-size-lg"
             data-active=""
             data-radix-collection-item=""
             type="button"
@@ -942,7 +942,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+            class="c-rTOZb c-rTOZb-jLELKD-size-lg"
             data-radix-collection-item=""
             href="/somewhere"
           >
@@ -961,7 +961,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+            class="c-rTOZb c-rTOZb-jLELKD-size-lg"
             data-radix-collection-item=""
             href="http://google.com"
             rel="noopener noreferrer"
@@ -985,7 +985,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           <button
             aria-controls="radix-0"
             aria-expanded="true"
-            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-bcEwPX c-bcEwPX-jLELKD-size-lg"
+            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-rTOZb c-rTOZb-jLELKD-size-lg"
             data-radix-collection-item=""
             data-state="open"
             data-testid="accordion-trigger"

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-fznDru {
+  .c-fmWFdu {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -350,24 +350,24 @@ exports[`Pagination component renders 1`] = `
     position: relative;
   }
 
-  .c-fznDru:not(:disabled):hover {
+  .c-fmWFdu:not(:disabled):hover {
     color: var(--colors-accent10);
     background: var(--colors-base2);
   }
 
-  .c-fznDru:not(:disabled):active {
+  .c-fmWFdu:not(:disabled):active {
     background: var(--colors-base3);
     color: var(--colors-grey1000);
   }
 
-  .c-fznDru:not(:disabled):focus-visible {
+  .c-fmWFdu:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-fznDru:disabled {
+  .c-fmWFdu:disabled {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -440,23 +440,23 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-fznDru-cVoMNQ-size-md {
+  .c-fmWFdu-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-fznDru-bxzneo-selected-true {
+  .c-fmWFdu-bxzneo-selected-true {
     border: 1px solid var(--colors-accent9);
     color: var(--colors-accent9);
     font-weight: 600;
   }
 
-  .c-fznDru-bxzneo-selected-true:not(:disabled):hover {
+  .c-fmWFdu-bxzneo-selected-true:not(:disabled):hover {
     border-color: var(--colors-accent10);
     color: var(--colors-accent10);
   }
 
-  .c-fznDru-bxzneo-selected-true:not(:disabled):active {
+  .c-fmWFdu-bxzneo-selected-true:not(:disabled):active {
     border-color: var(--colors-accent11);
     font-color: var(--accent11);
   }
@@ -506,14 +506,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-fznDru c-fznDru-cVoMNQ-size-md c-fznDru-bxzneo-selected-true"
+      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md c-fmWFdu-bxzneo-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-fznDru c-fznDru-cVoMNQ-size-md"
+      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md"
     >
       2
     </button>
@@ -553,7 +553,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-fznDru c-fznDru-cVoMNQ-size-md"
+      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/stepper/StepperStepContainer.tsx
+++ b/lib/src/components/stepper/StepperStepContainer.tsx
@@ -97,7 +97,7 @@ export const StepperStepContainer = styled(Flex, {
         },
         '&:focus-visible': {
           '& :first-child': {
-            outline: '2px solid $primary !important',
+            outline: '2px solid $primary800 !important',
             outlineOffset: '2px !important'
           }
         }
@@ -109,7 +109,7 @@ export const StepperStepContainer = styled(Flex, {
       css: {
         '&:focus-visible': {
           '& :first-child': {
-            outline: '2px solid $primary !important',
+            outline: '2px solid $primary800 !important',
             outlineOffset: '2px !important'
           }
         }

--- a/lib/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/lib/src/components/stepper/__snapshots__/Stepper.test.tsx.snap
@@ -229,22 +229,22 @@ exports[`Stepper renders correctly with default direction changed 1`] = `
     outline-offset: 2px;
   }
 
-  .c-boNUgq-iIblYT-cv:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
+  .c-boNUgq-hfecOD-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary800) !important;
     outline-offset: 2px !important;
   }
 
-  .c-boNUgq-fCshQK-cv:hover :first-child {
+  .c-boNUgq-gAJIna-cv:hover :first-child {
     border-color: var(--colors-tonal400);
     color: var(--colors-tonal600);
   }
 
-  .c-boNUgq-fCshQK-cv:hover :last-child {
+  .c-boNUgq-gAJIna-cv:hover :last-child {
     color: var(--colors-tonal600);
   }
 
-  .c-boNUgq-fCshQK-cv:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
+  .c-boNUgq-gAJIna-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary800) !important;
     outline-offset: 2px !important;
   }
 }
@@ -602,22 +602,22 @@ exports[`Stepper renders success icon for bullets when step is completed 1`] = `
     outline-offset: 2px;
   }
 
-  .c-boNUgq-iIblYT-cv:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
+  .c-boNUgq-hfecOD-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary800) !important;
     outline-offset: 2px !important;
   }
 
-  .c-boNUgq-fCshQK-cv:hover :first-child {
+  .c-boNUgq-gAJIna-cv:hover :first-child {
     border-color: var(--colors-tonal400);
     color: var(--colors-tonal600);
   }
 
-  .c-boNUgq-fCshQK-cv:hover :last-child {
+  .c-boNUgq-gAJIna-cv:hover :last-child {
     color: var(--colors-tonal600);
   }
 
-  .c-boNUgq-fCshQK-cv:focus-visible :first-child {
-    outline: 2px solid var(--colors-primary) !important;
+  .c-boNUgq-gAJIna-cv:focus-visible :first-child {
+    outline: 2px solid var(--colors-primary800) !important;
     outline-offset: 2px !important;
   }
 }

--- a/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -315,7 +315,7 @@ exports[`Tabs component renders 1`] = `
     background: var(--colors-interactive1);
   }
 
-  .c-fxTTrv {
+  .c-cDgrSH {
     background: none;
     border: none;
     cursor: pointer;
@@ -327,37 +327,37 @@ exports[`Tabs component renders 1`] = `
     position: relative;
   }
 
-  .c-fxTTrv[data-state="active"] {
+  .c-cDgrSH[data-state="active"] {
     color: var(--colors-interactive1);
     font-weight: 600;
     letter-spacing: -0.005em;
     border-color: currentColor;
   }
 
-  .c-fxTTrv[data-disabled] {
+  .c-cDgrSH[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-fxTTrv:not([data-disabled]):hover,
-  .c-fxTTrv:not([data-disabled]):focus-visible {
+  .c-cDgrSH:not([data-disabled]):hover,
+  .c-cDgrSH:not([data-disabled]):focus-visible {
     color: var(--colors-interactive2);
   }
 
-  .c-fxTTrv:not([data-disabled]):hover .c-iPskiL,
-  .c-fxTTrv:not([data-disabled]):focus-visible .c-iPskiL {
+  .c-cDgrSH:not([data-disabled]):hover .c-iPskiL,
+  .c-cDgrSH:not([data-disabled]):focus-visible .c-iPskiL {
     opacity: 0.07;
   }
 
-  .c-fxTTrv:not([data-disabled]):active {
+  .c-cDgrSH:not([data-disabled]):active {
     color: var(--colors-interactive3);
   }
 
-  .c-fxTTrv:not([data-disabled]):focus-visible {
+  .c-cDgrSH:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
   .c-gZZKZD {
@@ -430,7 +430,7 @@ exports[`Tabs component renders 1`] = `
         <button
           aria-controls="radix-3-content-tab1"
           aria-selected="true"
-          class="c-fxTTrv"
+          class="c-cDgrSH"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -451,7 +451,7 @@ exports[`Tabs component renders 1`] = `
         <button
           aria-controls="radix-3-content-tab2"
           aria-selected="false"
-          class="c-fxTTrv"
+          class="c-cDgrSH"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"
@@ -472,7 +472,7 @@ exports[`Tabs component renders 1`] = `
         <button
           aria-controls="radix-3-content-tab3"
           aria-selected="false"
-          class="c-fxTTrv"
+          class="c-cDgrSH"
           data-disabled=""
           data-orientation="horizontal"
           data-radix-collection-item=""

--- a/lib/src/components/tile-interactive/__snapshots__/TileInteractive.test.tsx.snap
+++ b/lib/src/components/tile-interactive/__snapshots__/TileInteractive.test.tsx.snap
@@ -308,18 +308,18 @@ exports[`TileInteractive component renders 1`] = `
     border-color: transparent;
   }
 
-  .c-bZTcGT[data-disabled] {
+  .c-bZdTZj[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bZTcGT:not([data-disabled]) {
+  .c-bZdTZj:not([data-disabled]) {
     cursor: pointer;
     transform: translateY(0);
     transition: transform 250ms ease;
   }
 
-  .c-bZTcGT:not([data-disabled])::after {
+  .c-bZdTZj:not([data-disabled])::after {
     content: "";
     position: absolute;
     inset: 0;
@@ -329,28 +329,28 @@ exports[`TileInteractive component renders 1`] = `
     border-radius: inherit;
   }
 
-  .c-bZTcGT:not([data-disabled]):hover {
+  .c-bZdTZj:not([data-disabled]):hover {
     transform: translateY(calc(var(--space-0)*-1));
   }
 
-  .c-bZTcGT:not([data-disabled]):hover::after {
+  .c-bZdTZj:not([data-disabled]):hover::after {
     opacity: 1;
   }
 
-  .c-bZTcGT:not([data-disabled]):active {
+  .c-bZdTZj:not([data-disabled]):active {
     background: var(--colors-base2);
   }
 
-  .c-bZTcGT:not([data-disabled]):focus-visible {
+  .c-bZdTZj:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 }
 
 @media  {
-  .c-bZTcGT-iMShsb-css {
+  .c-bZdTZj-iMShsb-css {
     margin: auto;
     height: 100px;
     width: 100px;
@@ -359,7 +359,7 @@ exports[`TileInteractive component renders 1`] = `
 
 <div>
   <button
-    class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZTcGT c-bZTcGT-iMShsb-css"
+    class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZdTZj c-bZdTZj-iMShsb-css"
     type="button"
   >
     A

--- a/lib/src/components/tile-toggle-group/__snapshots__/TileToggleGroup.test.tsx.snap
+++ b/lib/src/components/tile-toggle-group/__snapshots__/TileToggleGroup.test.tsx.snap
@@ -312,18 +312,18 @@ exports[`TileToggleGroup component renders 1`] = `
     border-color: transparent;
   }
 
-  .c-bZTcGT[data-disabled] {
+  .c-bZdTZj[data-disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bZTcGT:not([data-disabled]) {
+  .c-bZdTZj:not([data-disabled]) {
     cursor: pointer;
     transform: translateY(0);
     transition: transform 250ms ease;
   }
 
-  .c-bZTcGT:not([data-disabled])::after {
+  .c-bZdTZj:not([data-disabled])::after {
     content: "";
     position: absolute;
     inset: 0;
@@ -333,23 +333,23 @@ exports[`TileToggleGroup component renders 1`] = `
     border-radius: inherit;
   }
 
-  .c-bZTcGT:not([data-disabled]):hover {
+  .c-bZdTZj:not([data-disabled]):hover {
     transform: translateY(calc(var(--space-0)*-1));
   }
 
-  .c-bZTcGT:not([data-disabled]):hover::after {
+  .c-bZdTZj:not([data-disabled]):hover::after {
     opacity: 1;
   }
 
-  .c-bZTcGT:not([data-disabled]):active {
+  .c-bZdTZj:not([data-disabled]):active {
     background: var(--colors-base2);
   }
 
-  .c-bZTcGT:not([data-disabled]):focus-visible {
+  .c-bZdTZj:not([data-disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
   .c-SVNbK:not([disabled])[data-state="on"]:hover {
@@ -395,7 +395,7 @@ exports[`TileToggleGroup component renders 1`] = `
   >
     <button
       aria-pressed="true"
-      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZdTZj c-SVNbK"
       data-radix-collection-item=""
       data-state="on"
       tabindex="-1"
@@ -405,7 +405,7 @@ exports[`TileToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZdTZj c-SVNbK"
       data-disabled=""
       data-radix-collection-item=""
       data-state="on"
@@ -417,7 +417,7 @@ exports[`TileToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZdTZj c-SVNbK"
       data-radix-collection-item=""
       data-state="off"
       tabindex="-1"
@@ -427,7 +427,7 @@ exports[`TileToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZTcGT c-SVNbK"
+      class="c-htDHry t-dVJiaJ t-bFCOZb t-dmfxVJ c-bZdTZj c-SVNbK"
       data-disabled=""
       data-radix-collection-item=""
       data-state="off"

--- a/lib/src/components/toggle-group/__snapshots__/ToggleGroup.test.tsx.snap
+++ b/lib/src/components/toggle-group/__snapshots__/ToggleGroup.test.tsx.snap
@@ -6,49 +6,49 @@ exports[`ToggleGroup renders 1`] = `
     display: flex;
   }
 
-  .c-fdTLEV {
+  .c-kpcTGN {
     background: white;
     color: var(--colors-tonal400);
     border: 1px solid var(--colors-tonal200);
     cursor: pointer;
   }
 
-  .c-fdTLEV::before {
+  .c-kpcTGN::before {
     background: var(--colors-tonal200);
   }
 
-  .c-fdTLEV:not([disabled]):hover::before,
-  .c-fdTLEV:not([disabled]):focus-visible::before,
-  .c-fdTLEV:not([disabled])[data-state="on"]::before {
+  .c-kpcTGN:not([disabled]):hover::before,
+  .c-kpcTGN:not([disabled]):focus-visible::before,
+  .c-kpcTGN:not([disabled])[data-state="on"]::before {
     background: none;
   }
 
-  .c-fdTLEV:not([disabled]):hover {
+  .c-kpcTGN:not([disabled]):hover {
     border-color: currentColor !important;
     color: var(--colors-primary900);
   }
 
-  .c-fdTLEV:not([disabled]):focus-visible {
+  .c-kpcTGN:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
-    box-shadow: white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-fdTLEV:not([disabled]):focus-visible[data-state="off"] {
+  .c-kpcTGN:not([disabled]):focus-visible[data-state="off"] {
     border-color: var(--colors-tonal200) !important;
   }
 
-  .c-fdTLEV:not([disabled]):focus-visible[data-state="on"] {
-    box-shadow: inset currentColor 0px 0px 0px 1px, white 0px 0px 0px 2px, var(--colors-primary) 0px 0px 0px 4px;
+  .c-kpcTGN:not([disabled]):focus-visible[data-state="on"] {
+    box-shadow: inset currentColor 0px 0px 0px 1px, white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-fdTLEV[disabled] {
+  .c-kpcTGN[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-fdTLEV[data-state="on"] {
+  .c-kpcTGN[data-state="on"] {
     color: var(--colors-primary800);
     border-color: currentColor !important;
     box-shadow: inset currentColor 0px 0px 0px 1px;
@@ -110,14 +110,14 @@ exports[`ToggleGroup renders 1`] = `
     stroke-width: 1.5;
   }
 
-  .c-flWDnm-SpZMc-hasGap-true .c-fdTLEV {
+  .c-flWDnm-TsEJk-hasGap-true .c-kpcTGN {
     border-radius: var(--radii-0);
   }
 }
 
 <div>
   <div
-    class="c-flWDnm c-flWDnm-SpZMc-hasGap-true"
+    class="c-flWDnm c-flWDnm-TsEJk-hasGap-true"
     data-orientation="vertical"
     dir="ltr"
     role="group"
@@ -129,7 +129,7 @@ exports[`ToggleGroup renders 1`] = `
     >
       <button
         aria-pressed="true"
-        class="c-fdTLEV"
+        class="c-kpcTGN"
         data-disabled=""
         data-orientation="vertical"
         data-radix-collection-item=""
@@ -142,7 +142,7 @@ exports[`ToggleGroup renders 1`] = `
       </button>
       <button
         aria-pressed="true"
-        class="c-fdTLEV c-cepAPw c-cepAPw-fKibdn-size-sm"
+        class="c-kpcTGN c-cepAPw c-cepAPw-fKibdn-size-sm"
         data-disabled=""
         data-orientation="vertical"
         data-radix-collection-item=""
@@ -163,7 +163,7 @@ exports[`ToggleGroup renders 1`] = `
       </button>
       <button
         aria-pressed="false"
-        class="c-fdTLEV c-cepAPw c-cepAPw-fKibdn-size-sm"
+        class="c-kpcTGN c-cepAPw c-cepAPw-fKibdn-size-sm"
         data-orientation="vertical"
         data-radix-collection-item=""
         data-state="off"
@@ -174,7 +174,7 @@ exports[`ToggleGroup renders 1`] = `
       </button>
       <button
         aria-pressed="false"
-        class="c-fdTLEV c-cepAPw c-cepAPw-fKibdn-size-sm"
+        class="c-kpcTGN c-cepAPw c-cepAPw-fKibdn-size-sm"
         data-orientation="vertical"
         data-radix-collection-item=""
         data-state="off"

--- a/lib/src/utilities/style/focus-visible-style-block.ts
+++ b/lib/src/utilities/style/focus-visible-style-block.ts
@@ -1,4 +1,4 @@
-/* 
+/*
   Focus styling for block element.
 */
 
@@ -24,6 +24,6 @@ export const focusVisibleStyleBlock = ({
       ? position
       : 'relative',
     zIndex: zIndex > 1 ? zIndex : 1,
-    boxShadow: 'white 0px 0px 0px 2px, $colors$primary 0px 0px 0px 4px'
+    boxShadow: 'white 0px 0px 0px 2px, $colors$primary800 0px 0px 0px 4px'
   }
 }


### PR DESCRIPTION
Some uses of `$primary` were missed in the previous replacement, particularly the one which does all our focus rings :o

Focus outlines are back on the menu boiz.

**before**
(the first tile is focused can't you tell?)
<img width="629" alt="Screenshot 2024-01-19 at 13 18 35" src="https://github.com/Atom-Learning/components/assets/6905473/5ba7e8a6-e0e0-45f2-bad9-d5cabd1aaeae">


**after**
<img width="692" alt="Screenshot 2024-01-19 at 13 18 24" src="https://github.com/Atom-Learning/components/assets/6905473/d2f470ae-136c-47a0-98e8-ab0f78c18acd">
<img width="639" alt="Screenshot 2024-01-19 at 13 18 50" src="https://github.com/Atom-Learning/components/assets/6905473/a89e06fb-3060-4713-80c5-38bea8421a2b">