### PR TITLE
feat: table header themes update

### DIFF
--- a/documentation/content/components.table.md
+++ b/documentation/content/components.table.md
@@ -170,7 +170,7 @@ tabs:
       ```
 
 
-      `Table.Header` accepts a theme prop, the current available options are `primary`, `primaryDark`, and `light`. The default is `primaryDark`.
+      `Table.Header` accepts a theme prop, the current available options are `primary`, `primaryDark`, `primaryLight`, `white` and `light`. The default is `primaryDark`.
 
 
       ```

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -446,9 +446,9 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
+  .c-PJLV-eSDNKZ-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+    color: var(--colors-grey1000);
   }
 
   .c-PJLV-cevUCR-striped-false .c-hjAYDb {
@@ -1179,9 +1179,9 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
+  .c-PJLV-eSDNKZ-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+    color: var(--colors-grey1000);
   }
 
   .c-PJLV-cevUCR-striped-false .c-hjAYDb {
@@ -1384,7 +1384,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-iPJLV-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gJBDLb-theme-light"
+      class="c-PJLV c-PJLV-eSDNKZ-theme-light"
     >
       <tr
         class="c-hjAYDb"
@@ -2666,9 +2666,9 @@ exports[`DataTable component renders 1`] = `
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
+  .c-PJLV-eSDNKZ-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+    color: var(--colors-grey1000);
   }
 
   .c-PJLV-cevUCR-striped-false .c-hjAYDb {
@@ -2840,7 +2840,7 @@ exports[`DataTable component renders 1`] = `
     class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-illIiIE-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gJBDLb-theme-light"
+      class="c-PJLV c-PJLV-eSDNKZ-theme-light"
     >
       <tr
         class="c-hjAYDb"
@@ -3652,9 +3652,9 @@ exports[`DataTable server-side renders 1`] = `
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
+  .c-PJLV-eSDNKZ-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+    color: var(--colors-grey1000);
   }
 
   .c-PJLV-cevUCR-striped-false .c-hjAYDb {
@@ -4043,7 +4043,7 @@ exports[`DataTable server-side renders 1`] = `
     class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-illIiIE-css"
   >
     <thead
-      class="c-PJLV c-PJLV-gJBDLb-theme-light"
+      class="c-PJLV c-PJLV-eSDNKZ-theme-light"
     >
       <tr
         class="c-hjAYDb"
@@ -4855,9 +4855,9 @@ exports[`DataTable sticky columns renders 1`] = `
     border-bottom-right-radius: var(--radii-0);
   }
 
-  .c-PJLV-gJBDLb-theme-light .c-jhJxGZ {
+  .c-PJLV-eSDNKZ-theme-light .c-jhJxGZ {
     background: var(--colors-tonal50);
-    color: var(--colors-tonal600);
+    color: var(--colors-grey1000);
   }
 
   .c-PJLV-cevUCR-striped-false .c-hjAYDb {
@@ -5164,7 +5164,7 @@ exports[`DataTable sticky columns renders 1`] = `
       class="c-cwQMhQ c-cwQMhQ-urYIk-size-md c-cwQMhQ-fplEaP-corners-round c-cwQMhQ-iPJLV-css"
     >
       <thead
-        class="c-PJLV c-PJLV-gJBDLb-theme-light"
+        class="c-PJLV c-PJLV-eSDNKZ-theme-light"
       >
         <tr
           class="c-hjAYDb"

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -450,12 +450,12 @@ exports[`DateInput component renders lg size 1`] = `
     display: table;
   }
 
-  .c-dOwGHN-hztIub-isToday-true {
-    background: var(--colors-tonal100);
-  }
-
   .c-dOwGHN-huXVXM-isOutsideMonth-true {
     color: var(--colors-tonal200);
+  }
+
+  .c-dOwGHN-hztIub-isToday-true {
+    background: var(--colors-tonal100);
   }
 
   .c-iKnjyA-kUaMfZ-size-md {

--- a/lib/src/components/table/TableHeader.tsx
+++ b/lib/src/components/table/TableHeader.tsx
@@ -10,7 +10,7 @@ export const TABLE_HEADER_THEMES = {
   PRIMARY_LIGHT: 'primaryLight',
   LIGHT: 'light',
   WHITE: 'white'
-}
+} as const
 
 const StyledTableHeader = styled('thead', {
   variants: {

--- a/lib/src/components/table/TableHeader.tsx
+++ b/lib/src/components/table/TableHeader.tsx
@@ -7,7 +7,9 @@ import { TableHeaderCell } from './TableHeaderCell'
 export const TABLE_HEADER_THEMES = {
   PRIMARY: 'primary',
   PRIMARY_DARK: 'primaryDark',
-  LIGHT: 'light'
+  PRIMARY_LIGHT: 'primaryLight',
+  LIGHT: 'light',
+  WHITE: 'white'
 }
 
 const StyledTableHeader = styled('thead', {
@@ -23,10 +25,22 @@ const StyledTableHeader = styled('thead', {
           bg: '$primary1000'
         }
       },
+      [TABLE_HEADER_THEMES.PRIMARY_LIGHT]: {
+        [`${TableHeaderCell}`]: {
+          bg: '$primary200',
+          color: '$grey1000'
+        }
+      },
       [TABLE_HEADER_THEMES.LIGHT]: {
         [`${TableHeaderCell}`]: {
           bg: '$tonal50',
-          color: '$tonal600'
+          color: '$grey1000'
+        }
+      },
+      [TABLE_HEADER_THEMES.WHITE]: {
+        [`${TableHeaderCell}`]: {
+          bg: '$white',
+          color: '$grey1000'
         }
       }
     },


### PR DESCRIPTION
Table component
TableHeader themes additions

- primaryLight
- white

Ticket:  https://atomlearningltd.atlassian.net/browse/NC-442

Screenshots: 

![Zrzut ekranu 2024-02-5 o 09 20 04](https://github.com/Atom-Learning/components/assets/23363033/7fd47a7d-b28c-4679-88ee-a3136de95d05)
![Zrzut ekranu 2024-02-5 o 09 20 26](https://github.com/Atom-Learning/components/assets/23363033/cf1093a3-afb5-4320-9ddc-9444c17b5a0e)

Types improvement :)

**Before:**

- no support for themes type

![Zrzut ekranu 2024-02-5 o 15 11 32](https://github.com/Atom-Learning/components/assets/23363033/2cd2c64e-2f6f-4055-8aa8-9c958dd64651)

**After:**

![Zrzut ekranu 2024-02-5 o 15 13 35](https://github.com/Atom-Learning/components/assets/23363033/f177ace6-aa36-4895-a6c9-c6b3eeadb086)
![Zrzut ekranu 2024-02-5 o 15 13 56](https://github.com/Atom-Learning/components/assets/23363033/c46ce6d3-0959-480c-9350-d3af5966689c)

![Zrzut ekranu 2024-02-5 o 15 47 44](https://github.com/Atom-Learning/components/assets/23363033/ca84ea5c-a245-44ff-a8bc-e20bf0fad989)



