### PR TITLE
fix: section message icon spacing

### DIFF
--- a/lib/src/components/section-message/SectionMessageIcon.tsx
+++ b/lib/src/components/section-message/SectionMessageIcon.tsx
@@ -32,7 +32,7 @@ export const SectionMessageIcon = ({
         m: 'auto',
         position: 'absolute',
         left: '$4',
-        top: '$4',
+        top: 'calc($4 - 2px)',
         color: 'currentColor',
         ...css
       }}

--- a/lib/src/components/section-message/SectionMessageIcon.tsx
+++ b/lib/src/components/section-message/SectionMessageIcon.tsx
@@ -32,7 +32,7 @@ export const SectionMessageIcon = ({
         m: 'auto',
         position: 'absolute',
         left: '$4',
-        top: 'calc($4 - 2px)',
+        top: '$4',
         color: 'currentColor',
         ...css
       }}

--- a/lib/src/components/section-message/SectionMessageLayout.tsx
+++ b/lib/src/components/section-message/SectionMessageLayout.tsx
@@ -11,6 +11,7 @@ export const SectionMessageContent = ({
     css={{
       maxWidth: '100%',
       flexShrink: 0,
+      paddingTop: '$0',
       ['& > *:not(:last-child)']: { mb: '$2' },
       ...css
     }}

--- a/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
+++ b/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
@@ -199,11 +199,11 @@ exports[`renders SectionMessage component and has no programmatically detectable
     flex-grow: 1;
   }
 
-  .c-hMRxhp-ihCBfwK-css {
+  .c-hMRxhp-ifRusCN-css {
     margin: auto;
     position: absolute;
     left: var(--space-4);
-    top: var(--space-4);
+    top: calc(var(--space-4) - 2px);
     color: currentColor;
   }
 
@@ -241,7 +241,7 @@ exports[`renders SectionMessage component and has no programmatically detectable
     >
       <svg
         aria-hidden="true"
-        class="c-hMRxhp c-hMRxhp-cyeZeh-size-sm c-hMRxhp-ihCBfwK-css"
+        class="c-hMRxhp c-hMRxhp-cyeZeh-size-sm c-hMRxhp-ifRusCN-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
+++ b/lib/src/components/section-message/__snapshots__/SectionMessage.test.tsx.snap
@@ -199,20 +199,21 @@ exports[`renders SectionMessage component and has no programmatically detectable
     flex-grow: 1;
   }
 
-  .c-hMRxhp-ifRusCN-css {
+  .c-hMRxhp-ihCBfwK-css {
     margin: auto;
     position: absolute;
     left: var(--space-4);
-    top: calc(var(--space-4) - 2px);
+    top: var(--space-4);
     color: currentColor;
   }
 
-  .c-PJLV-iCOfVx-css {
+  .c-PJLV-ihLIGwZ-css {
     max-width: 100%;
     flex-shrink: 0;
+    padding-top: var(--space-0);
   }
 
-  .c-PJLV-iCOfVx-css > *:not(:last-child) {
+  .c-PJLV-ihLIGwZ-css > *:not(:last-child) {
     margin-bottom: var(--space-2);
   }
 
@@ -241,7 +242,7 @@ exports[`renders SectionMessage component and has no programmatically detectable
     >
       <svg
         aria-hidden="true"
-        class="c-hMRxhp c-hMRxhp-cyeZeh-size-sm c-hMRxhp-ifRusCN-css"
+        class="c-hMRxhp c-hMRxhp-cyeZeh-size-sm c-hMRxhp-ihCBfwK-css"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -261,7 +262,7 @@ exports[`renders SectionMessage component and has no programmatically detectable
         />
       </svg>
       <div
-        class="c-PJLV c-PJLV-iCOfVx-css"
+        class="c-PJLV c-PJLV-ihLIGwZ-css"
       >
         <p
           class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dyvMgW-iecBjWS-css"


### PR DESCRIPTION
SectionMessageIcon issue

![Zrzut ekranu 2024-02-12 o 14 37 10](https://github.com/Atom-Learning/components/assets/23363033/f8a4d5f9-56db-48d7-b6f1-9b72a982c41b)

SectionMessageIcon has a top edge at the same line as the content top border (top position of an icon is equal to the content padding.

Because an icon is most likely higher than the `heading`, both elements looks not aligned vertically.
There's not a perfect fix considering API shape and all of possible combinations like
- different heading size
- no heading
- no text
- heading and text 
- etc

Icon is positioned absolutely to be kept next to the `top` line of heading/text in case that heading/text is multiline.

Proposed fix:
- Add $0 padding to the content. It makes all elements more centered (icon/text/heading/x)
- Looks good with `Text` and heading `sm/md`.
- Checked with @MiguelGDLR --> from UI perspective it's way better.
- ⚠️ not a pixel perfect solution, but the easiest non-breaking change.

### Additional images:

before:
![Zrzut ekranu 2024-02-12 o 14 31 05](https://github.com/Atom-Learning/components/assets/23363033/f8123662-3c51-4649-9833-ca622b2712f5)

<img width="1164" alt="Zrzut ekranu 2024-02-12 o 15 13 23" src="https://github.com/Atom-Learning/components/assets/23363033/e58c397f-022b-4758-b869-22d2502c852e">

<img width="938" alt="Zrzut ekranu 2024-02-12 o 15 22 00" src="https://github.com/Atom-Learning/components/assets/23363033/4cd8834c-743b-4e09-97df-3d9a4bf3469b">

after
![Zrzut ekranu 2024-02-13 o 13 38 18](https://github.com/Atom-Learning/components/assets/23363033/ffa4c348-aea4-43b8-ac68-62b6b6230aa1)
![Zrzut ekranu 2024-02-13 o 13 38 43](https://github.com/Atom-Learning/components/assets/23363033/e877bf00-bbb9-46da-9730-7c4e1a2d7b74)

