### PR TITLE
refactor: prefer native [disabled] over [data-disabled] for styles ta…

### DIFF
--- a/lib/src/components/accordion/AccordionTrigger.tsx
+++ b/lib/src/components/accordion/AccordionTrigger.tsx
@@ -29,11 +29,11 @@ const StyledTrigger = styled(Trigger, {
   cursor: 'pointer',
   bg: '$interactive2',
   color: '$interactiveForeground',
-  '&[data-disabled]': {
+  '&[disabled]': {
     opacity: 0.3,
     cursor: 'not-allowed'
   },
-  '&:not([data-disabled])': {
+  '&:not([disabled])': {
     '&:active, &:hover, &:focus-visible': {
       bg: '$interactive3'
     },

--- a/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -338,7 +338,7 @@ exports[`Accordion component renders an accordion 1`] = `
     transform: rotate(0deg);
   }
 
-  .c-cHXTzy {
+  .c-cdQaC {
     border: 0;
     padding-top: var(--space-3);
     padding-bottom: var(--space-3);
@@ -353,29 +353,29 @@ exports[`Accordion component renders an accordion 1`] = `
     color: var(--colors-interactiveForeground);
   }
 
-  .c-cHXTzy[data-disabled] {
+  .c-cdQaC[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-cHXTzy:not([data-disabled]):active,
-  .c-cHXTzy:not([data-disabled]):hover,
-  .c-cHXTzy:not([data-disabled]):focus-visible {
+  .c-cdQaC:not([disabled]):active,
+  .c-cdQaC:not([disabled]):hover,
+  .c-cdQaC:not([disabled]):focus-visible {
     background: var(--colors-interactive3);
   }
 
-  .c-cHXTzy:not([data-disabled]):focus-visible {
+  .c-cdQaC:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-cHXTzy[data-state="open"] {
+  .c-cdQaC[data-state="open"] {
     border-radius: var(--radii-0) var(--radii-0) 0 0;
   }
 
-  .c-cHXTzy[data-state="closed"] {
+  .c-cdQaC[data-state="closed"] {
     border-radius: var(--radii-0);
   }
 
@@ -437,7 +437,7 @@ exports[`Accordion component renders an accordion 1`] = `
         aria-controls="radix-:r1:"
         aria-disabled="true"
         aria-expanded="true"
-        class="c-cHXTzy t-dVJiaJ t-hwCMvs"
+        class="c-cdQaC t-dVJiaJ t-hwCMvs"
         data-orientation="vertical"
         data-radix-collection-item=""
         data-state="open"
@@ -477,7 +477,7 @@ exports[`Accordion component renders an accordion 1`] = `
       <button
         aria-controls="radix-:r3:"
         aria-expanded="false"
-        class="c-cHXTzy t-dVJiaJ t-hwCMvs"
+        class="c-cdQaC t-dVJiaJ t-hwCMvs"
         data-orientation="vertical"
         data-radix-collection-item=""
         data-state="closed"

--- a/lib/src/components/chip-dismissible-group/__snapshots__/ChipDismissibleGroup.test.tsx.snap
+++ b/lib/src/components/chip-dismissible-group/__snapshots__/ChipDismissibleGroup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ChipDismissibleGroup component renders 1`] = `
     display: flex;
   }
 
-  .c-cDmpis {
+  .c-iCmdOp {
     padding-left: var(--space-2);
     padding-right: var(--space-2);
     border: 1px solid;
@@ -19,7 +19,7 @@ exports[`ChipDismissibleGroup component renders 1`] = `
     background: var(--colors-primary100);
   }
 
-  .c-cDmpis[data-disabled] {
+  .c-iCmdOp[disabled] {
     opacity: 0.3;
     pointer-events: none;
   }
@@ -137,19 +137,19 @@ exports[`ChipDismissibleGroup component renders 1`] = `
     gap: var(--space-2);
   }
 
-  .c-cDmpis-kIEsaE-size-md {
+  .c-iCmdOp-kIEsaE-size-md {
     height: var(--sizes-3);
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-cDmpis-kIEsaE-size-md::before {
+  .c-iCmdOp-kIEsaE-size-md::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-cDmpis-kIEsaE-size-md::after {
+  .c-iCmdOp-kIEsaE-size-md::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -204,7 +204,7 @@ exports[`ChipDismissibleGroup component renders 1`] = `
     class="c-dhzjXW c-dhzjXW-ejCoEP-direction-row c-dhzjXW-XefLA-wrap-wrap c-dhzjXW-kaVYFn-gap-2"
   >
     <div
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-efCiES"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-efCiES"
     >
       <span
         class="c-eOdeXL"
@@ -230,7 +230,7 @@ exports[`ChipDismissibleGroup component renders 1`] = `
       </button>
     </div>
     <div
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-efCiES"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-efCiES"
       data-disabled=""
     >
       <span

--- a/lib/src/components/chip-toggle-group/__snapshots__/ChipToggleGroup.test.tsx.snap
+++ b/lib/src/components/chip-toggle-group/__snapshots__/ChipToggleGroup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     display: flex;
   }
 
-  .c-cDmpis {
+  .c-iCmdOp {
     padding-left: var(--space-2);
     padding-right: var(--space-2);
     border: 1px solid;
@@ -19,7 +19,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     background: var(--colors-primary100);
   }
 
-  .c-cDmpis[data-disabled] {
+  .c-iCmdOp[disabled] {
     opacity: 0.3;
     pointer-events: none;
   }
@@ -99,19 +99,19 @@ exports[`ChipToggleGroup component renders 1`] = `
     gap: var(--space-2);
   }
 
-  .c-cDmpis-kIEsaE-size-md {
+  .c-iCmdOp-kIEsaE-size-md {
     height: var(--sizes-3);
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-cDmpis-kIEsaE-size-md::before {
+  .c-iCmdOp-kIEsaE-size-md::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-cDmpis-kIEsaE-size-md::after {
+  .c-iCmdOp-kIEsaE-size-md::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -135,7 +135,7 @@ exports[`ChipToggleGroup component renders 1`] = `
   >
     <button
       aria-pressed="true"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-ioEXok"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-ioEXok"
       data-orientation="horizontal"
       data-radix-collection-item=""
       data-state="on"
@@ -160,7 +160,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-ioEXok"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-ioEXok"
       data-disabled=""
       data-orientation="horizontal"
       data-radix-collection-item=""
@@ -187,7 +187,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-ioEXok"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-ioEXok"
       data-orientation="horizontal"
       data-radix-collection-item=""
       data-state="off"
@@ -212,7 +212,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md c-ioEXok"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-ioEXok"
       data-disabled=""
       data-orientation="horizontal"
       data-radix-collection-item=""

--- a/lib/src/components/chip/Chip.tsx
+++ b/lib/src/components/chip/Chip.tsx
@@ -68,7 +68,7 @@ export const StyledRoot = styled(Flex, {
   borderColor: '$primary800',
   color: '$primary900',
   bg: '$primary100',
-  '&[data-disabled]': {
+  '&[disabled]': {
     opacity: '0.3',
     pointerEvents: 'none'
   },

--- a/lib/src/components/chip/__snapshots__/Chip.test.tsx.snap
+++ b/lib/src/components/chip/__snapshots__/Chip.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Chip component renders 1`] = `
     display: flex;
   }
 
-  .c-cDmpis {
+  .c-iCmdOp {
     padding-left: var(--space-2);
     padding-right: var(--space-2);
     border: 1px solid;
@@ -19,7 +19,7 @@ exports[`Chip component renders 1`] = `
     background: var(--colors-primary100);
   }
 
-  .c-cDmpis[data-disabled] {
+  .c-iCmdOp[disabled] {
     opacity: 0.3;
     pointer-events: none;
   }
@@ -51,19 +51,19 @@ exports[`Chip component renders 1`] = `
 }
 
 @media  {
-  .c-cDmpis-kIEsaE-size-md {
+  .c-iCmdOp-kIEsaE-size-md {
     height: var(--sizes-3);
     font-size: var(--fontSizes-sm);
     line-height: 1.53;
   }
 
-  .c-cDmpis-kIEsaE-size-md::before {
+  .c-iCmdOp-kIEsaE-size-md::before {
     content: '';
     margin-bottom: -0.4056em;
     display: table;
   }
 
-  .c-cDmpis-kIEsaE-size-md::after {
+  .c-iCmdOp-kIEsaE-size-md::after {
     content: '';
     margin-top: -0.4056em;
     display: table;
@@ -86,7 +86,7 @@ exports[`Chip component renders 1`] = `
 
 <div>
   <div
-    class="c-dhzjXW c-cDmpis c-cDmpis-kIEsaE-size-md"
+    class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md"
   >
     <span
       class="c-eOdeXL"

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.styles.ts
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.styles.ts
@@ -22,11 +22,11 @@ export const navigationMenuVerticalItemStyles = {
   '&[data-state=open]': {
     '--navigation-menu-vertical-item-font-weight': 600
   },
-  '&[data-disabled]': {
+  '&[disabled]': {
     opacity: 0.3,
     cursor: 'not-allowed'
   },
-  '&:not([data-disabled])': {
+  '&:not([disabled])': {
     '&:hover': {
       bg: '$backgroundHover'
     },

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -324,7 +324,7 @@ exports[`NavigationMenuVertical renders 1`] = `
     line-height: 1.2;
   }
 
-  .c-rTOZb {
+  .c-fcJjQf {
     padding: var(--space-2);
     border: none;
     outline: none;
@@ -342,30 +342,30 @@ exports[`NavigationMenuVertical renders 1`] = `
     --navigation-menu-vertical-item-font-weight: 400;
   }
 
-  .c-rTOZb[data-active] {
+  .c-fcJjQf[data-active] {
     background: var(--colors-backgroundSelected);
     color: var(--colors-textSelected);
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-rTOZb[data-state=open] {
+  .c-fcJjQf[data-state=open] {
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-rTOZb[data-disabled] {
+  .c-fcJjQf[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-rTOZb:not([data-disabled]):hover {
+  .c-fcJjQf:not([disabled]):hover {
     background: var(--colors-backgroundHover);
   }
 
-  .c-rTOZb:not([data-disabled]):active {
+  .c-fcJjQf:not([disabled]):active {
     background: var(--colors-backgroundActive);
   }
 
-  .c-rTOZb:not([data-disabled]):focus-visible {
+  .c-fcJjQf:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
@@ -426,7 +426,7 @@ exports[`NavigationMenuVertical renders 1`] = `
     display: table;
   }
 
-  .c-rTOZb-jLELKD-size-lg {
+  .c-fcJjQf-jLELKD-size-lg {
     min-height: var(--sizes-5);
   }
 }
@@ -450,7 +450,7 @@ exports[`NavigationMenuVertical renders 1`] = `
       >
         <button
           aria-current="page"
-          class="c-rTOZb c-rTOZb-jLELKD-size-lg"
+          class="c-fcJjQf c-fcJjQf-jLELKD-size-lg"
           data-active=""
           data-radix-collection-item=""
           type="button"
@@ -470,7 +470,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-rTOZb c-rTOZb-jLELKD-size-lg"
+          class="c-fcJjQf c-fcJjQf-jLELKD-size-lg"
           data-radix-collection-item=""
           href="/somewhere"
         >
@@ -489,7 +489,7 @@ exports[`NavigationMenuVertical renders 1`] = `
         class="c-PJLV"
       >
         <a
-          class="c-rTOZb c-rTOZb-jLELKD-size-lg"
+          class="c-fcJjQf c-fcJjQf-jLELKD-size-lg"
           data-radix-collection-item=""
           href="http://google.com"
           rel="noopener noreferrer"
@@ -835,7 +835,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     line-height: 1.2;
   }
 
-  .c-rTOZb {
+  .c-fcJjQf {
     padding: var(--space-2);
     border: none;
     outline: none;
@@ -853,30 +853,30 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     --navigation-menu-vertical-item-font-weight: 400;
   }
 
-  .c-rTOZb[data-active] {
+  .c-fcJjQf[data-active] {
     background: var(--colors-backgroundSelected);
     color: var(--colors-textSelected);
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-rTOZb[data-state=open] {
+  .c-fcJjQf[data-state=open] {
     --navigation-menu-vertical-item-font-weight: 600;
   }
 
-  .c-rTOZb[data-disabled] {
+  .c-fcJjQf[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-rTOZb:not([data-disabled]):hover {
+  .c-fcJjQf:not([disabled]):hover {
     background: var(--colors-backgroundHover);
   }
 
-  .c-rTOZb:not([data-disabled]):active {
+  .c-fcJjQf:not([disabled]):active {
     background: var(--colors-backgroundActive);
   }
 
-  .c-rTOZb:not([data-disabled]):focus-visible {
+  .c-fcJjQf:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
@@ -955,7 +955,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     display: table;
   }
 
-  .c-rTOZb-jLELKD-size-lg {
+  .c-fcJjQf-jLELKD-size-lg {
     min-height: var(--sizes-5);
   }
 
@@ -994,7 +994,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
         >
           <button
             aria-current="page"
-            class="c-rTOZb c-rTOZb-jLELKD-size-lg"
+            class="c-fcJjQf c-fcJjQf-jLELKD-size-lg"
             data-active=""
             data-radix-collection-item=""
             type="button"
@@ -1014,7 +1014,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-rTOZb c-rTOZb-jLELKD-size-lg"
+            class="c-fcJjQf c-fcJjQf-jLELKD-size-lg"
             data-radix-collection-item=""
             href="/somewhere"
           >
@@ -1033,7 +1033,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           class="c-PJLV"
         >
           <a
-            class="c-rTOZb c-rTOZb-jLELKD-size-lg"
+            class="c-fcJjQf c-fcJjQf-jLELKD-size-lg"
             data-radix-collection-item=""
             href="http://google.com"
             rel="noopener noreferrer"
@@ -1057,7 +1057,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
           <button
             aria-controls="radix-:r8:"
             aria-expanded="true"
-            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-rTOZb c-rTOZb-jLELKD-size-lg"
+            class="c-dhzjXW c-dhzjXW-knmidH-justify-space-between c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 c-fcJjQf c-fcJjQf-jLELKD-size-lg"
             data-radix-collection-item=""
             data-state="open"
             data-testid="accordion-trigger"

--- a/lib/src/components/slider-field/__snapshots__/SliderField.test.tsx.snap
+++ b/lib/src/components/slider-field/__snapshots__/SliderField.test.tsx.snap
@@ -12,14 +12,14 @@ exports[`SliderField component renders 1`] = `
     margin: 0;
   }
 
-  .c-hNIRsQ {
+  .c-cYBvhd {
     background: var(--colors-primary800);
     border-radius: var(--radii-round);
     height: 100%;
     position: absolute;
   }
 
-  .c-hNIRsQ[data-disabled] {
+  .c-cYBvhd[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -38,7 +38,7 @@ exports[`SliderField component renders 1`] = `
     width: var(--space-1);
   }
 
-  .c-ccaAMC {
+  .c-bOlXUH {
     background: var(--colors-primary900);
     border-radius: var(--radii-round);
     display: block;
@@ -46,21 +46,21 @@ exports[`SliderField component renders 1`] = `
     width: var(--sizes-1);
   }
 
-  .c-ccaAMC:hover {
+  .c-bOlXUH:hover {
     background: var(--colors-primary1000);
   }
 
-  .c-ccaAMC:focus {
+  .c-bOlXUH:focus {
     outline: 2px solid var(--colors-primary900);
     outline-offset: 2px;
   }
 
-  .c-ccaAMC[data-disabled] {
+  .c-bOlXUH[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bwqjWK {
+  .c-kydCSz {
     align-items: center;
     display: flex;
     position: relative;
@@ -70,16 +70,16 @@ exports[`SliderField component renders 1`] = `
     cursor: pointer;
   }
 
-  .c-bwqjWK[data-orientation="horizontal"] {
+  .c-kydCSz[data-orientation="horizontal"] {
     height: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-orientation="vertical"] {
+  .c-kydCSz[data-orientation="vertical"] {
     flex-direction: column;
     width: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-disabled] {
+  .c-kydCSz[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -119,7 +119,7 @@ exports[`SliderField component renders 1`] = `
     font-weight: 600;
   }
 
-  .c-bwqjWK-dOexvR-theme-tonal .c-nJgcq {
+  .c-kydCSz-dOexvR-theme-tonal .c-nJgcq {
     background: var(--colors-tonal200);
   }
 
@@ -175,7 +175,7 @@ exports[`SliderField component renders 1`] = `
       </div>
       <span
         aria-disabled="false"
-        class="c-bwqjWK c-bwqjWK-dOexvR-theme-tonal"
+        class="c-kydCSz c-kydCSz-dOexvR-theme-tonal"
         data-orientation="horizontal"
         dir="ltr"
         style="--radix-slider-thumb-transform: translateX(-50%);"
@@ -185,7 +185,7 @@ exports[`SliderField component renders 1`] = `
           data-orientation="horizontal"
         >
           <span
-            class="c-hNIRsQ"
+            class="c-cYBvhd"
             data-orientation="horizontal"
             style="left: 0%; right: 50%;"
           />
@@ -198,7 +198,7 @@ exports[`SliderField component renders 1`] = `
             aria-valuemax="100"
             aria-valuemin="0"
             aria-valuenow="50"
-            class="c-ccaAMC"
+            class="c-bOlXUH"
             data-orientation="horizontal"
             data-radix-collection-item=""
             role="slider"

--- a/lib/src/components/slider/Slider.tsx
+++ b/lib/src/components/slider/Slider.tsx
@@ -29,7 +29,7 @@ const StyledSlider = styled(Root, {
     flexDirection: 'column',
     width: '$1'
   },
-  '&[data-disabled]': disabledStyle,
+  '&[disabled]': disabledStyle,
   variants: {
     theme: {
       light: {
@@ -47,7 +47,7 @@ const StyledRange = styled(Range, {
   borderRadius: '$round',
   height: '100%',
   position: 'absolute',
-  '&[data-disabled]': disabledStyle
+  '&[disabled]': disabledStyle
 })
 
 const StyledThumb = styled(Thumb, {
@@ -62,7 +62,7 @@ const StyledThumb = styled(Thumb, {
     outline: '2px solid $primary900',
     outlineOffset: '2px'
   },
-  '&[data-disabled]': disabledStyle
+  '&[disabled]': disabledStyle
 })
 
 export type SliderProps = React.ComponentProps<typeof StyledSlider>

--- a/lib/src/components/slider/__snapshots__/Slider.test.tsx.snap
+++ b/lib/src/components/slider/__snapshots__/Slider.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Slider component renders 1`] = `
 @media  {
-  .c-hNIRsQ {
+  .c-cYBvhd {
     background: var(--colors-primary800);
     border-radius: var(--radii-round);
     height: 100%;
     position: absolute;
   }
 
-  .c-hNIRsQ[data-disabled] {
+  .c-cYBvhd[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -28,7 +28,7 @@ exports[`Slider component renders 1`] = `
     width: var(--space-1);
   }
 
-  .c-ccaAMC {
+  .c-bOlXUH {
     background: var(--colors-primary900);
     border-radius: var(--radii-round);
     display: block;
@@ -36,21 +36,21 @@ exports[`Slider component renders 1`] = `
     width: var(--sizes-1);
   }
 
-  .c-ccaAMC:hover {
+  .c-bOlXUH:hover {
     background: var(--colors-primary1000);
   }
 
-  .c-ccaAMC:focus {
+  .c-bOlXUH:focus {
     outline: 2px solid var(--colors-primary900);
     outline-offset: 2px;
   }
 
-  .c-ccaAMC[data-disabled] {
+  .c-bOlXUH[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bwqjWK {
+  .c-kydCSz {
     align-items: center;
     display: flex;
     position: relative;
@@ -60,23 +60,23 @@ exports[`Slider component renders 1`] = `
     cursor: pointer;
   }
 
-  .c-bwqjWK[data-orientation="horizontal"] {
+  .c-kydCSz[data-orientation="horizontal"] {
     height: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-orientation="vertical"] {
+  .c-kydCSz[data-orientation="vertical"] {
     flex-direction: column;
     width: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-disabled] {
+  .c-kydCSz[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 }
 
 @media  {
-  .c-bwqjWK-dOexvR-theme-tonal .c-nJgcq {
+  .c-kydCSz-dOexvR-theme-tonal .c-nJgcq {
     background: var(--colors-tonal200);
   }
 }
@@ -84,7 +84,7 @@ exports[`Slider component renders 1`] = `
 <div>
   <span
     aria-disabled="false"
-    class="c-bwqjWK c-bwqjWK-dOexvR-theme-tonal"
+    class="c-kydCSz c-kydCSz-dOexvR-theme-tonal"
     data-orientation="horizontal"
     dir="ltr"
     style="--radix-slider-thumb-transform: translateX(-50%);"
@@ -94,7 +94,7 @@ exports[`Slider component renders 1`] = `
       data-orientation="horizontal"
     >
       <span
-        class="c-hNIRsQ"
+        class="c-cYBvhd"
         data-orientation="horizontal"
         style="left: 0%; right: 50%;"
       />
@@ -107,7 +107,7 @@ exports[`Slider component renders 1`] = `
         aria-valuemax="100"
         aria-valuemin="0"
         aria-valuenow="50"
-        class="c-ccaAMC"
+        class="c-bOlXUH"
         data-orientation="horizontal"
         data-radix-collection-item=""
         role="slider"
@@ -121,14 +121,14 @@ exports[`Slider component renders 1`] = `
 
 exports[`Slider component renders with a steps list 1`] = `
 @media  {
-  .c-hNIRsQ {
+  .c-cYBvhd {
     background: var(--colors-primary800);
     border-radius: var(--radii-round);
     height: 100%;
     position: absolute;
   }
 
-  .c-hNIRsQ[data-disabled] {
+  .c-cYBvhd[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -147,7 +147,7 @@ exports[`Slider component renders with a steps list 1`] = `
     width: var(--space-1);
   }
 
-  .c-ccaAMC {
+  .c-bOlXUH {
     background: var(--colors-primary900);
     border-radius: var(--radii-round);
     display: block;
@@ -155,21 +155,21 @@ exports[`Slider component renders with a steps list 1`] = `
     width: var(--sizes-1);
   }
 
-  .c-ccaAMC:hover {
+  .c-bOlXUH:hover {
     background: var(--colors-primary1000);
   }
 
-  .c-ccaAMC:focus {
+  .c-bOlXUH:focus {
     outline: 2px solid var(--colors-primary900);
     outline-offset: 2px;
   }
 
-  .c-ccaAMC[data-disabled] {
+  .c-bOlXUH[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bwqjWK {
+  .c-kydCSz {
     align-items: center;
     display: flex;
     position: relative;
@@ -179,23 +179,23 @@ exports[`Slider component renders with a steps list 1`] = `
     cursor: pointer;
   }
 
-  .c-bwqjWK[data-orientation="horizontal"] {
+  .c-kydCSz[data-orientation="horizontal"] {
     height: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-orientation="vertical"] {
+  .c-kydCSz[data-orientation="vertical"] {
     flex-direction: column;
     width: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-disabled] {
+  .c-kydCSz[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 }
 
 @media  {
-  .c-bwqjWK-dOexvR-theme-tonal .c-nJgcq {
+  .c-kydCSz-dOexvR-theme-tonal .c-nJgcq {
     background: var(--colors-tonal200);
   }
 }
@@ -203,7 +203,7 @@ exports[`Slider component renders with a steps list 1`] = `
 <div>
   <span
     aria-disabled="false"
-    class="c-bwqjWK c-bwqjWK-dOexvR-theme-tonal"
+    class="c-kydCSz c-kydCSz-dOexvR-theme-tonal"
     data-orientation="horizontal"
     dir="ltr"
     steps="[object Object],[object Object],[object Object]"
@@ -214,7 +214,7 @@ exports[`Slider component renders with a steps list 1`] = `
       data-orientation="horizontal"
     >
       <span
-        class="c-hNIRsQ"
+        class="c-cYBvhd"
         data-orientation="horizontal"
         style="left: 0%; right: 50%;"
       />
@@ -227,7 +227,7 @@ exports[`Slider component renders with a steps list 1`] = `
         aria-valuemax="100"
         aria-valuemin="0"
         aria-valuenow="50"
-        class="c-ccaAMC"
+        class="c-bOlXUH"
         data-orientation="horizontal"
         data-radix-collection-item=""
         role="slider"
@@ -241,14 +241,14 @@ exports[`Slider component renders with a steps list 1`] = `
 
 exports[`Slider.Value component renders 1`] = `
 @media  {
-  .c-hNIRsQ {
+  .c-cYBvhd {
     background: var(--colors-primary800);
     border-radius: var(--radii-round);
     height: 100%;
     position: absolute;
   }
 
-  .c-hNIRsQ[data-disabled] {
+  .c-cYBvhd[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -267,7 +267,7 @@ exports[`Slider.Value component renders 1`] = `
     width: var(--space-1);
   }
 
-  .c-ccaAMC {
+  .c-bOlXUH {
     background: var(--colors-primary900);
     border-radius: var(--radii-round);
     display: block;
@@ -275,21 +275,21 @@ exports[`Slider.Value component renders 1`] = `
     width: var(--sizes-1);
   }
 
-  .c-ccaAMC:hover {
+  .c-bOlXUH:hover {
     background: var(--colors-primary1000);
   }
 
-  .c-ccaAMC:focus {
+  .c-bOlXUH:focus {
     outline: 2px solid var(--colors-primary900);
     outline-offset: 2px;
   }
 
-  .c-ccaAMC[data-disabled] {
+  .c-bOlXUH[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-bwqjWK {
+  .c-kydCSz {
     align-items: center;
     display: flex;
     position: relative;
@@ -299,16 +299,16 @@ exports[`Slider.Value component renders 1`] = `
     cursor: pointer;
   }
 
-  .c-bwqjWK[data-orientation="horizontal"] {
+  .c-kydCSz[data-orientation="horizontal"] {
     height: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-orientation="vertical"] {
+  .c-kydCSz[data-orientation="vertical"] {
     flex-direction: column;
     width: var(--sizes-1);
   }
 
-  .c-bwqjWK[data-disabled] {
+  .c-kydCSz[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
@@ -326,7 +326,7 @@ exports[`Slider.Value component renders 1`] = `
 }
 
 @media  {
-  .c-bwqjWK-dOexvR-theme-tonal .c-nJgcq {
+  .c-kydCSz-dOexvR-theme-tonal .c-nJgcq {
     background: var(--colors-tonal200);
   }
 

--- a/lib/src/components/tabs/TabsTrigger.tsx
+++ b/lib/src/components/tabs/TabsTrigger.tsx
@@ -29,8 +29,8 @@ const StyledTabsTrigger = styled(Trigger, {
     letterSpacing: '-0.005em',
     borderColor: 'currentColor'
   },
-  '&[data-disabled]': disabledStyle,
-  '&:not([data-disabled])': {
+  '&[disabled]': disabledStyle,
+  '&:not([disabled])': {
     '&:hover, &:focus-visible': {
       color: '$interactive2',
       [`& ${StyledTabsTriggerHoverBackground}`]: {

--- a/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -351,7 +351,7 @@ exports[`Tabs component renders 1`] = `
     background: var(--colors-interactive1);
   }
 
-  .c-cDgrSH {
+  .c-efqMNv {
     background: none;
     border: none;
     cursor: pointer;
@@ -363,33 +363,33 @@ exports[`Tabs component renders 1`] = `
     position: relative;
   }
 
-  .c-cDgrSH[data-state="active"] {
+  .c-efqMNv[data-state="active"] {
     color: var(--colors-interactive1);
     font-weight: 600;
     letter-spacing: -0.005em;
     border-color: currentColor;
   }
 
-  .c-cDgrSH[data-disabled] {
+  .c-efqMNv[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
   }
 
-  .c-cDgrSH:not([data-disabled]):hover,
-  .c-cDgrSH:not([data-disabled]):focus-visible {
+  .c-efqMNv:not([disabled]):hover,
+  .c-efqMNv:not([disabled]):focus-visible {
     color: var(--colors-interactive2);
   }
 
-  .c-cDgrSH:not([data-disabled]):hover .c-iPskiL,
-  .c-cDgrSH:not([data-disabled]):focus-visible .c-iPskiL {
+  .c-efqMNv:not([disabled]):hover .c-iPskiL,
+  .c-efqMNv:not([disabled]):focus-visible .c-iPskiL {
     opacity: 0.07;
   }
 
-  .c-cDgrSH:not([data-disabled]):active {
+  .c-efqMNv:not([disabled]):active {
     color: var(--colors-interactive3);
   }
 
-  .c-cDgrSH:not([data-disabled]):focus-visible {
+  .c-efqMNv:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
@@ -466,7 +466,7 @@ exports[`Tabs component renders 1`] = `
         <button
           aria-controls="radix-:r0:-content-tab1"
           aria-selected="true"
-          class="c-cDgrSH"
+          class="c-efqMNv"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="active"
@@ -487,7 +487,7 @@ exports[`Tabs component renders 1`] = `
         <button
           aria-controls="radix-:r0:-content-tab2"
           aria-selected="false"
-          class="c-cDgrSH"
+          class="c-efqMNv"
           data-orientation="horizontal"
           data-radix-collection-item=""
           data-state="inactive"
@@ -508,7 +508,7 @@ exports[`Tabs component renders 1`] = `
         <button
           aria-controls="radix-:r0:-content-tab3"
           aria-selected="false"
-          class="c-cDgrSH"
+          class="c-efqMNv"
           data-disabled=""
           data-orientation="horizontal"
           data-radix-collection-item=""


### PR DESCRIPTION
…rgeting disabled state

_This is more of a suggestion PR as nothing is currently breaking due to it, but I think it will be a good change for the codebase._

[After fixing `TileInteractive`'s disabled state which was wrongly targeting `[data-disabled]`, ](https://github.com/Atom-Learning/components/pull/622)I'm also applying the same changes to all other components with disabled styles.

The point is, `[data-disabled]` is a radix data attribute but it will always for accessibility/functionality ALSO be adding the `disabled` native attribute. So we could be targeting either with no issues. Thus targeting `[data-disabled]` is mudding the waters when it comes to copying around styles - like I had done for `TileInteractive`(which is actually just a native button and not a radix component) a few months ago.

If we agree to only be targeting `[disabled]` from now on, these sort of bugs will be avoided and components' css will be more solid as they wont be depending on a radix attribute.