### PR TITLE
fix: remove usage of React.FC type

### DIFF
--- a/lib/src/components/accordion/AccordionContent.tsx
+++ b/lib/src/components/accordion/AccordionContent.tsx
@@ -27,13 +27,11 @@ const StyledContent = styled(Content, {
   }
 })
 
-type AccordionContentProps = React.ComponentProps<typeof StyledContent>
-
-export const AccordionContent: React.FC<AccordionContentProps> = ({
+export const AccordionContent = ({
   children,
   css,
   ...remainingProps
-}) => (
+}: React.ComponentProps<typeof StyledContent>) => (
   <StyledContent {...remainingProps}>
     <CSSWrapper css={css}>{children}</CSSWrapper>
   </StyledContent>

--- a/lib/src/components/accordion/AccordionItem.tsx
+++ b/lib/src/components/accordion/AccordionItem.tsx
@@ -3,22 +3,10 @@ import React from 'react'
 
 import { styled } from '~/stitches'
 
-const StyledItem = styled(Item, {
+export const AccordionItem = styled(Item, {
   width: '100%',
 
   '&:not(:last-child)': {
     mb: '$1'
   }
 })
-
-type AccordionItemProps = React.ComponentProps<typeof StyledItem>
-
-export const AccordionItem: React.FC<AccordionItemProps> = ({
-  children,
-  value,
-  ...remainingProps
-}) => (
-  <StyledItem value={value} {...remainingProps}>
-    {children}
-  </StyledItem>
-)

--- a/lib/src/components/accordion/AccordionTrigger.tsx
+++ b/lib/src/components/accordion/AccordionTrigger.tsx
@@ -49,14 +49,12 @@ const StyledTrigger = styled(Trigger, {
   }
 })
 
-type AccordionTriggerProps = React.ComponentProps<typeof StyledTrigger> & {
-  colorScheme?: TcolorScheme
-}
-
-export const AccordionTrigger: React.FC<AccordionTriggerProps> = ({
+export const AccordionTrigger = ({
   children,
   colorScheme = {},
   ...remainingProps
+}: React.ComponentProps<typeof StyledTrigger> & {
+  colorScheme?: TcolorScheme
 }) => (
   <ColorScheme asChild accent="grey1" interactive="loContrast" {...colorScheme}>
     <StyledTrigger {...remainingProps}>

--- a/lib/src/components/alert-dialog/AlertDialog.tsx
+++ b/lib/src/components/alert-dialog/AlertDialog.tsx
@@ -14,22 +14,13 @@ import { AlertDialogContent } from './AlertDialogContent'
 
 const StyledAlertDialog = styled(Root, {})
 
-type AlertDialogProps = React.ComponentProps<typeof StyledAlertDialog>
-
-export const AlertDialog: React.FC<AlertDialogProps> & {
-  Content: typeof AlertDialogContent
-  Trigger: typeof Trigger
-  Description: typeof Description
-  Title: typeof Title
-  Action: typeof Action
-  Cancel: typeof Cancel
-} = (props) => <StyledAlertDialog {...props} />
-
-AlertDialog.Description = Description
-AlertDialog.Title = Title
-AlertDialog.Action = Action
-AlertDialog.Cancel = Cancel
-AlertDialog.Content = AlertDialogContent
-AlertDialog.Trigger = Trigger
+export const AlertDialog = Object.assign(StyledAlertDialog, {
+  Description: Description,
+  Title: Title,
+  Action: Action,
+  Cancel: Cancel,
+  Content: AlertDialogContent,
+  Trigger: Trigger
+})
 
 AlertDialog.displayName = 'AlertDialog'

--- a/lib/src/components/alert-dialog/AlertDialogContent.tsx
+++ b/lib/src/components/alert-dialog/AlertDialogContent.tsx
@@ -67,14 +67,10 @@ const StyledAlertDialogContent = styled(Content, {
   }
 })
 
-type AlertDialogContentProps = React.ComponentProps<
-  typeof StyledAlertDialogContent
->
-
-export const AlertDialogContent: React.FC<AlertDialogContentProps> = ({
+export const AlertDialogContent = ({
   size = 'sm',
   ...remainingProps
-}) => (
+}: React.ComponentProps<typeof StyledAlertDialogContent>) => (
   <Portal>
     <StyledAlertDialogOverlay />
     <StyledAlertDialogContent size={size} {...remainingProps} />

--- a/lib/src/components/alert-dialog/alert-context/AlertContext.tsx
+++ b/lib/src/components/alert-dialog/alert-context/AlertContext.tsx
@@ -14,7 +14,9 @@ const AlertContext = React.createContext<context>({
   showAlert: () => null
 })
 
-export const AlertProvider: React.FC = ({ children }) => {
+export const AlertProvider = ({
+  children
+}: React.PropsWithChildren<unknown>) => {
   const [alerts, dispatch] = React.useReducer(reducer, initialState)
   const isMountedRef = useIsMountedRef()
 

--- a/lib/src/components/alert-dialog/alert-context/AlertDialog.tsx
+++ b/lib/src/components/alert-dialog/alert-context/AlertDialog.tsx
@@ -15,7 +15,7 @@ type AlertDialogContentProps = React.ComponentProps<typeof AlertDialog> & {
   onClose: () => void
 } & alert
 
-export const Alert: React.FC<AlertDialogContentProps> = ({
+export const Alert = ({
   title,
   size,
   theme,
@@ -27,7 +27,7 @@ export const Alert: React.FC<AlertDialogContentProps> = ({
   confirmElement,
   cancelElement,
   ...remainingProps
-}) => (
+}: AlertDialogContentProps) => (
   <AlertDialog defaultOpen>
     <AlertDialog.Content
       size={size}

--- a/lib/src/components/avatar/Avatar.tsx
+++ b/lib/src/components/avatar/Avatar.tsx
@@ -106,16 +106,11 @@ export const AvatarRoot = ({
   </AvatarRootProvider>
 )
 
-type TAvatar = typeof AvatarRoot & {
-  Image: typeof AvatarImage
-  Initial: typeof AvatarInitial
-  Placeholder: typeof AvatarPlaceholder
-  Icon: typeof AvatarIcon
-}
+export const Avatar = Object.assign(AvatarRoot, {
+  Image: AvatarImage,
+  Initial: AvatarInitial,
+  Placeholder: AvatarPlaceholder,
+  Icon: AvatarIcon
+})
 
-export const Avatar = AvatarRoot as TAvatar
-Avatar.Image = AvatarImage
-Avatar.Initial = AvatarInitial
-Avatar.Placeholder = AvatarPlaceholder
-Avatar.Icon = AvatarIcon
-Avatar.displayName = 'Avatar'
+AvatarRoot.displayName = 'Avatar'

--- a/lib/src/components/avatar/Avatar.tsx
+++ b/lib/src/components/avatar/Avatar.tsx
@@ -70,11 +70,7 @@ export const AvatarRootContext = React.createContext<TAvatarRootContext>({
   size: 'lg'
 })
 
-export const AvatarRootProvider: React.FC<TAvatarProps> = ({
-  children,
-  name,
-  size
-}) => {
+export const AvatarRootProvider = ({ children, name, size }: TAvatarProps) => {
   const value = React.useMemo<TAvatarRootContext>(
     () => ({ name, size }),
     [name, size]
@@ -87,13 +83,13 @@ export const AvatarRootProvider: React.FC<TAvatarProps> = ({
   )
 }
 
-export const AvatarRoot: React.FC<TAvatarProps> = ({
+export const AvatarRoot = ({
   children,
   size = 'lg',
   name,
   disabled = false,
   onClick
-}) => (
+}: TAvatarProps) => (
   <AvatarRootProvider name={name} size={size}>
     {onClick ? (
       <StyledButton

--- a/lib/src/components/avatar/AvatarIcon.tsx
+++ b/lib/src/components/avatar/AvatarIcon.tsx
@@ -14,11 +14,7 @@ const toIconSize = {
   xxl: 'lg'
 }
 
-type TAvatarIconProps = {
-  is: typeof Icon
-}
-
-export const AvatarIcon: React.FC<TAvatarIconProps> = ({ is }) => {
+export const AvatarIcon = ({ is }: { is: typeof Icon }) => {
   const rootContext = React.useContext(AvatarRootContext)
   const { size } = rootContext
   const iconSize = React.useMemo(

--- a/lib/src/components/avatar/AvatarImage.tsx
+++ b/lib/src/components/avatar/AvatarImage.tsx
@@ -10,12 +10,7 @@ const StyledImage = styled(Image, {
   objectFit: 'cover'
 })
 
-type TAvatarImageProps = {
-  src: string
-  alt: string
-}
-
-export const AvatarImage: React.FC<TAvatarImageProps> = ({ src, alt }) => {
+export const AvatarImage = ({ src, alt }: { src: string; alt: string }) => {
   if (!src) {
     return <AvatarInitial />
   }

--- a/lib/src/components/avatar/AvatarInitial.tsx
+++ b/lib/src/components/avatar/AvatarInitial.tsx
@@ -15,7 +15,7 @@ const toTextSize = {
   xxl: 'lg'
 }
 
-export const AvatarInitial: React.FC<Record<string, never>> = () => {
+export const AvatarInitial = () => {
   const rootContext = React.useContext(AvatarRootContext)
   const { name, size } = rootContext
   const textSize = React.useMemo(

--- a/lib/src/components/avatar/AvatarPlaceholder.tsx
+++ b/lib/src/components/avatar/AvatarPlaceholder.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { Box } from '../box'
 import { Icon } from '../icon'
 
-export const AvatarPlaceholder: React.FC<Record<string, never>> = () => {
+export const AvatarPlaceholder = () => {
   return (
     <Box css={{ position: 'relative', size: '100%' }}>
       <Icon is={User} css={{ size: '100%' }} />

--- a/lib/src/components/banner/Banner.tsx
+++ b/lib/src/components/banner/Banner.tsx
@@ -3,15 +3,8 @@ import * as React from 'react'
 import { Dismissible } from '../dismissible'
 import { BannerProvider } from './BannerContext'
 
-export const Banner: React.FC<React.ComponentProps<typeof BannerProvider>> & {
-  Dismiss: typeof Dismissible.Trigger
-} = ({ children, size, emphasis }) => {
-  return (
-    <BannerProvider emphasis={emphasis} size={size}>
-      {children}
-    </BannerProvider>
-  )
-}
+export const Banner = Object.assign(BannerProvider, {
+  Dismiss: Dismissible.Trigger
+})
 
-Banner.Dismiss = Dismissible.Trigger
 Banner.displayName = 'Banner'

--- a/lib/src/components/banner/Banner.tsx
+++ b/lib/src/components/banner/Banner.tsx
@@ -1,10 +1,6 @@
-import * as React from 'react'
-
 import { Dismissible } from '../dismissible'
 import { BannerProvider } from './BannerContext'
 
 export const Banner = Object.assign(BannerProvider, {
   Dismiss: Dismissible.Trigger
 })
-
-Banner.displayName = 'Banner'

--- a/lib/src/components/banner/BannerContext.tsx
+++ b/lib/src/components/banner/BannerContext.tsx
@@ -32,14 +32,14 @@ export const useBannerContext = (): TBannerContextValue => {
   return context
 }
 
-export const BannerProvider: React.FC<TBannerProviderProps> = ({
+export const BannerProvider = ({
   emphasis = 'minimal',
   size = {
     '@initial': 'sm',
     '@md': 'md'
   },
   children
-}) => {
+}: React.PropsWithChildren<TBannerProviderProps>) => {
   const [hasDismiss, setHasDismiss] = React.useState(false)
   const value = React.useMemo<TBannerContextValue>(
     () => ({ emphasis, size, hasDismiss, setHasDismiss }),

--- a/lib/src/components/banner/BannerContext.tsx
+++ b/lib/src/components/banner/BannerContext.tsx
@@ -49,3 +49,5 @@ export const BannerProvider = ({
     <BannerContext.Provider value={value}>{children}</BannerContext.Provider>
   )
 }
+
+BannerProvider.displayName = 'Banner'

--- a/lib/src/components/banner/banner-regular/BannerRegular.test.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegular.test.tsx
@@ -5,9 +5,10 @@ import * as React from 'react'
 
 import { BannerRegular } from './'
 
-const BannerRegularImplementation: React.FC<
-  React.ComponentProps<typeof BannerRegular>
-> = ({ children, ...props }) => (
+const BannerRegularImplementation = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof BannerRegular>) => (
   <BannerRegular {...props}>
     <BannerRegular.Content>
       <BannerRegular.Heading>
@@ -27,9 +28,9 @@ const BannerRegularImplementation: React.FC<
   </BannerRegular>
 )
 
-const BannerRegularDismissibleImplementation: React.FC<
-  React.ComponentProps<typeof BannerRegular>
-> = (props) => (
+const BannerRegularDismissibleImplementation = (
+  props: React.ComponentProps<typeof BannerRegular>
+) => (
   <BannerRegularImplementation {...props}>
     <BannerRegular.Dismiss data-testid="dismiss" label="dismiss banner" />
   </BannerRegularImplementation>

--- a/lib/src/components/banner/banner-regular/BannerRegular.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegular.tsx
@@ -10,34 +10,30 @@ import { BannerRegularHeading } from './BannerRegularHeading'
 import { BannerRegularImage } from './BannerRegularImage'
 import { BannerRegularText } from './BannerRegularText'
 
-export const BannerRegular: React.FC<
-  React.ComponentProps<typeof BannerRegularContainer>
-> & {
-  Content: typeof BannerRegularContent
-  Heading: typeof BannerRegularHeading
-  Text: typeof BannerRegularText
-  Actions: typeof BannerRegularActions
-  Image: typeof BannerRegularImage
-  Button: typeof BannerRegularButton
-  Dismiss: typeof BannerRegularDismiss
-} = ({ colorScheme, size, emphasis, onDismiss, ...rest }) => {
-  return (
-    <Banner size={size} emphasis={emphasis}>
-      <BannerRegularContainer
-        colorScheme={colorScheme}
-        onDismiss={onDismiss}
-        {...rest}
-      />
-    </Banner>
-  )
-}
+const BannerRegularComponent = ({
+  colorScheme,
+  size,
+  emphasis,
+  onDismiss,
+  ...rest
+}: React.ComponentProps<typeof BannerRegularContainer>) => (
+  <Banner size={size} emphasis={emphasis}>
+    <BannerRegularContainer
+      colorScheme={colorScheme}
+      onDismiss={onDismiss}
+      {...rest}
+    />
+  </Banner>
+)
 
-BannerRegular.Content = BannerRegularContent
-BannerRegular.Heading = BannerRegularHeading
-BannerRegular.Text = BannerRegularText
-BannerRegular.Actions = BannerRegularActions
-BannerRegular.Image = BannerRegularImage
-BannerRegular.Button = BannerRegularButton
-BannerRegular.Dismiss = BannerRegularDismiss
+export const BannerRegular = Object.assign(BannerRegularComponent, {
+  Content: BannerRegularContent,
+  Heading: BannerRegularHeading,
+  Text: BannerRegularText,
+  Actions: BannerRegularActions,
+  Image: BannerRegularImage,
+  Button: BannerRegularButton,
+  Dismiss: BannerRegularDismiss
+})
 
-BannerRegular.displayName = 'BannerRegular'
+BannerRegularComponent.displayName = 'BannerRegular'

--- a/lib/src/components/banner/banner-regular/BannerRegularActions.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularActions.tsx
@@ -19,9 +19,10 @@ const toDirection = {
   md: 'row'
 }
 
-export const BannerRegularActions: React.FC<
-  React.ComponentProps<typeof Flex>
-> = ({ children, ...props }) => {
+export const BannerRegularActions = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof Flex>) => {
   const { size } = useBannerContext()
 
   const gap = React.useMemo(

--- a/lib/src/components/banner/banner-regular/BannerRegularButton.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularButton.tsx
@@ -5,9 +5,9 @@ import { overrideStitchesVariantValue } from '~/utilities/override-stitches-vari
 import { Button } from '../../button'
 import { useBannerContext } from '../BannerContext'
 
-export const BannerRegularButton: React.FC<
-  React.ComponentProps<typeof Button>
-> = (props) => {
+export const BannerRegularButton = (
+  props: React.ComponentProps<typeof Button>
+) => {
   const { emphasis, size } = useBannerContext()
 
   const fullWidth = React.useMemo(

--- a/lib/src/components/banner/banner-regular/BannerRegularContent.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularContent.tsx
@@ -21,9 +21,9 @@ const Container = styled(Box, {
   }
 })
 
-export const BannerRegularContent: React.FC<
-  React.ComponentProps<typeof Container>
-> = (props) => {
+export const BannerRegularContent = (
+  props: React.ComponentProps<typeof Container>
+) => {
   const { size } = useBannerContext()
 
   return <Container size={size} {...props} />

--- a/lib/src/components/banner/banner-regular/BannerRegularHeading.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularHeading.tsx
@@ -28,9 +28,9 @@ const StyledHeading = styled(Heading, {
   ]
 })
 
-export const BannerRegularHeading: React.FC<
-  React.ComponentProps<typeof Heading>
-> = (props) => {
+export const BannerRegularHeading = (
+  props: React.ComponentProps<typeof Heading>
+) => {
   const { size, hasDismiss } = useBannerContext()
 
   return (

--- a/lib/src/components/banner/banner-regular/BannerRegularImage.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularImage.tsx
@@ -30,9 +30,9 @@ const StyledImage = styled(Image, {
   objectFit: 'cover'
 })
 
-export const BannerRegularImage: React.FC<
-  React.ComponentProps<typeof Image>
-> = (props) => {
+export const BannerRegularImage = (
+  props: React.ComponentProps<typeof Image>
+) => {
   const { size } = useBannerContext()
 
   return (

--- a/lib/src/components/banner/banner-regular/BannerRegularText.tsx
+++ b/lib/src/components/banner/banner-regular/BannerRegularText.tsx
@@ -31,9 +31,7 @@ const StyledText = styled(Text, {
   ]
 })
 
-export const BannerRegularText: React.FC<React.ComponentProps<typeof Text>> = (
-  props
-) => {
+export const BannerRegularText = (props: React.ComponentProps<typeof Text>) => {
   const { size, hasDismiss } = useBannerContext()
 
   return (

--- a/lib/src/components/banner/banner-slim/BannerSlim.test.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlim.test.tsx
@@ -5,9 +5,10 @@ import * as React from 'react'
 
 import { BannerSlim } from './'
 
-const BannerSlimImplementation: React.FC<
-  React.ComponentProps<typeof BannerSlim>
-> = ({ children, ...props }) => (
+const BannerSlimImplementation = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof BannerSlim>) => (
   <BannerSlim {...props}>
     <BannerSlim.Content>
       <BannerSlim.Image src="https://picsum.photos/400/400" alt="image" />
@@ -23,9 +24,9 @@ const BannerSlimImplementation: React.FC<
   </BannerSlim>
 )
 
-const BannerSlimDismissibleImplementation: React.FC<
-  React.ComponentProps<typeof BannerSlim>
-> = (props) => (
+const BannerSlimDismissibleImplementation = (
+  props: React.ComponentProps<typeof BannerSlim>
+) => (
   <BannerSlimImplementation {...props}>
     <BannerSlim.Dismiss data-testid="dismiss" label="dismiss banner" />
   </BannerSlimImplementation>

--- a/lib/src/components/banner/banner-slim/BannerSlim.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlim.tsx
@@ -10,33 +10,30 @@ import { BannerSlimDismiss } from './BannerSlimDismiss'
 import { BannerSlimImage } from './BannerSlimImage'
 import { BannerSlimText } from './BannerSlimText'
 
-export const BannerSlim: React.FC<
-  React.ComponentProps<typeof Banner> &
-    React.ComponentProps<typeof BannerContainer>
-> & {
-  Content: typeof BannerSlimContent
-  Text: typeof BannerSlimText
-  Image: typeof BannerSlimImage
-  Button: typeof BannerSlimButton
-  Dismiss: typeof BannerSlimDismiss
-  Actions: typeof BannerSlimActions
-} = ({ colorScheme, size, emphasis, onDismiss, ...rest }) => {
-  return (
-    <Banner size={size} emphasis={emphasis}>
-      <BannerSlimContainer
-        colorScheme={colorScheme}
-        onDismiss={onDismiss}
-        {...rest}
-      />
-    </Banner>
-  )
-}
+const BannerSlimComponent = ({
+  colorScheme,
+  size,
+  emphasis,
+  onDismiss,
+  ...rest
+}: React.ComponentProps<typeof Banner> &
+  React.ComponentProps<typeof BannerContainer>) => (
+  <Banner size={size} emphasis={emphasis}>
+    <BannerSlimContainer
+      colorScheme={colorScheme}
+      onDismiss={onDismiss}
+      {...rest}
+    />
+  </Banner>
+)
 
-BannerSlim.Content = BannerSlimContent
-BannerSlim.Text = BannerSlimText
-BannerSlim.Image = BannerSlimImage
-BannerSlim.Button = BannerSlimButton
-BannerSlim.Dismiss = BannerSlimDismiss
-BannerSlim.Actions = BannerSlimActions
+export const BannerSlim = Object.assign(BannerSlimComponent, {
+  Content: BannerSlimContent,
+  Text: BannerSlimText,
+  Image: BannerSlimImage,
+  Button: BannerSlimButton,
+  Dismiss: BannerSlimDismiss,
+  Actions: BannerSlimActions
+})
 
-BannerSlim.displayName = 'BannerSlim'
+BannerSlimComponent.displayName = 'BannerSlim'

--- a/lib/src/components/banner/banner-slim/BannerSlimActions.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlimActions.tsx
@@ -14,10 +14,10 @@ const StyledBannerSlimActions = styled(Flex, {
   }
 })
 
-export const BannerSlimActions: React.FC<React.ComponentProps<typeof Flex>> = ({
+export const BannerSlimActions = ({
   children,
   ...props
-}) => {
+}: React.ComponentProps<typeof Flex>) => {
   const { size } = useBannerContext()
   return (
     <StyledBannerSlimActions size={size} gap={4} {...props}>

--- a/lib/src/components/banner/banner-slim/BannerSlimButton.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlimButton.tsx
@@ -5,9 +5,10 @@ import { overrideStitchesVariantValue } from '~/utilities/override-stitches-vari
 import { Button } from '../../button'
 import { useBannerContext } from '../BannerContext'
 
-export const BannerSlimButton: React.FC<
-  React.ComponentProps<typeof Button>
-> = ({ css, ...props }) => {
+export const BannerSlimButton = ({
+  css,
+  ...props
+}: React.ComponentProps<typeof Button>) => {
   const { emphasis, size } = useBannerContext()
 
   const fullWidth = React.useMemo(

--- a/lib/src/components/banner/banner-slim/BannerSlimContent.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlimContent.tsx
@@ -8,10 +8,8 @@ const StyledBannerSlimContent = styled(Flex, {
   width: '100%'
 })
 
-export const BannerSlimContent: React.FC<
-  React.ComponentProps<typeof StyledBannerSlimContent>
-> = (props) => {
-  return <StyledBannerSlimContent align="center" gap={4} {...props} />
-}
+export const BannerSlimContent = (
+  props: React.ComponentProps<typeof StyledBannerSlimContent>
+) => <StyledBannerSlimContent align="center" gap={4} {...props} />
 
 BannerSlimContent.displayName = 'BannerSlimContent'

--- a/lib/src/components/banner/banner-slim/BannerSlimImage.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlimImage.tsx
@@ -29,9 +29,7 @@ const StyledImage = styled(Image, {
   objectFit: 'cover'
 })
 
-export const BannerSlimImage: React.FC<React.ComponentProps<typeof Image>> = (
-  props
-) => {
+export const BannerSlimImage = (props: React.ComponentProps<typeof Image>) => {
   const { size } = useBannerContext()
 
   return (

--- a/lib/src/components/banner/banner-slim/BannerSlimText.tsx
+++ b/lib/src/components/banner/banner-slim/BannerSlimText.tsx
@@ -28,9 +28,7 @@ const StyledText = styled(Text, {
   ]
 })
 
-export const BannerSlimText: React.FC<React.ComponentProps<typeof Text>> = (
-  props
-) => {
+export const BannerSlimText = (props: React.ComponentProps<typeof Text>) => {
   const { size, hasDismiss } = useBannerContext()
 
   return (

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -196,6 +196,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       )}
     </StyledButton>
   )
-) as React.FC<ButtonProps>
+)
 
 Button.displayName = 'Button'

--- a/lib/src/components/calendar/Calendar.tsx
+++ b/lib/src/components/calendar/Calendar.tsx
@@ -69,7 +69,7 @@ const offsetWeekdayNames = (
   return end.concat(start)
 }
 
-export const Calendar: React.FC<CalendarProps> = ({
+export const Calendar = ({
   css,
   refDateSelected,
   refDateToday,
@@ -82,7 +82,7 @@ export const Calendar: React.FC<CalendarProps> = ({
   maxDate,
   setYear,
   ...remainingProps
-}) => {
+}: CalendarProps) => {
   const [showYears, setShowYears] = React.useState<boolean>(false)
   const [currentYear, setCurrentYear] = React.useState<number>(
     date?.getFullYear()

--- a/lib/src/components/carousel/Carousel.tsx
+++ b/lib/src/components/carousel/Carousel.tsx
@@ -14,43 +14,30 @@ type CarouselProps = {
   numSlides: number
 }
 
-type CarouselSubComponents = {
-  ArrowNext: typeof CarouselArrowNext
-  ArrowPrevious: typeof CarouselArrowPrevious
-  Pagination: typeof CarouselPagination
-  Slide: typeof CarouselSlide
-  Slider: typeof CarouselSlider
-}
-
-export const Carousel: React.FC<
-  CarouselProps &
-    Omit<
-      React.ComponentProps<typeof CarouselProvider>,
-      'naturalSlideWidth' | 'naturalSlideHeight' | 'totalSlides'
-    > &
-    React.ComponentProps<typeof CSSWrapper>
-> &
-  CarouselSubComponents = ({
+export const CarouselComponent = ({
   children,
   css,
   slideHeight,
   slideWidth,
   numSlides,
   ...props
-}) => {
-  return (
-    <CSSWrapper css={css}>
-      <CarouselProvider
-        naturalSlideWidth={slideWidth}
-        naturalSlideHeight={slideHeight}
-        totalSlides={numSlides}
-        {...props}
-      >
-        {children}
-      </CarouselProvider>
-    </CSSWrapper>
-  )
-}
+}: CarouselProps &
+  Omit<
+    React.ComponentProps<typeof CarouselProvider>,
+    'naturalSlideWidth' | 'naturalSlideHeight' | 'totalSlides'
+  > &
+  React.ComponentProps<typeof CSSWrapper>) => (
+  <CSSWrapper css={css}>
+    <CarouselProvider
+      naturalSlideWidth={slideWidth}
+      naturalSlideHeight={slideHeight}
+      totalSlides={numSlides}
+      {...props}
+    >
+      {children}
+    </CarouselProvider>
+  </CSSWrapper>
+)
 
 /**
  * Documentation about the hook usage
@@ -58,10 +45,12 @@ export const Carousel: React.FC<
  */
 export const useCarousel = () => React.useContext(CarouselContext)
 
-Carousel.ArrowNext = CarouselArrowNext
-Carousel.ArrowPrevious = CarouselArrowPrevious
-Carousel.Pagination = CarouselPagination
-Carousel.Slide = CarouselSlide
-Carousel.Slider = CarouselSlider
+export const Carousel = Object.assign(CarouselComponent, {
+  ArrowNext: CarouselArrowNext,
+  ArrowPrevious: CarouselArrowPrevious,
+  Pagination: CarouselPagination,
+  Slide: CarouselSlide,
+  Slider: CarouselSlider
+})
 
-Carousel.displayName = 'Carousel'
+CarouselComponent.displayName = 'Carousel'

--- a/lib/src/components/carousel/CarouselArrows.tsx
+++ b/lib/src/components/carousel/CarouselArrows.tsx
@@ -36,12 +36,12 @@ const StyledButtonBack = styled(BaseButtonBack, buttonStyles)
 
 const StyledButtonNext = styled(BaseButtonNext, buttonStyles)
 
-export const CarouselArrowPrevious: React.FC<{ css: CSS }> = (props) => (
+export const CarouselArrowPrevious = (props: { css: CSS }) => (
   <StyledButtonBack {...props}>
     <Icon is={ChevronLeft} />
   </StyledButtonBack>
 )
-export const CarouselArrowNext: React.FC<{ css: CSS }> = (props) => (
+export const CarouselArrowNext = (props: { css: CSS }) => (
   <StyledButtonNext {...props}>
     <Icon is={ChevronRight} />
   </StyledButtonNext>

--- a/lib/src/components/carousel/CarouselSlide.tsx
+++ b/lib/src/components/carousel/CarouselSlide.tsx
@@ -6,12 +6,10 @@ import { styled } from '~/stitches'
 
 const StyledSlide = styled(BaseSlide, {})
 
-type SlideProps = React.ComponentProps<typeof StyledSlide> & { index: number }
-
-export const CarouselSlide: React.FC<SlideProps> = ({
+export const CarouselSlide = ({
   children,
   ...remainingProps
-}) => (
+}: React.ComponentProps<typeof StyledSlide> & { index: number }) => (
   <StyledSlide {...remainingProps} tag="div">
     {/* padding to create the gap between slides */}
     <Box css={{ px: '$3' }}>{children}</Box>

--- a/lib/src/components/checkbox-field/CheckboxField.tsx
+++ b/lib/src/components/checkbox-field/CheckboxField.tsx
@@ -8,15 +8,12 @@ import {
 } from '~/components/field-wrapper'
 import { useFieldError } from '~/components/form'
 
-type CheckboxFieldProps = React.ComponentProps<typeof Checkbox> &
-  FieldElementWrapperProps
-
 enum CheckboxValue {
   ON = 'on',
   OFF = 'off'
 }
 
-export const CheckboxField: React.FC<CheckboxFieldProps> = ({
+export const CheckboxField = ({
   css,
   label,
   name,
@@ -26,7 +23,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   checked,
   onCheckedChange,
   ...remainingProps
-}) => {
+}: React.ComponentProps<typeof Checkbox> & FieldElementWrapperProps) => {
   const { control } = useFormContext()
   const { error } = useFieldError(name)
   const {

--- a/lib/src/components/checkbox-group/context/CheckboxGroupChecked.context.tsx
+++ b/lib/src/components/checkbox-group/context/CheckboxGroupChecked.context.tsx
@@ -37,14 +37,12 @@ const generateNewCheckedFn = (
   }
 }
 
-export const CheckboxGroupCheckedProvider: React.FC<
-  CheckboxGroupCheckedContextProps
-> = ({
+export const CheckboxGroupCheckedProvider = ({
   checked: controlledChecked,
   defaultChecked = [],
   onCheckedChange,
   ...rest
-}) => {
+}: CheckboxGroupCheckedContextProps) => {
   const [checked, setChecked] = React.useState(defaultChecked)
 
   const handleItemControlledCheckedChange = React.useCallback(

--- a/lib/src/components/checkbox-group/context/CheckboxGroupChecked.context.tsx
+++ b/lib/src/components/checkbox-group/context/CheckboxGroupChecked.context.tsx
@@ -42,7 +42,7 @@ export const CheckboxGroupCheckedProvider = ({
   defaultChecked = [],
   onCheckedChange,
   ...rest
-}: CheckboxGroupCheckedContextProps) => {
+}: React.PropsWithChildren<CheckboxGroupCheckedContextProps>) => {
   const [checked, setChecked] = React.useState(defaultChecked)
 
   const handleItemControlledCheckedChange = React.useCallback(

--- a/lib/src/components/checkbox/Checkbox.tsx
+++ b/lib/src/components/checkbox/Checkbox.tsx
@@ -66,29 +66,28 @@ const toIconSize = {
   lg: 'md'
 }
 
-type CheckboxProps = React.ComponentProps<typeof StyledCheckbox>
+export const Checkbox = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof StyledCheckbox>
+>(({ size = 'md', checked, ...rest }, ref) => {
+  const iconSize = React.useMemo(
+    () => overrideStitchesVariantValue(size, (s) => toIconSize[s]),
+    [size]
+  )
 
-export const Checkbox: React.FC<CheckboxProps> = React.forwardRef(
-  ({ size = 'md', checked, ...rest }, ref) => {
-    const iconSize = React.useMemo(
-      () => overrideStitchesVariantValue(size, (s) => toIconSize[s]),
-      [size]
-    )
-
-    return (
-      <StyledCheckbox ref={ref} checked={checked} size={size} {...rest}>
-        <StyledIndicator asChild>
-          <Icon
-            is={checked === 'indeterminate' ? Minus : Ok}
-            css={{
-              strokeWidth: '3'
-            }}
-            size={iconSize}
-          />
-        </StyledIndicator>
-      </StyledCheckbox>
-    )
-  }
-)
+  return (
+    <StyledCheckbox ref={ref} checked={checked} size={size} {...rest}>
+      <StyledIndicator asChild>
+        <Icon
+          is={checked === 'indeterminate' ? Minus : Ok}
+          css={{
+            strokeWidth: '3'
+          }}
+          size={iconSize}
+        />
+      </StyledIndicator>
+    </StyledCheckbox>
+  )
+})
 
 Checkbox.displayName = 'Checkbox'

--- a/lib/src/components/chip-dismissible-group/ChipDismissibleGroupItem.tsx
+++ b/lib/src/components/chip-dismissible-group/ChipDismissibleGroupItem.tsx
@@ -17,12 +17,12 @@ export type TChipDismissibleGroupItem = React.ComponentProps<
     dismissActionLabel: string
   }
 
-export const ChipDismissibleGroupItem: React.FC<TChipDismissibleGroupItem> = ({
+export const ChipDismissibleGroupItem = ({
   size = 'md',
   children,
   dismissActionLabel = 'Dismiss',
   ...rest
-}) => {
+}: TChipDismissibleGroupItem) => {
   return (
     <DismissibleGroup.Item asChild {...rest}>
       <StyledChipDismissibleGroupItem size={size}>

--- a/lib/src/components/chip-toggle-group/ChipToggleGroupItem.tsx
+++ b/lib/src/components/chip-toggle-group/ChipToggleGroupItem.tsx
@@ -46,11 +46,11 @@ const StyledChipToggleGroupItem = styled.withConfig({
 type TChipToggleGroupItem = React.ComponentProps<typeof ToggleGroup.Item> &
   React.ComponentProps<typeof StyledChipToggleGroupItem>
 
-export const ChipToggleGroupItem: React.FC<TChipToggleGroupItem> = ({
+export const ChipToggleGroupItem = ({
   size = 'md',
   children,
   ...rest
-}) => {
+}: TChipToggleGroupItem) => {
   return (
     <ToggleGroup.Item {...rest} asChild>
       <StyledChipToggleGroupItem as="button">

--- a/lib/src/components/chip/Chip.tsx
+++ b/lib/src/components/chip/Chip.tsx
@@ -25,7 +25,7 @@ export const StyledChipContent = styled('span', {
 
 const toIconSize = { sm: 'sm', md: 'sm', lg: 'md' }
 
-export const ChipIcon: typeof Icon = ({ ...props }) => {
+export const ChipIcon = (props: React.ComponentProps<typeof Icon>) => {
   const rootContext = React.useContext(ChipRootContext)
   const { size } = rootContext
   const iconSize = React.useMemo(
@@ -118,12 +118,9 @@ const ChipRoot: React.ForwardRefExoticComponent<TChipRootProps> =
     )
   })
 
-type TChipType = typeof ChipRoot & {
-  Content: typeof ChipContent
-  Icon: typeof ChipIcon
-}
+export const Chip = Object.assign(ChipRoot, {
+  Content: ChipContent,
+  Icon: ChipIcon
+})
 
-export const Chip = ChipRoot as TChipType
-Chip.Content = ChipContent
-Chip.Icon = ChipIcon
-Chip.displayName = 'Chip'
+ChipRoot.displayName = 'Chip'

--- a/lib/src/components/chip/Chip.tsx
+++ b/lib/src/components/chip/Chip.tsx
@@ -95,10 +95,10 @@ export type TChipRootProviderProps = TChipRootContext
 
 export const ChipRootContext = React.createContext<TChipRootContext>({})
 
-export const ChipRootProvider: React.FC<TChipRootProviderProps> = ({
+export const ChipRootProvider = ({
   size,
   children
-}) => {
+}: TChipRootProviderProps) => {
   const value = React.useMemo<TChipRootContext>(() => ({ size }), [size])
   return (
     <ChipRootContext.Provider value={value}>

--- a/lib/src/components/combobox/Combobox.tsx
+++ b/lib/src/components/combobox/Combobox.tsx
@@ -1,5 +1,4 @@
 import { Combobox as BaseCombobox, ComboboxOptionText } from '@reach/combobox'
-import * as React from 'react'
 
 import { globalCss, styled } from '~/stitches'
 
@@ -10,21 +9,11 @@ import { ComboboxPopover } from './ComboboxPopover'
 
 globalCss({ ':root': { '--reach-combobox': 1 } })()
 
-const StyledCombobox = styled(BaseCombobox, {})
-
-type ComboboxProps = React.ComponentProps<typeof StyledCombobox>
-
-export const Combobox: React.FC<ComboboxProps> & {
-  Input: typeof ComboboxInput
-  Popover: typeof ComboboxPopover
-  List: typeof ComboboxList
-  Option: typeof ComboboxOption
-  OptionText: typeof ComboboxOptionText
-} = (props) => <StyledCombobox {...props} />
-
-Combobox.displayName = 'Combobox'
-Combobox.Option = ComboboxOption
-Combobox.Input = ComboboxInput
-Combobox.Popover = ComboboxPopover
-Combobox.List = ComboboxList
-Combobox.OptionText = ComboboxOptionText
+export const Combobox = Object.assign(styled(BaseCombobox, {}), {
+  displayName: 'Combobox',
+  Option: ComboboxOption,
+  Input: ComboboxInput,
+  Popover: ComboboxPopover,
+  List: ComboboxList,
+  OptionText: ComboboxOptionText
+})

--- a/lib/src/components/combobox/ComboboxInput.tsx
+++ b/lib/src/components/combobox/ComboboxInput.tsx
@@ -67,8 +67,9 @@ export type ComboboxInputProps = React.ComponentProps<
   typeof StyledComboboxInput
 >
 
-export const ComboboxInput: React.FC<ComboboxInputProps> = React.forwardRef(
-  ({ size = 'md', ...rest }, ref) => {
-    return <StyledComboboxInput size={size} {...rest} ref={ref} />
-  }
-)
+export const ComboboxInput = React.forwardRef<
+  HTMLInputElement,
+  ComboboxInputProps
+>(({ size = 'md', ...rest }, ref) => (
+  <StyledComboboxInput size={size} {...rest} ref={ref} />
+))

--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -64,7 +64,7 @@ const data = [
  * In practice, `Tooltip.Provider` is rendered once at the root of an app,
  * but this wrapper provides it for these tests.
  */
-const Wrapper: React.FC = ({ children }) => (
+const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => (
   <Tooltip.Provider>{children}</Tooltip.Provider>
 )
 

--- a/lib/src/components/data-table/DataTable.tsx
+++ b/lib/src/components/data-table/DataTable.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { DataTableBody } from './DataTableBody'
 import { DataTableBulkActions } from './DataTableBulkActions'
 import { DataTableProvider } from './DataTableContext'
@@ -18,28 +16,35 @@ import { DataTableTable } from './DataTableTable'
 import { DragAndDropTable } from './drag-and-drop'
 import { Pagination } from './pagination'
 
-type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
+/** Context provider for DataTable state and logic.
+ *
+ * Children can call `useDataTable` to access everything provided by `@tanstack/react-table` plus
+ * the functionality we've built on top.
+ */
+export const DataTable = Object.assign(DataTableProvider, {
   /** Default table body implementation for `DataTable`.
    *
    * Can be configured with alternating colours of rows. If you need more customisation options,
    * you can build your own implementation with `useDataTable()` and the UI-only `Table` components.
    */
-  Body: typeof DataTableBody
+  Body: DataTableBody,
 
   /** Default table data cell implementation for `DataTable`
    *
    *
    */
-  DataCell: typeof DataTableDataCell
+  DataCell: DataTableDataCell,
+
   /**
    * Used in place of `DataTable.Table` to render a table with rows that the user can sort by drag-and-drop
    */
-  DragAndDropTable: typeof DragAndDropTable
+  DragAndDropTable: DragAndDropTable,
+
   /** Default global search implementation for `DataTable`
    *
    * If you need more customisation options, you can compose your own implementation with our UI-only input components and `useDataTable`.
    */
-  GlobalFilter: typeof DataTableGlobalFilter
+  GlobalFilter: DataTableGlobalFilter,
 
   /** Default table head implementation
    *
@@ -47,35 +52,34 @@ type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
    * If you need more customisation options, you can build your own implementation
    * with `useDataTable` and the UI-only `Table` components.
    */
+  Head: DataTableHead,
 
-  Head: typeof DataTableHead
   /** Default header implementation for `DataTable`
    *
    * Can be configured to make the column sortable. If you need more customisation options,
    * you can build your own implementation with the UI-only `Table` components.
    */
+  HeaderCell: DataTableHeaderCell,
 
-  HeaderCell: typeof DataTableHeaderCell
   /** Default pagination implementation for `DataTable`
    *
    * Can navigate forward, backward, or to any specific page. If you need more customisation options,
    * you can build your own implementation with `useDataTable` and other UI components.
    *
    */
+  MetaData: DataTableMetaData,
 
-  MetaData: typeof DataTableMetaData
   /** Default display of amount of items and current sorting status for 'DataTable'
    *
    */
+  Pagination: Pagination,
 
-  Pagination: typeof Pagination
   /** Default row implementation for `DataTable`
    *
    * Renders all visible cells as `Table.Cell`. If you need more customisation options,
    * you can build your own implementation with the UI-only `Table` components.
    */
-
-  Row: typeof DataTableRow
+  Row: DataTableRow,
 
   /** Default table implementation for `DataTable`.
    *
@@ -86,7 +90,7 @@ type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
    * scratch with `useDataTable` and the UI-only `Table` components.
    *
    */
-  Table: typeof DataTableTable
+  Table: DataTableTable,
 
   /** Default loading implementation for remote data
    *
@@ -95,7 +99,7 @@ type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
    * If you need more customisation, you can compose your own implentation, `asyncDataState`
    * can be retrieved from `useDataTable`
    */
-  Loading: typeof DataTableLoading
+  Loading: DataTableLoading,
 
   /** Default error implementation for remote data
    *
@@ -108,53 +112,29 @@ type TDataTable = React.FC<React.ComponentProps<typeof DataTableProvider>> & {
    * can be retrieved from `useDataTable`
    *
    */
-  Error: typeof DataTableError
+  Error: DataTableError,
 
   /** Empty state implementation for `DataTable`.
    *
    * Extends the EmptyState component
    */
-  EmptyState: typeof DataTableEmptyState
+  EmptyState: DataTableEmptyState,
 
   /** Empty state implementation for `DataTable`.
    *
    * Renders a checkbox on the header, allowing for bulk selection/deselection of all selectable rows
    */
-  SelectAllRowsCheckbox: typeof DataTableSelectAllRowsCheckbox
+  SelectAllRowsCheckbox: DataTableSelectAllRowsCheckbox,
 
   /** Empty state implementation for `DataTable`.
    *
    * Renders a checkbox on the header, allowing for individual selection/deselection of any selectable row
    */
-  RowSelectionCheckbox: typeof DataTableRowSelectionCheckbox
+  RowSelectionCheckbox: DataTableRowSelectionCheckbox,
 
   /** Empty state implementation for `DataTable`.
    *
    * Renders a checkbox on the header, allowing for individual selection/deselection of any selectable row
    */
-  BulkActions: typeof DataTableBulkActions
-}
-
-/** Context provider for DataTable state and logic.
- *
- * Children can call `useDataTable` to access everything provided by `@tanstack/react-table` plus
- * the functionality we've built on top.
- */
-export const DataTable: TDataTable = (props) => <DataTableProvider {...props} />
-
-DataTable.Body = DataTableBody
-DataTable.DataCell = DataTableDataCell
-DataTable.DragAndDropTable = DragAndDropTable
-DataTable.Head = DataTableHead
-DataTable.HeaderCell = DataTableHeaderCell
-DataTable.MetaData = DataTableMetaData
-DataTable.Pagination = Pagination
-DataTable.Row = DataTableRow
-DataTable.GlobalFilter = DataTableGlobalFilter
-DataTable.Table = DataTableTable
-DataTable.Loading = DataTableLoading
-DataTable.Error = DataTableError
-DataTable.EmptyState = DataTableEmptyState
-DataTable.SelectAllRowsCheckbox = DataTableSelectAllRowsCheckbox
-DataTable.RowSelectionCheckbox = DataTableRowSelectionCheckbox
-DataTable.BulkActions = DataTableBulkActions
+  BulkActions: DataTableBulkActions
+})

--- a/lib/src/components/data-table/DataTableBody.tsx
+++ b/lib/src/components/data-table/DataTableBody.tsx
@@ -9,10 +9,10 @@ type DataTableBodyProps = Omit<
   'children'
 >
 
-export const DataTableBody: React.FC<DataTableBodyProps> = ({
+export const DataTableBody = ({
   striped = false,
   ...props
-}) => {
+}: DataTableBodyProps) => {
   const { getRowModel } = useDataTable()
 
   return (

--- a/lib/src/components/data-table/DataTableBulkActions.tsx
+++ b/lib/src/components/data-table/DataTableBulkActions.tsx
@@ -8,28 +8,6 @@ import { Flex } from '../flex'
 import { DataTable } from '.'
 import { useDataTable } from './DataTableContext'
 
-interface DataTableBulkActionsProps {
-  css?: CSS
-  children:
-    | React.ReactElement<React.ComponentProps<typeof BulkActionsDefaultActions>>
-    | React.ReactElement<
-        React.ComponentProps<typeof BulkActionsSelectedRowActions>
-      >
-    | [
-        React.ReactElement<
-          React.ComponentProps<typeof BulkActionsDefaultActions>
-        >,
-        React.ReactElement<
-          React.ComponentProps<typeof BulkActionsSelectedRowActions>
-        >
-      ]
-}
-
-interface BulkActionsSelectedRowActionsProps {
-  cancelLabel?: string
-  children: React.ReactNode
-}
-
 const StyledContainer = styled(Flex, {
   p: '$2',
   width: '100%',
@@ -60,9 +38,13 @@ const BulkActionsDefaultActions = ({
   return children
 }
 
-const BulkActionsSelectedRowActions: React.FC<
-  BulkActionsSelectedRowActionsProps
-> = ({ cancelLabel = 'Cancel', children }) => {
+const BulkActionsSelectedRowActions = ({
+  cancelLabel = 'Cancel',
+  children
+}: {
+  cancelLabel?: string
+  children: React.ReactNode
+}) => {
   const { toggleAllPageRowsSelected, rowSelection } = useDataTable()
 
   const handleDeselectAllPageRows = () => toggleAllPageRowsSelected(false)
@@ -82,24 +64,44 @@ const BulkActionsSelectedRowActions: React.FC<
   )
 }
 
-export const DataTableBulkActions: React.FC<DataTableBulkActionsProps> & {
-  DefaultActions: typeof BulkActionsDefaultActions
-  SelectedRowActions: typeof BulkActionsSelectedRowActions
-} = ({ children, ...rest }) => {
-  const { rowSelection } = useDataTable()
+export const DataTableBulkActions = Object.assign(
+  ({
+    children,
+    ...rest
+  }: {
+    css?: CSS
+    children:
+      | React.ReactElement<
+          React.ComponentProps<typeof BulkActionsDefaultActions>
+        >
+      | React.ReactElement<
+          React.ComponentProps<typeof BulkActionsSelectedRowActions>
+        >
+      | [
+          React.ReactElement<
+            React.ComponentProps<typeof BulkActionsDefaultActions>
+          >,
+          React.ReactElement<
+            React.ComponentProps<typeof BulkActionsSelectedRowActions>
+          >
+        ]
+  }) => {
+    const { rowSelection } = useDataTable()
 
-  const isRowSelected = Object.keys(rowSelection || {}).length > 0
+    const isRowSelected = Object.keys(rowSelection || {}).length > 0
 
-  return (
-    <StyledContainer isRowSelected={isRowSelected} {...rest}>
-      <DataTable.MetaData />
+    return (
+      <StyledContainer isRowSelected={isRowSelected} {...rest}>
+        <DataTable.MetaData />
 
-      <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
-        {children}
-      </Flex>
-    </StyledContainer>
-  )
-}
-
-DataTableBulkActions.DefaultActions = BulkActionsDefaultActions
-DataTableBulkActions.SelectedRowActions = BulkActionsSelectedRowActions
+        <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
+          {children}
+        </Flex>
+      </StyledContainer>
+    )
+  },
+  {
+    DefaultActions: BulkActionsDefaultActions,
+    SelectedRowActions: BulkActionsSelectedRowActions
+  }
+)

--- a/lib/src/components/data-table/DataTableDataCell.tsx
+++ b/lib/src/components/data-table/DataTableDataCell.tsx
@@ -8,9 +8,7 @@ type DataTableDataCellProps = {
   cell: Cell<Record<string, unknown>, unknown>
 }
 
-export const DataTableDataCell: React.FC<DataTableDataCellProps> = ({
-  cell
-}) => {
+export const DataTableDataCell = ({ cell }: DataTableDataCellProps) => {
   return (
     <Table.Cell key={cell.id}>
       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/lib/src/components/data-table/DataTableEmptyState.tsx
+++ b/lib/src/components/data-table/DataTableEmptyState.tsx
@@ -6,10 +6,10 @@ import { useDataTable } from './DataTableContext'
 
 type DataTableEmptyStateProps = React.ComponentProps<typeof EmptyState>
 
-export const DataTableEmptyState: React.FC<DataTableEmptyStateProps> = ({
+export const DataTableEmptyState = ({
   children,
   ...rest
-}) => {
+}: DataTableEmptyStateProps) => {
   const { asyncDataState, getTotalRows } = useDataTable()
 
   const isPending = asyncDataState === AsyncDataState.PENDING

--- a/lib/src/components/data-table/DataTableError.tsx
+++ b/lib/src/components/data-table/DataTableError.tsx
@@ -3,12 +3,10 @@ import * as React from 'react'
 import { AsyncDataState, DataTableContextType } from './DataTable.types'
 import { useDataTable } from './DataTableContext'
 
-interface IDataTableErrorProps {
-  children: (retry?: DataTableContextType['runAsyncData']) => React.ReactElement
-}
-
-export const DataTableError: React.FC<IDataTableErrorProps> = ({
+export const DataTableError = ({
   children
+}: {
+  children: (retry?: DataTableContextType['runAsyncData']) => React.ReactElement
 }) => {
   const { asyncDataState, runAsyncData } = useDataTable()
 

--- a/lib/src/components/data-table/DataTableGlobalFilter.tsx
+++ b/lib/src/components/data-table/DataTableGlobalFilter.tsx
@@ -11,12 +11,12 @@ type DataTableSearchProps = React.ComponentProps<typeof SearchInput> & {
   label: string
   hideLabel?: boolean
 }
-export const DataTableGlobalFilter: React.FC<DataTableSearchProps> = ({
+export const DataTableGlobalFilter = ({
   onChange,
   label,
   hideLabel = false,
   ...props
-}) => {
+}: DataTableSearchProps) => {
   const {
     setGlobalFilter,
     getState,

--- a/lib/src/components/data-table/DataTableHead.tsx
+++ b/lib/src/components/data-table/DataTableHead.tsx
@@ -15,12 +15,12 @@ type DataTableHeadProps = Omit<
   headerCss?: CSS
 }
 
-export const DataTableHead: React.FC<DataTableHeadProps> = ({
+export const DataTableHead = ({
   sortable = true,
   theme = 'light',
   isSticky = false,
   ...props
-}) => {
+}: DataTableHeadProps) => {
   const {
     getHeaderGroups,
     setIsSortable,

--- a/lib/src/components/data-table/DataTableHeaderCell.tsx
+++ b/lib/src/components/data-table/DataTableHeaderCell.tsx
@@ -16,7 +16,7 @@ const sortIcons = {
   desc: SortDown
 }
 
-const SortIcon: React.FC<{ direction: 'asc' | 'desc' }> = ({ direction }) => (
+const SortIcon = ({ direction }: { direction: 'asc' | 'desc' }) => (
   <Icon
     is={sortIcons[direction]}
     size="sm"
@@ -24,12 +24,12 @@ const SortIcon: React.FC<{ direction: 'asc' | 'desc' }> = ({ direction }) => (
   />
 )
 
-export const DataTableHeaderCell: React.FC<DataTableHeaderProps> = ({
+export const DataTableHeaderCell = ({
   header,
   children,
   css,
   ...props
-}) => {
+}: DataTableHeaderProps) => {
   const sortDirection = header.column.getIsSorted()
   const { isSortable: isSortableTable } = useDataTable()
   // false for display columns, e.g. "Actions"

--- a/lib/src/components/data-table/DataTableLoading.tsx
+++ b/lib/src/components/data-table/DataTableLoading.tsx
@@ -14,9 +14,9 @@ const PendingState = styled(Loader, {
   zIndex: 1
 })
 
-export const DataTableLoading: React.FC<
-  React.ComponentProps<typeof PendingState>
-> = (props) => {
+export const DataTableLoading = (
+  props: React.ComponentProps<typeof PendingState>
+) => {
   const { asyncDataState } = useDataTable()
 
   if (asyncDataState !== AsyncDataState.PENDING) return null

--- a/lib/src/components/data-table/DataTableMetaData.tsx
+++ b/lib/src/components/data-table/DataTableMetaData.tsx
@@ -4,7 +4,17 @@ import * as React from 'react'
 import { Text } from '../text'
 import { useDataTable } from './index'
 
-interface IDataTableMetaDataProps {
+const defaultCopy = {
+  sorted_by: 'Sorted by',
+  ascending: 'ascending',
+  descending: 'descending',
+  separator: '-'
+}
+
+export const DataTableMetaData = ({
+  copy,
+  css
+}: {
   copy?: {
     sorted_by?: string
     ascending?: string
@@ -13,18 +23,6 @@ interface IDataTableMetaDataProps {
   }
   sortLabel?: string
   css?: CSS
-}
-
-const defaultCopy = {
-  sorted_by: 'Sorted by',
-  ascending: 'ascending',
-  descending: 'descending',
-  separator: '-'
-}
-
-export const DataTableMetaData: React.FC<IDataTableMetaDataProps> = ({
-  copy,
-  css
 }) => {
   const { getState, columns, getRowModel, rowSelection } = useDataTable()
   const { sorting } = getState()

--- a/lib/src/components/data-table/DataTableRow.tsx
+++ b/lib/src/components/data-table/DataTableRow.tsx
@@ -26,7 +26,7 @@ const StyledRow = styled(Table.Row, {
   }
 })
 
-export const DataTableRow: React.FC<DataTableRowProps> = ({ row }) => {
+export const DataTableRow = ({ row }: DataTableRowProps) => {
   const { enableRowSelection, getCanSomeRowsExpand } = useDataTable()
 
   const toggleExpandHandler = row.getToggleExpandedHandler()

--- a/lib/src/components/data-table/DataTableRowSelectionCheckbox.tsx
+++ b/lib/src/components/data-table/DataTableRowSelectionCheckbox.tsx
@@ -6,19 +6,17 @@ import { Checkbox } from '../checkbox'
 import { Label } from '../label'
 import { useDataTable } from './DataTableContext'
 
-interface DataTableRowSelectionCheckboxProps {
-  row: Row<Record<string, unknown>>
-  checked: boolean | 'indeterminate'
-  onCheckedChange: (value: boolean) => void
-  label?: string
-}
-
 export const DataTableRowSelectionCheckbox = ({
   row,
   checked,
   onCheckedChange,
   label = `Row ${row.id} selection`
-}: DataTableRowSelectionCheckboxProps): React.ReactElement => {
+}: {
+  row: Row<Record<string, unknown>>
+  checked: boolean | 'indeterminate'
+  onCheckedChange: (value: boolean) => void
+  label?: string
+}): React.ReactElement => {
   const { tableId } = useDataTable()
 
   return (

--- a/lib/src/components/data-table/DataTableSelectAllRowsCheckbox.tsx
+++ b/lib/src/components/data-table/DataTableSelectAllRowsCheckbox.tsx
@@ -5,13 +5,11 @@ import { Checkbox } from '../checkbox'
 import { Label } from '../label'
 import { useDataTable } from './DataTableContext'
 
-interface DataTableSelectAllRowsCheckboxProps {
-  label?: string
-}
-
 export const DataTableSelectAllRowsCheckbox = ({
   label = 'All rows selection'
-}: DataTableSelectAllRowsCheckboxProps) => {
+}: {
+  label?: string
+}) => {
   const {
     getIsAllPageRowsSelected,
     getIsSomePageRowsSelected,

--- a/lib/src/components/data-table/DataTableTable.tsx
+++ b/lib/src/components/data-table/DataTableTable.tsx
@@ -3,19 +3,21 @@ import * as React from 'react'
 import { CSS } from '~/stitches'
 
 import { Table } from '../table'
+import { TableBody } from '../table/TableBody'
 import { DataTable } from './DataTable'
 import { AsyncDataState } from './DataTable.types'
 import { useDataTable } from './DataTableContext'
 import { DataTableLoading } from './DataTableLoading'
+import { DataTableHead } from './DataTableHead'
 
 export type DataTableTableProps = Omit<
   React.ComponentProps<typeof Table>,
   'children' | 'numberOfStickyColumns'
 > &
   Partial<
-    Pick<React.ComponentProps<typeof DataTable.Head>, 'theme' | 'sortable'>
+    Pick<React.ComponentProps<typeof DataTableHead>, 'theme' | 'sortable'>
   > &
-  Partial<Pick<React.ComponentProps<typeof Table.Body>, 'striped'>> & {
+  Partial<Pick<React.ComponentProps<typeof TableBody>, 'striped'>> & {
     scrollOptions?: {
       hasStickyHeader?: boolean
       headerCss?: CSS
@@ -24,7 +26,7 @@ export type DataTableTableProps = Omit<
     }
   }
 
-export const DataTableTable: React.FC<DataTableTableProps> = ({
+export const DataTableTable = ({
   sortable,
   striped,
   theme,
@@ -34,7 +36,7 @@ export const DataTableTable: React.FC<DataTableTableProps> = ({
     hasStickyHeader: false
   },
   ...props
-}) => {
+}: DataTableTableProps) => {
   const { asyncDataState, getTotalRows } = useDataTable()
   const isPending = asyncDataState === AsyncDataState.PENDING
   const isEmpty = !isPending && getTotalRows() === 0

--- a/lib/src/components/data-table/drag-and-drop/DragAndDropTable.tsx
+++ b/lib/src/components/data-table/drag-and-drop/DragAndDropTable.tsx
@@ -19,7 +19,7 @@ type DragAndDropTableProps = DataTableTableProps & {
   }) => void
 }
 
-export const DragAndDropTable: React.FC<DragAndDropTableProps> = ({
+export const DragAndDropTable = ({
   idColumn = 'id',
   onDragAndDrop,
   sortable,
@@ -27,7 +27,7 @@ export const DragAndDropTable: React.FC<DragAndDropTableProps> = ({
   theme,
   css,
   ...props
-}) => {
+}: DragAndDropTableProps) => {
   const { asyncDataState, data, setData } = useDataTable()
   const isPending = asyncDataState === AsyncDataState.PENDING
 

--- a/lib/src/components/data-table/drag-and-drop/DragAndDropTableBody.tsx
+++ b/lib/src/components/data-table/drag-and-drop/DragAndDropTableBody.tsx
@@ -4,6 +4,11 @@ import { Table } from '../../table'
 import { useDataTable } from '../DataTableContext'
 import { DragAndDropTableRow } from './DragAndDropTableRow'
 
+type DataTableBodyProps = Omit<
+  React.ComponentProps<typeof Table.Body>,
+  'children'
+> & { idColumn?: string }
+
 export const DragAndDropTableBody = ({
   striped = false,
   idColumn = 'id',

--- a/lib/src/components/data-table/drag-and-drop/DragAndDropTableBody.tsx
+++ b/lib/src/components/data-table/drag-and-drop/DragAndDropTableBody.tsx
@@ -4,16 +4,11 @@ import { Table } from '../../table'
 import { useDataTable } from '../DataTableContext'
 import { DragAndDropTableRow } from './DragAndDropTableRow'
 
-type DataTableBodyProps = Omit<
-  React.ComponentProps<typeof Table.Body>,
-  'children'
-> & { idColumn?: string }
-
-export const DragAndDropTableBody: React.FC<DataTableBodyProps> = ({
+export const DragAndDropTableBody = ({
   striped = false,
   idColumn = 'id',
   ...props
-}) => {
+}: DataTableBodyProps) => {
   const { getRowModel } = useDataTable()
   return (
     <Table.Body {...props} striped={striped}>

--- a/lib/src/components/data-table/drag-and-drop/DragAndDropTableRow.tsx
+++ b/lib/src/components/data-table/drag-and-drop/DragAndDropTableRow.tsx
@@ -13,10 +13,10 @@ export type DataTableDraggableRowProps = React.ComponentProps<
   idColumn?: string
 }
 
-export const DragAndDropTableRow: React.FC<DataTableDraggableRowProps> = ({
+export const DragAndDropTableRow = ({
   row,
   idColumn = 'id'
-}) => {
+}: DataTableDraggableRowProps) => {
   const rowId = row.original[idColumn] as React.ReactText
   return (
     <Sortable.Item id={rowId} asChild>

--- a/lib/src/components/data-table/pagination/Pagination.tsx
+++ b/lib/src/components/data-table/pagination/Pagination.tsx
@@ -20,7 +20,7 @@ const StyledNav = styled('nav', {
 type PaginationProps = React.ComponentProps<typeof StyledNav>
 
 /** Applies pagination to parent DataTableProvider and renders UI to switch pages etc */
-export const Pagination: React.FC<PaginationProps> = (props) => {
+export const Pagination = (props: PaginationProps) => {
   const {
     applyPagination,
     getState,

--- a/lib/src/components/data-table/pagination/PaginationButtons.tsx
+++ b/lib/src/components/data-table/pagination/PaginationButtons.tsx
@@ -9,12 +9,15 @@ import { Icon } from '../../icon'
 import { Select } from '../../select'
 import { Text } from '../../text'
 
-export const DirectionButton: React.FC<{
+export const DirectionButton = ({
+  direction,
+  ...remainingProps
+}: {
   css?: CSS
   direction: 'next' | 'previous'
   disabled: boolean
   onClick: () => void
-}> = ({ direction, ...remainingProps }) => {
+}) => {
   const isNext = direction === 'next'
 
   return (
@@ -31,12 +34,17 @@ export const DirectionButton: React.FC<{
   )
 }
 
-export const GotoPageSelect: React.FC<{
+export const GotoPageSelect = ({
+  gotoPage,
+  pageCount,
+  pageIndex,
+  disabled
+}: {
   pageIndex: number
   pageCount: number
   gotoPage: (pageNumber: number) => void
   disabled: boolean
-}> = ({ gotoPage, pageCount, pageIndex, disabled }) => {
+}) => {
   return (
     <Flex css={{ alignItems: 'center' }}>
       <Select

--- a/lib/src/components/date-field/DateField.tsx
+++ b/lib/src/components/date-field/DateField.tsx
@@ -10,7 +10,7 @@ import { useFieldError } from '~/components/form'
 
 type DateFieldProps = DateInputProps & FieldElementWrapperProps
 
-export const DateField: React.FC<DateFieldProps> = ({
+export const DateField = ({
   css,
   hideLabel,
   label,
@@ -19,7 +19,7 @@ export const DateField: React.FC<DateFieldProps> = ({
   prompt,
   description,
   ...remainingProps
-}) => {
+}: DateFieldProps) => {
   const { register, trigger } = useFormContext()
   const { error } = useFieldError(name)
   const ref = validation ? register(validation) : register

--- a/lib/src/components/dialog/Dialog.tsx
+++ b/lib/src/components/dialog/Dialog.tsx
@@ -1,5 +1,4 @@
 import { Description, Root, Title, Trigger } from '@radix-ui/react-dialog'
-import * as React from 'react'
 
 import { styled } from '~/stitches'
 
@@ -11,27 +10,16 @@ import { DialogHeading } from './DialogHeading'
 
 const StyledDialog = styled(Root, {})
 
-type DialogProps = React.ComponentProps<typeof StyledDialog>
+export const Dialog = Object.assign(StyledDialog, {
+  Background: DialogBackground,
+  Close: DialogClose,
+  Content: DialogContent,
+  Heading: DialogHeading,
+  Footer: DialogFooter,
 
-export const Dialog: React.FC<DialogProps> & {
-  Background: typeof DialogBackground
-  Close: typeof DialogClose
-  Content: typeof DialogContent
-  Heading: typeof DialogHeading
-  Footer: typeof DialogFooter
-  Description: typeof Description
-  Title: typeof Title
-  Trigger: typeof Trigger
-} = (props) => <StyledDialog {...props} />
-
-Dialog.Background = DialogBackground
-Dialog.Close = DialogClose
-Dialog.Content = DialogContent
-Dialog.Heading = DialogHeading
-Dialog.Footer = DialogFooter
-
-Dialog.Description = Description
-Dialog.Title = Title
-Dialog.Trigger = Trigger
+  Description: Description,
+  Title: Title,
+  Trigger: Trigger
+})
 
 Dialog.displayName = 'Dialog'

--- a/lib/src/components/dialog/DialogContent.tsx
+++ b/lib/src/components/dialog/DialogContent.tsx
@@ -66,13 +66,13 @@ type DialogContentProps = React.ComponentProps<typeof StyledDialogContent> & {
   showCloseButton?: boolean
 }
 
-export const DialogContent: React.FC<DialogContentProps> = ({
+export const DialogContent = ({
   size = 'sm',
   children,
   closeDialogText = 'Close dialog',
   showCloseButton = true,
   ...remainingProps
-}) => (
+}: DialogContentProps) => (
   <Portal>
     <StyledDialogOverlay id={modalOverlayId}>
       {React.Children.map(

--- a/lib/src/components/dismissible-group/DismissibleGroupItem.tsx
+++ b/lib/src/components/dismissible-group/DismissibleGroupItem.tsx
@@ -11,12 +11,12 @@ export type TDismissibleGroupItemProps = React.ComponentProps<
   disabled?: boolean
 }
 
-export const DismissibleGroupItem: React.FC<TDismissibleGroupItemProps> = ({
+export const DismissibleGroupItem = ({
   children,
   value,
   disabled: itemDisabled = false,
   ...rest
-}) => {
+}: React.PropsWithChildren<TDismissibleGroupItemProps>) => {
   const groupContext = React.useContext(DismissibleGroupContext)
   if (groupContext === undefined) {
     throw new Error(

--- a/lib/src/components/dismissible-group/DismissibleGroupRoot.tsx
+++ b/lib/src/components/dismissible-group/DismissibleGroupRoot.tsx
@@ -14,11 +14,11 @@ export interface IDismissibleGroupProps {
   onDismiss: (value: React.ReactText) => void
 }
 
-export const DismissibleGroupProvider: React.FC<IDismissibleGroupProps> = ({
+export const DismissibleGroupProvider = ({
   children,
   disabled,
   onDismiss
-}) => {
+}: React.PropsWithChildren<IDismissibleGroupProps>) => {
   const value = React.useMemo<IDismissibleGroupContext>(
     () => ({ disabled, onDismiss }),
     [disabled, onDismiss]
@@ -31,15 +31,15 @@ export const DismissibleGroupProvider: React.FC<IDismissibleGroupProps> = ({
 }
 
 export interface IDismissibleGroupRootProps extends IDismissibleGroupProps {
-  as?: React.ComponentType
+  as?: React.ElementType
 }
 
-export const DismissibleGroupRoot: React.FC<IDismissibleGroupRootProps> = ({
+export const DismissibleGroupRoot = ({
   as: Component = 'div',
   disabled,
   onDismiss,
   ...rest
-}) => {
+}: React.PropsWithChildren<IDismissibleGroupRootProps>) => {
   return (
     <DismissibleGroupProvider disabled={disabled} onDismiss={onDismiss}>
       <Component {...rest} />

--- a/lib/src/components/dismissible-group/DismissibleGroupRoot.tsx
+++ b/lib/src/components/dismissible-group/DismissibleGroupRoot.tsx
@@ -46,3 +46,5 @@ export const DismissibleGroupRoot = ({
     </DismissibleGroupProvider>
   )
 }
+
+DismissibleGroupRoot.displayName = 'DismissibleGroup'

--- a/lib/src/components/dismissible-group/index.ts
+++ b/lib/src/components/dismissible-group/index.ts
@@ -3,12 +3,7 @@ import { DismissibleTrigger } from '~/components/dismissible/DismissibleTrigger'
 import { DismissibleGroupItem } from './DismissibleGroupItem'
 import { DismissibleGroupRoot } from './DismissibleGroupRoot'
 
-type TDismissibleGroup = typeof DismissibleGroupRoot & {
-  Item: typeof DismissibleGroupItem
-  Trigger: typeof DismissibleTrigger
-}
-
-export const DismissibleGroup = DismissibleGroupRoot as TDismissibleGroup
-DismissibleGroup.Item = DismissibleGroupItem
-DismissibleGroup.Trigger = DismissibleTrigger
-DismissibleGroup.displayName = 'DismissibleGroup'
+export const DismissibleGroup = Object.assign(DismissibleGroupRoot, {
+  Item: DismissibleGroupItem,
+  Trigger: DismissibleTrigger
+})

--- a/lib/src/components/dismissible/DismissibleRoot.tsx
+++ b/lib/src/components/dismissible/DismissibleRoot.tsx
@@ -72,7 +72,9 @@ export const DismissibleRoot = ({
   dismissed,
   onDismiss,
   ...rest
-}: IDismissibleRootInternalProps & IDismissibleRootProps) => (
+}: React.PropsWithChildren<
+  IDismissibleRootInternalProps & IDismissibleRootProps
+>) => (
   <DismissibleRootProvider
     dismissed={dismissed}
     disabled={disabled}
@@ -81,3 +83,5 @@ export const DismissibleRoot = ({
     <DismissibleRootInternal {...rest} />
   </DismissibleRootProvider>
 )
+
+DismissibleRoot.displayName = 'Dismissible'

--- a/lib/src/components/dismissible/DismissibleRoot.tsx
+++ b/lib/src/components/dismissible/DismissibleRoot.tsx
@@ -21,12 +21,12 @@ export interface IDismissibleRootProps {
   onDismiss?: () => void
 }
 
-export const DismissibleRootProvider: React.FC<IDismissibleRootProps> = ({
+export const DismissibleRootProvider = ({
   dismissed: controlledIsDismissed,
   children,
   disabled,
   onDismiss = () => null
-}) => {
+}: React.PropsWithChildren<IDismissibleRootProps>) => {
   const [isDismissed, setIsDismissed] = React.useState(false)
 
   const value = React.useMemo<IDismissibleRootContext>(() => {
@@ -52,10 +52,10 @@ export interface IDismissibleRootInternalProps {
   asChild?: boolean
 }
 
-const DismissibleRootInternal: React.FC<IDismissibleRootInternalProps> = ({
+const DismissibleRootInternal = ({
   asChild = false,
   ...rest
-}) => {
+}: React.PropsWithChildren<IDismissibleRootInternalProps>) => {
   const rootContext = React.useContext(DismissibleRootContext)
 
   const { isDismissed, disabled } = rootContext
@@ -67,9 +67,12 @@ const DismissibleRootInternal: React.FC<IDismissibleRootInternalProps> = ({
   return <Component {...props} />
 }
 
-export const DismissibleRoot: React.FC<
-  IDismissibleRootInternalProps & IDismissibleRootProps
-> = ({ disabled = false, dismissed, onDismiss, ...rest }) => (
+export const DismissibleRoot = ({
+  disabled = false,
+  dismissed,
+  onDismiss,
+  ...rest
+}: IDismissibleRootInternalProps & IDismissibleRootProps) => (
   <DismissibleRootProvider
     dismissed={dismissed}
     disabled={disabled}

--- a/lib/src/components/dismissible/DismissibleTrigger.tsx
+++ b/lib/src/components/dismissible/DismissibleTrigger.tsx
@@ -13,10 +13,10 @@ const DefaultTrigger = (props) => (
   </button>
 )
 
-export const DismissibleTrigger: React.FC<IDismissibleTriggerProps> = ({
+export const DismissibleTrigger = ({
   asChild = false,
   ...rest
-}) => {
+}: React.PropsWithChildren<IDismissibleTriggerProps>) => {
   const context = React.useContext(DismissibleRootContext)
   if (context === undefined) {
     throw new Error(

--- a/lib/src/components/dismissible/index.ts
+++ b/lib/src/components/dismissible/index.ts
@@ -1,10 +1,6 @@
 import { DismissibleRoot } from './DismissibleRoot'
 import { DismissibleTrigger } from './DismissibleTrigger'
 
-type TDismissible = typeof DismissibleRoot & {
-  Trigger: typeof DismissibleTrigger
-}
-
-export const Dismissible = DismissibleRoot as TDismissible
-Dismissible.Trigger = DismissibleTrigger
-Dismissible.displayName = 'Dismissible'
+export const Dismissible = Object.assign(DismissibleRoot, {
+  Trigger: DismissibleTrigger
+})

--- a/lib/src/components/drawer/DrawerContent.tsx
+++ b/lib/src/components/drawer/DrawerContent.tsx
@@ -90,9 +90,10 @@ export const StyledContent = styled(Content, {
   }
 })
 
-export const DrawerContent: React.FC<
-  React.ComponentProps<typeof StyledContent>
-> = ({ children, ...rest }) => {
+export const DrawerContent = ({
+  children,
+  ...rest
+}: React.ComponentProps<typeof StyledContent>) => {
   const { position } = React.useContext(DrawerContext)
 
   return (

--- a/lib/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/lib/src/components/dropdown-menu/DropdownMenu.tsx
@@ -11,18 +11,11 @@ import { DropdownMenuTrigger } from './DropdownMenuTrigger'
 
 const Root = styled(DropdownMenuRoot, {})
 
-export const DropdownMenu: React.FC<React.ComponentProps<typeof Root>> & {
-  Content: typeof DropdownMenuContent
-  Item: typeof DropdownMenuItem
-  LinkItem: typeof DropdownMenuLinkItem
-  Portal: typeof Portal
-  Separator: typeof DropdownMenuSeparator
-  Trigger: typeof DropdownMenuTrigger
-} = (props) => <Root {...props} />
-
-DropdownMenu.Content = DropdownMenuContent
-DropdownMenu.Item = DropdownMenuItem
-DropdownMenu.LinkItem = DropdownMenuLinkItem
-DropdownMenu.Portal = Portal
-DropdownMenu.Separator = DropdownMenuSeparator
-DropdownMenu.Trigger = DropdownMenuTrigger
+export const DropdownMenu = Object.assign(Root, {
+  Content: DropdownMenuContent,
+  Item: DropdownMenuItem,
+  LinkItem: DropdownMenuLinkItem,
+  Portal: Portal,
+  Separator: DropdownMenuSeparator,
+  Trigger: DropdownMenuTrigger
+})

--- a/lib/src/components/dropdown-menu/DropdownMenuLinkItem.tsx
+++ b/lib/src/components/dropdown-menu/DropdownMenuLinkItem.tsx
@@ -9,9 +9,11 @@ const StyledLink = styled('a', {
   textDecoration: 'none'
 })
 
-export const DropdownMenuLinkItem: React.FC<
-  React.ComponentProps<typeof DropdownMenuItem> & { href: string }
-> = ({ children, href, ...props }) => (
+export const DropdownMenuLinkItem = ({
+  children,
+  href,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuItem> & { href: string }) => (
   <DropdownMenuItem {...props} asChild>
     <StyledLink href={href} role="menuitem" {...getExternalAnchorProps(href)}>
       {children}

--- a/lib/src/components/empty-state/EmptyState.tsx
+++ b/lib/src/components/empty-state/EmptyState.tsx
@@ -37,11 +37,11 @@ const EmptyStateContainer = styled(Flex, {
 
 type EmptyStateProps = React.ComponentProps<typeof EmptyStateContainer>
 
-export const EmptyState: React.FC<EmptyStateProps> & {
-  Image: typeof EmptyStateImage
-  Title: typeof EmptyStateTitle
-  Body: typeof EmptyStateBody
-} = ({ size = 'sm', children, ...props }) => (
+const EmptyStateComponent = ({
+  size = 'sm',
+  children,
+  ...props
+}: EmptyStateProps) => (
   <EmptyStateContainer size={size} {...props}>
     {React.Children.map(children, (child) => {
       if (!React.isValidElement(child)) return child
@@ -59,7 +59,10 @@ export const EmptyState: React.FC<EmptyStateProps> & {
   </EmptyStateContainer>
 )
 
-EmptyState.displayName = 'EmptyState'
-EmptyState.Image = EmptyStateImage
-EmptyState.Title = EmptyStateTitle
-EmptyState.Body = EmptyStateBody
+export const EmptyState = Object.assign(EmptyStateComponent, {
+  Image: EmptyStateImage,
+  Title: EmptyStateTitle,
+  Body: EmptyStateBody
+})
+
+EmptyStateComponent.displayName = 'EmptyState'

--- a/lib/src/components/empty-state/EmptyStateImage.tsx
+++ b/lib/src/components/empty-state/EmptyStateImage.tsx
@@ -38,6 +38,6 @@ const StyledEmptyStateImage = styled(Image, {
 type EmptyStateImageProps = React.ComponentProps<typeof StyledEmptyStateImage> &
   React.ComponentProps<typeof Image>
 
-export const EmptyStateImage: React.FC<EmptyStateImageProps> = (props) => (
+export const EmptyStateImage = (props: EmptyStateImageProps) => (
   <StyledEmptyStateImage {...props} />
 )

--- a/lib/src/components/field-wrapper/FieldDescription.tsx
+++ b/lib/src/components/field-wrapper/FieldDescription.tsx
@@ -7,7 +7,10 @@ type DescriptionProps = {
   css?: CSS
 }
 
-export const Description: React.FC<DescriptionProps> = ({ children, css }) => (
+export const Description = ({
+  children,
+  css
+}: React.PropsWithChildren<DescriptionProps>) => (
   <Text size="sm" css={{ color: '$tonal300', maxWidth: '80ch', ...css }}>
     {children}
   </Text>

--- a/lib/src/components/field-wrapper/FieldWrapper.tsx
+++ b/lib/src/components/field-wrapper/FieldWrapper.tsx
@@ -27,7 +27,7 @@ export type FieldElementWrapperProps = Omit<FieldWrapperProps, 'fieldId'> & {
   validation?: ValidationOptions
 }
 
-export const FieldWrapper: React.FC<FieldWrapperProps> = ({
+export const FieldWrapper = ({
   css,
   children,
   error,
@@ -37,7 +37,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
   description,
   required,
   hideLabel
-}) => {
+}: React.PropsWithChildren<FieldWrapperProps>) => {
   const LabelContainer = hideLabel ? VisuallyHidden.Root : Flex
 
   return (

--- a/lib/src/components/field-wrapper/InlineFieldWrapper.tsx
+++ b/lib/src/components/field-wrapper/InlineFieldWrapper.tsx
@@ -19,7 +19,7 @@ type InlineFieldWrapperProps = {
   description?: string
 }
 
-export const InlineFieldWrapper: React.FC<InlineFieldWrapperProps> = ({
+export const InlineFieldWrapper = ({
   align = 'start',
   children,
   css,
@@ -28,7 +28,7 @@ export const InlineFieldWrapper: React.FC<InlineFieldWrapperProps> = ({
   error,
   label,
   required
-}) => (
+}: React.PropsWithChildren<InlineFieldWrapperProps>) => (
   <Box css={css}>
     <Label
       align={align}

--- a/lib/src/components/file-input/FileInput.tsx
+++ b/lib/src/components/file-input/FileInput.tsx
@@ -10,13 +10,13 @@ export type FileInputProps = React.ComponentProps<typeof Button> & {
   multiple?: boolean
 }
 
-export const FileInput: React.FC<FileInputProps> = ({
+export const FileInput = ({
   accept,
   children,
   multiple = false,
   onFileSelect,
   ...rest
-}) => {
+}: FileInputProps) => {
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event.target
 

--- a/lib/src/components/form/Form.tsx
+++ b/lib/src/components/form/Form.tsx
@@ -25,12 +25,12 @@ type PersistFormWrapperProps = React.ComponentPropsWithoutRef<
 > &
   PersistFormWrapperValues
 
-const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
+const PersistFormWrapper = ({
   persist,
   watch,
   setValue,
   children
-}) => {
+}: PersistFormWrapperProps) => {
   const { id, ...options } = persist
 
   let params: FormPersistParams = {
@@ -58,14 +58,14 @@ const PersistFormWrapper: React.FC<PersistFormWrapperProps> = ({
   return children
 }
 
-const FormContent: React.FC<FormContentProps> = ({
+const FormContent = ({
   formMethods,
   handleSubmit,
   onSubmit,
   onError,
   children,
   ...remainingProps
-}) => (
+}: FormContentProps) => (
   <FormProvider {...formMethods}>
     <StyledForm
       aria-label="form"
@@ -77,7 +77,7 @@ const FormContent: React.FC<FormContentProps> = ({
   </FormProvider>
 )
 
-export const Form: React.FC<FormProps> = ({
+export const Form = ({
   children,
   defaultValues = {},
   onSubmit,
@@ -86,7 +86,7 @@ export const Form: React.FC<FormProps> = ({
   render,
   persist,
   ...remainingProps
-}) => {
+}: FormProps) => {
   invariant(
     !(children && render),
     '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'

--- a/lib/src/components/grid/Grid.tsx
+++ b/lib/src/components/grid/Grid.tsx
@@ -18,13 +18,13 @@ type GridProps = React.ComponentProps<typeof GridContainer> & {
   as?: any
 } // (!) `css` and `as` are both props that come from `stitches`. It would be better to figure out and export the appropriate type for them in stitches!
 
-export const Grid: React.FC<GridProps> = ({
+export const Grid = ({
   css,
   gap = 2,
   minItemSize,
   maxItemSize = '1fr',
   ...remainingProps
-}) => (
+}: GridProps) => (
   <GridContainer
     css={{
       ...(minItemSize && {

--- a/lib/src/components/icon/Icon.tsx
+++ b/lib/src/components/icon/Icon.tsx
@@ -28,7 +28,7 @@ type IconProps = Override<
   }
 >
 
-export const Icon: React.FC<IconProps> = React.forwardRef(
+export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
   ({ is: SVG, size = 'md', ...remainingProps }, ref) => (
     <StyledIcon
       size={size}

--- a/lib/src/components/image/Image.tsx
+++ b/lib/src/components/image/Image.tsx
@@ -33,6 +33,6 @@ type ImageProps = Override<
   }
 >
 
-export const Image: React.FC<ImageProps> = StyledImage
+export const Image = (props: ImageProps) => <StyledImage {...props} />
 
 Image.displayName = 'Image'

--- a/lib/src/components/inline-message/InlineMessage.tsx
+++ b/lib/src/components/inline-message/InlineMessage.tsx
@@ -24,14 +24,14 @@ type TInlineMessageProps = React.ComponentProps<
   size?: 'xs' | 'sm' | 'md'
 }
 
-export const InlineMessage: React.FC<TInlineMessageProps> = ({
+export const InlineMessage = ({
   css,
   showIcon = true,
   theme = 'error',
   size = 'sm',
   children,
   ...rest
-}) => (
+}: TInlineMessageProps) => (
   <InlineMessageContainer theme={theme} css={css} {...rest}>
     {showIcon && (
       <Icon

--- a/lib/src/components/input-field/InputField.tsx
+++ b/lib/src/components/input-field/InputField.tsx
@@ -10,7 +10,7 @@ import { Input, InputProps } from '~/components/input'
 
 type InputFieldProps = InputProps & FieldElementWrapperProps
 
-export const InputField: React.FC<InputFieldProps> = ({
+export const InputField = ({
   css,
   label,
   name,
@@ -19,7 +19,7 @@ export const InputField: React.FC<InputFieldProps> = ({
   description,
   hideLabel,
   ...remainingProps
-}) => {
+}: InputFieldProps) => {
   const { register } = useFormContext()
   const { error } = useFieldError(name)
   const ref = validation ? register(validation) : register

--- a/lib/src/components/input/Input.tsx
+++ b/lib/src/components/input/Input.tsx
@@ -63,7 +63,7 @@ export type InputProps = Override<
   }
 >
 
-export const Input: React.FC<InputProps> = React.forwardRef(
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ type = 'text', size = 'md', ...rest }, ref) => {
     if (type === 'number') {
       return (

--- a/lib/src/components/label/Label.tsx
+++ b/lib/src/components/label/Label.tsx
@@ -66,7 +66,7 @@ type LabelProps = Override<
   }
 >
 
-export const Label: React.FC<LabelProps> = ({
+export const Label = ({
   align = 'start',
   as = 'label',
   direction = 'row',
@@ -75,7 +75,7 @@ export const Label: React.FC<LabelProps> = ({
   children,
   required,
   ...rest
-}) => (
+}: LabelProps) => (
   <StyledLabel
     as={as}
     size={size}

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -62,6 +62,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       ref={ref}
     />
   )
-) as React.FC<LinkProps>
+)
 
 Link.displayName = 'Link'

--- a/lib/src/components/loader/Loader.tsx
+++ b/lib/src/components/loader/Loader.tsx
@@ -45,12 +45,12 @@ type LoaderProps = {
   css?: CSS
 }
 
-export const Loader: React.FC<LoaderProps> = ({
+export const Loader = ({
   css = {},
   message = 'Loading',
   size = 'md',
   ...props
-}) => (
+}: LoaderProps) => (
   <Flex
     css={{
       justifyContent: 'center',

--- a/lib/src/components/markdown-content/MarkdownContent.tsx
+++ b/lib/src/components/markdown-content/MarkdownContent.tsx
@@ -26,10 +26,7 @@ type HandleNode = (node) => JSX.Element | null
 type MarkdownContentProps = {
   content: string
   customComponents?: {
-    [key: string]: React.FC<{
-      node: any
-      handleNode: HandleNode
-    }>
+    [key: string]: (props: { node: any; handleNode: HandleNode }) => JSX.Element
   }
   css?: CSS
 }
@@ -58,11 +55,11 @@ const generateNodeKey = (node) => {
   return `${node.type}${+new Date()}`
 }
 
-export const MarkdownContent: React.FC<MarkdownContentProps> = ({
+export const MarkdownContent = ({
   content,
   customComponents = {},
   css
-}) => {
+}: MarkdownContentProps) => {
   const AST = fromMarkdown(content, {
     extensions: [syntax()],
     mdastExtensions: [directive.fromMarkdown]

--- a/lib/src/components/markdown-content/components/MarkdownCode.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownCode.tsx
@@ -20,6 +20,6 @@ const StyledMarkdownCode = styled(Box, {
   p: '$3'
 })
 
-export const MarkdownCode: React.FC<MarkdownCodeProps> = ({ node }) => (
+export const MarkdownCode = ({ node }: MarkdownCodeProps) => (
   <StyledMarkdownCode as="pre">{node.value}</StyledMarkdownCode>
 )

--- a/lib/src/components/markdown-content/components/MarkdownEmphasis.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownEmphasis.tsx
@@ -10,10 +10,10 @@ type MarkdownEmphasisProps = {
 
 export const StyledMarkdownEmphasis = styled('em', { fontStyle: 'italic' })
 
-export const MarkdownEmphasis: React.FC<MarkdownEmphasisProps> = ({
+export const MarkdownEmphasis = ({
   node,
   handleNode
-}) => (
+}: MarkdownEmphasisProps) => (
   <StyledMarkdownEmphasis>
     {node.children?.map(handleNode)}
   </StyledMarkdownEmphasis>

--- a/lib/src/components/markdown-content/components/MarkdownHeading.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownHeading.tsx
@@ -25,11 +25,11 @@ const getHeadingProps = (depth: number): HeadingProps => {
   }
 }
 
-export const MarkdownHeading: React.FC<MarkdownHeadingProps> = ({
+export const MarkdownHeading = ({
   node,
   handleNode,
   ...rest
-}) => {
+}: MarkdownHeadingProps) => {
   const { as, size } = getHeadingProps(node.depth)
 
   return (

--- a/lib/src/components/markdown-content/components/MarkdownImage.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownImage.tsx
@@ -10,6 +10,6 @@ type MarkdownImageProps = {
   css?: CSS
 }
 
-export const MarkdownImage: React.FC<MarkdownImageProps> = ({ node, css }) => (
+export const MarkdownImage = ({ node, css }: MarkdownImageProps) => (
   <Image src={node.url} alt={node.alt ?? undefined} css={css} />
 )

--- a/lib/src/components/markdown-content/components/MarkdownInlineCode.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownInlineCode.tsx
@@ -19,8 +19,6 @@ const StyledMarkdownInlineCode = styled(Box, {
   p: '$0 $1'
 })
 
-export const MarkdownInlineCode: React.FC<MarkdownInlineCodeProps> = ({
-  node
-}) => (
+export const MarkdownInlineCode = ({ node }: MarkdownInlineCodeProps) => (
   <StyledMarkdownInlineCode as="code">{node.value}</StyledMarkdownInlineCode>
 )

--- a/lib/src/components/markdown-content/components/MarkdownLink.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownLink.tsx
@@ -8,10 +8,7 @@ type MarkdownLinkProps = {
   handleNode: (node: Content) => React.ReactElement
 }
 
-export const MarkdownLink: React.FC<MarkdownLinkProps> = ({
-  node,
-  handleNode
-}) => (
+export const MarkdownLink = ({ node, handleNode }: MarkdownLinkProps) => (
   <Link title={node.title ?? undefined} href={node.url}>
     {node.children?.map(handleNode)}
   </Link>

--- a/lib/src/components/markdown-content/components/MarkdownList.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownList.tsx
@@ -11,11 +11,7 @@ type MarkdownListProps = {
   css?: CSS
 }
 
-export const MarkdownList: React.FC<MarkdownListProps> = ({
-  node,
-  handleNode,
-  css
-}) => (
+export const MarkdownList = ({ node, handleNode, css }: MarkdownListProps) => (
   <List
     css={
       {

--- a/lib/src/components/markdown-content/components/MarkdownListItem.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownListItem.tsx
@@ -8,7 +8,9 @@ type MarkdownListItemProps = {
   handleNode: (node: Content) => React.ReactElement
 }
 
-export const MarkdownListItem: React.FC<MarkdownListItemProps> = ({
+export const MarkdownListItem = ({
   node,
   handleNode
-}) => <List.Item>{node.children?.map(handleNode)}</List.Item>
+}: MarkdownListItemProps) => (
+  <List.Item>{node.children?.map(handleNode)}</List.Item>
+)

--- a/lib/src/components/markdown-content/components/MarkdownParagraph.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownParagraph.tsx
@@ -8,8 +8,10 @@ type MarkdownParagraphProps = {
   handleNode: (node: Content) => React.ReactElement
 }
 
-export const MarkdownParagraph: React.FC<MarkdownParagraphProps> = ({
+export const MarkdownParagraph = ({
   node,
   handleNode,
   ...rest
-}) => <Text {...rest}>{node.children?.map(handleNode)}</Text>
+}: MarkdownParagraphProps) => (
+  <Text {...rest}>{node.children?.map(handleNode)}</Text>
+)

--- a/lib/src/components/markdown-content/components/MarkdownStrong.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownStrong.tsx
@@ -10,9 +10,6 @@ type MarkdownStrongProps = {
 
 const StyledMarkdownStrong = styled('strong', { fontWeight: 600 })
 
-export const MarkdownStrong: React.FC<MarkdownStrongProps> = ({
-  node,
-  handleNode
-}) => (
+export const MarkdownStrong = ({ node, handleNode }: MarkdownStrongProps) => (
   <StyledMarkdownStrong>{node.children?.map(handleNode)}</StyledMarkdownStrong>
 )

--- a/lib/src/components/markdown-content/components/MarkdownThematicBreak.tsx
+++ b/lib/src/components/markdown-content/components/MarkdownThematicBreak.tsx
@@ -8,6 +8,6 @@ type MarkdownThematicBreakProps = {
   css?: CSS
 }
 
-export const MarkdownThematicBreak: React.FC<MarkdownThematicBreakProps> = ({
-  css
-}) => <Divider css={{ width: '100%', ...css } as CSS} />
+export const MarkdownThematicBreak = ({ css }: MarkdownThematicBreakProps) => (
+  <Divider css={{ width: '100%', ...css }} />
+)

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVertical.tsx
@@ -34,19 +34,8 @@ type TNavigationVerticalProps = Omit<
   | 'onValueChange'
 >
 
-type TNavigationVerticalType = React.FC<TNavigationVerticalProps> & {
-  Link: typeof NavigationMenuVerticalLink
-  Accordion: typeof NavigationMenuVerticalAccordion
-  AccordionContent: typeof NavigationMenuVerticalAccordionContent
-  AccordionTrigger: typeof NavigationMenuVerticalAccordionTrigger
-  Item: typeof NavigationMenuVerticalItem
-  ItemContent: typeof NavigationMenuVerticalItemContent
-  Icon: typeof NavigationMenuVerticalIcon
-  Text: typeof NavigationMenuVerticalText
-}
-
-export const NavigationMenuVertical = (({ children, ...rest }) => {
-  return (
+export const NavigationMenuVertical = Object.assign(
+  ({ children, ...rest }: TNavigationVerticalProps) => (
     <StyledRoot
       className={navigationMenuVerticalColorSchemes['light']}
       {...rest}
@@ -54,14 +43,15 @@ export const NavigationMenuVertical = (({ children, ...rest }) => {
     >
       <NavigationMenuVerticalList>{children}</NavigationMenuVerticalList>
     </StyledRoot>
-  )
-}) as TNavigationVerticalType
-
-NavigationMenuVertical.Link = NavigationMenuVerticalLink
-NavigationMenuVertical.Accordion = NavigationMenuVerticalAccordion
-NavigationMenuVertical.AccordionContent = NavigationMenuVerticalAccordionContent
-NavigationMenuVertical.AccordionTrigger = NavigationMenuVerticalAccordionTrigger
-NavigationMenuVertical.Item = NavigationMenuVerticalItem
-NavigationMenuVertical.ItemContent = NavigationMenuVerticalItemContent
-NavigationMenuVertical.Icon = NavigationMenuVerticalIcon
-NavigationMenuVertical.Text = NavigationMenuVerticalText
+  ),
+  {
+    Link: NavigationMenuVerticalLink,
+    Accordion: NavigationMenuVerticalAccordion,
+    AccordionContent: NavigationMenuVerticalAccordionContent,
+    AccordionTrigger: NavigationMenuVerticalAccordionTrigger,
+    Item: NavigationMenuVerticalItem,
+    ItemContent: NavigationMenuVerticalItemContent,
+    Icon: NavigationMenuVerticalIcon,
+    Text: NavigationMenuVerticalText
+  }
+)

--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalLink.tsx
@@ -20,9 +20,12 @@ type NavigationMenuVerticalItemProps = React.ComponentProps<
   as?: React.ComponentType | React.ElementType
 }
 
-export const NavigationMenuVerticalLink: React.FC<
-  NavigationMenuVerticalItemProps
-> = ({ as, href, children, ...rest }) => {
+export const NavigationMenuVerticalLink = ({
+  as,
+  href,
+  children,
+  ...rest
+}: NavigationMenuVerticalItemProps) => {
   const Component = as || (href ? 'a' : 'button')
   const componentProps = as
     ? {}

--- a/lib/src/components/navigation/NavigationMenu.tsx
+++ b/lib/src/components/navigation/NavigationMenu.tsx
@@ -2,7 +2,7 @@ import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import React from 'react'
 
 import { MAX_Z_INDEX } from '~/constants/zIndices'
-import { CSS, keyframes, styled } from '~/stitches'
+import { keyframes, styled } from '~/stitches'
 import { fadeOut } from '~/utilities/style/keyframe-animations'
 
 import { NavigationMenuContext } from './NavigationMenuContext'
@@ -15,15 +15,6 @@ import {
 import { NavigationMenuDropdownTrigger } from './NavigationMenuDropdownTrigger'
 import { NavigationMenuLink } from './NavigationMenuLink'
 import { colorSchemes as navigationMenuColorSchemes } from './stitches.navigationMenu.colorscheme.config'
-
-type NavigationMenuSubComponents = {
-  Link: typeof NavigationMenuLink
-  Dropdown: typeof NavigationMenuDropdown
-  DropdownContent: typeof NavigationMenuDropdownContent
-  DropdownItem: typeof NavigationMenuDropdownItem
-  DropdownItemTitle: typeof NavigationMenuDropdownItemTitle
-  DropdownTrigger: typeof NavigationMenuDropdownTrigger
-}
 
 const delayedFadeIn = keyframes({
   '0%, 50%': { opacity: 0 },
@@ -58,10 +49,11 @@ const ViewportPosition = styled('div', {
   justifyContent: 'center'
 })
 
-type NavigationMenuProps = React.ComponentProps<typeof StyledMenu>
-
-export const NavigationMenu: React.FC<NavigationMenuProps> &
-  NavigationMenuSubComponents = ({ children, css, ...props }) => {
+const NavigationMenuComponent = ({
+  children,
+  css,
+  ...props
+}: React.ComponentProps<typeof StyledMenu>) => {
   const [offset, setOffset] = React.useState<number | null | undefined>()
   const [activeItem, setActiveItem] = React.useState<string | undefined>()
   const [listWidth, setListWidth] = React.useState(0)
@@ -134,11 +126,13 @@ export const NavigationMenu: React.FC<NavigationMenuProps> &
   )
 }
 
-NavigationMenu.Link = NavigationMenuLink
-NavigationMenu.Dropdown = NavigationMenuDropdown
-NavigationMenu.DropdownContent = NavigationMenuDropdownContent
-NavigationMenu.DropdownItem = NavigationMenuDropdownItem
-NavigationMenu.DropdownItemTitle = NavigationMenuDropdownItemTitle
-NavigationMenu.DropdownTrigger = NavigationMenuDropdownTrigger
+export const NavigationMenu = Object.assign(NavigationMenuComponent, {
+  Link: NavigationMenuLink,
+  Dropdown: NavigationMenuDropdown,
+  DropdownContent: NavigationMenuDropdownContent,
+  DropdownItem: NavigationMenuDropdownItem,
+  DropdownItemTitle: NavigationMenuDropdownItemTitle,
+  DropdownTrigger: NavigationMenuDropdownTrigger
+})
 
-NavigationMenu.displayName = 'NavigationMenu'
+NavigationMenuComponent.displayName = 'NavigationMenu'

--- a/lib/src/components/navigation/NavigationMenuDropdown.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdown.tsx
@@ -15,11 +15,11 @@ type NavigationMenuDropdownProps = {
 
 type DropdownTriggerProps = ComponentProps<typeof NavigationMenuDropdownTrigger>
 
-export const NavigationMenuDropdown: React.FC<NavigationMenuDropdownProps> = ({
+export const NavigationMenuDropdown = ({
   children,
   id,
   ...props
-}) => {
+}: NavigationMenuDropdownProps) => {
   const { onNodeUpdate } = useNavigationMenuContext()
 
   return (

--- a/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownContent.tsx
@@ -22,9 +22,10 @@ type NavigationMenuDropdownContentProps = React.ComponentProps<
   typeof StyledContent
 >
 
-export const NavigationMenuDropdownContent: React.FC<
-  NavigationMenuDropdownContentProps
-> = ({ children, ...rest }) => (
+export const NavigationMenuDropdownContent = ({
+  children,
+  ...rest
+}: NavigationMenuDropdownContentProps) => (
   <StyledContent
     onPointerMove={preventEvent}
     onPointerLeave={preventEvent}

--- a/lib/src/components/notification-badge/NotificationBadge.tsx
+++ b/lib/src/components/notification-badge/NotificationBadge.tsx
@@ -31,10 +31,10 @@ type NotificationBadgeProps = {
   value: number | string
 }
 
-export const NotificationBadge: React.FC<NotificationBadgeProps> = ({
+export const NotificationBadge = ({
   value,
   children
-}) => (
+}: React.PropsWithChildren<NotificationBadgeProps>) => (
   <StyledWrapper>
     {!!value && <StyledBadge role="status">{value}</StyledBadge>}
     {children}

--- a/lib/src/components/number-input-field/NumberInputField.tsx
+++ b/lib/src/components/number-input-field/NumberInputField.tsx
@@ -18,7 +18,7 @@ export interface NumberInputFieldProps extends NumberInputProps {
   validation?: ValidationOptions
 }
 
-export const NumberInputField: React.FC<NumberInputFieldProps> = ({
+export const NumberInputField = ({
   css,
   defaultValue = 0,
   hideLabel,
@@ -30,7 +30,7 @@ export const NumberInputField: React.FC<NumberInputFieldProps> = ({
   validation,
   onValueChange,
   ...remainingProps
-}) => {
+}: NumberInputFieldProps) => {
   const { control } = useFormContext()
   const {
     field: { ref, onChange, value: innerValue, name: innerName }

--- a/lib/src/components/pagination/Pagination.tsx
+++ b/lib/src/components/pagination/Pagination.tsx
@@ -7,7 +7,7 @@ import { PaginationProvider } from './pagination-context/PaginationContext'
 import { PaginationItems } from './PaginationItems'
 import type { PaginationProps } from './types'
 
-export const Pagination: React.FC<PaginationProps> = ({
+export const Pagination = ({
   colorScheme,
   onSelectedPageChange,
   selectedPage,
@@ -18,7 +18,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   onItemHover = () => null,
   labels = {},
   ...rest
-}) => {
+}: PaginationProps) => {
   if (!pagesCount) return null
 
   const paginationProviderProps = {

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -96,10 +96,7 @@ const StyledButton = styled('button', {
   }
 })
 
-export const PaginationPage: React.FC<PaginationPageProps> = ({
-  pageNumber,
-  css
-}) => {
+export const PaginationPage = ({ pageNumber, css }: PaginationPageProps) => {
   const { currentPage, goToPage, indicatedPages, disabledPages, onItemHover } =
     usePagination()
 

--- a/lib/src/components/pagination/pagination-context/PaginationContext.tsx
+++ b/lib/src/components/pagination/pagination-context/PaginationContext.tsx
@@ -21,7 +21,7 @@ export const PaginationContext = React.createContext<PaginationContextValue>({
   disabledPages: []
 })
 
-export const PaginationProvider: React.FC<PaginationProviderProps> = ({
+export const PaginationProvider = ({
   onSelectedPageChange,
   selectedPage,
   visibleElementsCount = VisibleElementsAmount.LESS,
@@ -31,7 +31,7 @@ export const PaginationProvider: React.FC<PaginationProviderProps> = ({
   onItemHover = () => null,
   labels = {},
   children
-}) => {
+}: React.PropsWithChildren<PaginationProviderProps>) => {
   const [internalCurrentPage, setInternalCurrentPage] = React.useState(1)
 
   const currentPage = selectedPage || internalCurrentPage

--- a/lib/src/components/password-field/PasswordField.tsx
+++ b/lib/src/components/password-field/PasswordField.tsx
@@ -14,7 +14,7 @@ type PasswordFieldProps = React.ComponentProps<typeof PasswordInput> &
     label?: string
   }
 
-export const PasswordField: React.FC<PasswordFieldProps> = ({
+export const PasswordField = ({
   css = {},
   hideLabel,
   label = 'Password',
@@ -23,7 +23,7 @@ export const PasswordField: React.FC<PasswordFieldProps> = ({
   description,
   validation,
   ...remainingProps
-}) => {
+}: PasswordFieldProps) => {
   const { register } = useFormContext()
   const { error } = useFieldError(name)
 

--- a/lib/src/components/password-input/PasswordInput.tsx
+++ b/lib/src/components/password-input/PasswordInput.tsx
@@ -15,7 +15,10 @@ type PasswordInputProps = Omit<InputProps, 'type'> & {
   showPasswordText?: string
 }
 
-export const PasswordInput: React.FC<PasswordInputProps> = React.forwardRef(
+export const PasswordInput = React.forwardRef<
+  HTMLInputElement,
+  PasswordInputProps
+>(
   (
     {
       css,

--- a/lib/src/components/popover/Popover.tsx
+++ b/lib/src/components/popover/Popover.tsx
@@ -7,16 +7,10 @@ import { PopoverContent } from './PopoverContent'
 
 const StyledRoot = styled(Root, {})
 
-type PopoverProps = React.ComponentProps<typeof StyledRoot>
+export const Popover = Object.assign(StyledRoot, {
+  Content: PopoverContent,
+  Portal: Portal,
+  Trigger: Trigger
+})
 
-export const Popover: React.FC<PopoverProps> & {
-  Trigger: typeof Trigger
-  Content: typeof PopoverContent
-  Portal: typeof Portal
-} = (props) => <Root {...props} />
-
-Popover.Content = PopoverContent
-Popover.Portal = Portal
-Popover.Trigger = Trigger
-
-Popover.displayName = 'Popover'
+StyledRoot.displayName = 'Popover'

--- a/lib/src/components/popover/PopoverContent.tsx
+++ b/lib/src/components/popover/PopoverContent.tsx
@@ -56,7 +56,7 @@ type PopoverContentProps = React.ComponentProps<typeof StyledContent> &
     showCloseButton?: boolean
   }
 
-export const PopoverContent: React.FC<PopoverContentProps> = ({
+export const PopoverContent = ({
   children,
   side = 'top',
   sideOffset = 8,
@@ -64,7 +64,7 @@ export const PopoverContent: React.FC<PopoverContentProps> = ({
   showCloseButton = true,
   size = 'md',
   ...remainingProps
-}) => (
+}: PopoverContentProps) => (
   <StyledContent
     size={size}
     side={side}

--- a/lib/src/components/progress-bar/ProgressBar.tsx
+++ b/lib/src/components/progress-bar/ProgressBar.tsx
@@ -38,12 +38,12 @@ type ProgressBarProps = React.ComponentPropsWithoutRef<
     | { 'aria-label': string; id?: string }
   )
 
-export const ProgressBar: React.FC<ProgressBarProps> = ({
+export const ProgressBar = ({
   value,
   max = 100,
   theme = 'primary',
   ...remainingProps
-}) => (
+}: ProgressBarProps) => (
   <StyledProgressBar value={value} max={max} theme={theme} {...remainingProps}>
     <StyledIndicator
       style={{

--- a/lib/src/components/radio-button-field/RadioButtonField.tsx
+++ b/lib/src/components/radio-button-field/RadioButtonField.tsx
@@ -18,9 +18,7 @@ const Fieldset = styled('fieldset', {
 type RadioButtonFieldProps = React.ComponentProps<typeof RadioButtonGroup> &
   FieldElementWrapperProps
 
-export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
-  Item: typeof RadioField
-} = ({
+const RadioButtonFieldComponent = ({
   children,
   css,
   direction = 'column',
@@ -32,7 +30,7 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
   validation,
   onValueChange,
   ...remainingProps
-}) => {
+}: RadioButtonFieldProps) => {
   const { control } = useFormContext()
   const {
     field: { ref, onChange, value: innerValue, name: innerName }
@@ -81,6 +79,8 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> & {
   )
 }
 
-RadioButtonField.Item = RadioField
+export const RadioButtonField = Object.assign(RadioButtonFieldComponent, {
+  Item: RadioField
+})
 
-RadioButtonField.displayName = 'RadioButtonField'
+RadioButtonFieldComponent.displayName = 'RadioButtonField'

--- a/lib/src/components/radio-button-field/RadioField.tsx
+++ b/lib/src/components/radio-button-field/RadioField.tsx
@@ -13,12 +13,12 @@ type RadioFieldProps = {
   validation?: ValidationOptions
 } & React.ComponentProps<typeof RadioButton>
 
-export const RadioField: React.FC<RadioFieldProps> = ({
+export const RadioField = ({
   css,
   label,
   value,
   ...remainingProps
-}) => (
+}: RadioFieldProps) => (
   <InlineFieldWrapper css={css} label={label}>
     <RadioButton value={value} {...remainingProps} />
   </InlineFieldWrapper>

--- a/lib/src/components/radio-button/RadioButton.tsx
+++ b/lib/src/components/radio-button/RadioButton.tsx
@@ -70,7 +70,7 @@ type RadioButtonProps = Override<
   }
 >
 
-export const RadioButton: React.FC<RadioButtonProps> = ({ size, ...props }) => {
+export const RadioButton = ({ size, ...props }: RadioButtonProps) => {
   return (
     <StyledRadioButton {...props} size={size}>
       <StyledIndicator size={size} />

--- a/lib/src/components/radio-card/RadioCard.tsx
+++ b/lib/src/components/radio-card/RadioCard.tsx
@@ -83,13 +83,13 @@ const Indicator = styled(RadioGroup.Indicator, {
 
 type RadioCardProps = React.ComponentProps<typeof StyledRadioCard>
 
-export const RadioCard: React.FC<RadioCardProps> = ({
+export const RadioCard = ({
   children,
   isFullWidth = false,
   size = 'md',
   align = 'left',
   ...rest
-}) => (
+}: RadioCardProps) => (
   <StyledRadioCard
     {...rest}
     align={align}

--- a/lib/src/components/radio-card/RadioCardGroup.tsx
+++ b/lib/src/components/radio-card/RadioCardGroup.tsx
@@ -13,7 +13,7 @@ type RadioCardGroupProps = Override<
   React.ComponentProps<typeof RadioGroup.Root>
 >
 
-export const RadioCardGroup: React.FC<RadioCardGroupProps> = ({
+export const RadioCardGroup = ({
   css,
   children,
   size,
@@ -22,7 +22,7 @@ export const RadioCardGroup: React.FC<RadioCardGroupProps> = ({
   gap = '3',
   justify,
   ...rest
-}) => (
+}: RadioCardGroupProps) => (
   <RadioGroup.Root {...rest}>
     <Flex direction="row" justify={justify} gap={gap} wrap="wrap" css={css}>
       {React.Children.map(children, (child) => {

--- a/lib/src/components/search-field/SearchField.tsx
+++ b/lib/src/components/search-field/SearchField.tsx
@@ -10,7 +10,7 @@ import { SearchInput, SearchInputProps } from '~/components/search-input'
 
 type SearchFieldProps = SearchInputProps & FieldElementWrapperProps
 
-export const SearchField: React.FC<SearchFieldProps> = ({
+export const SearchField = ({
   css,
   hideLabel,
   label,
@@ -19,7 +19,7 @@ export const SearchField: React.FC<SearchFieldProps> = ({
   prompt,
   description,
   ...remainingProps
-}) => {
+}: SearchFieldProps) => {
   const { register } = useFormContext()
   const { error } = useFieldError(name)
   const ref = validation ? register(validation) : register

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -53,7 +53,7 @@ const StyledSearchInput = styled(Input, {
     }
 })
 
-export const SearchInput: React.FC<SearchInputProps> = React.forwardRef(
+export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
   (
     {
       size = 'md',

--- a/lib/src/components/select-field/SelectField.tsx
+++ b/lib/src/components/select-field/SelectField.tsx
@@ -10,7 +10,7 @@ import { Select, SelectProps } from '~/components/select'
 
 type SelectFieldProps = SelectProps & FieldElementWrapperProps
 
-export const SelectField: React.FC<SelectFieldProps> = ({
+export const SelectField = ({
   css = undefined,
   hideLabel,
   children,
@@ -20,7 +20,7 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   prompt,
   description,
   ...remainingProps
-}) => {
+}: SelectFieldProps) => {
   const { register } = useFormContext()
   const { error } = useFieldError(name)
   const ref = validation ? register(validation) : register

--- a/lib/src/components/select/Select.tsx
+++ b/lib/src/components/select/Select.tsx
@@ -78,7 +78,7 @@ export type SelectProps = Override<
   // )
 >
 
-export const Select: React.FC<SelectProps> = React.forwardRef(
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ placeholder, children, size = 'md', ...remainingProps }, ref) => {
     const props = { size, ref, ...remainingProps }
 

--- a/lib/src/components/slider-field/SliderField.tsx
+++ b/lib/src/components/slider-field/SliderField.tsx
@@ -15,7 +15,7 @@ type SliderFieldProps = SliderProps &
   SliderValueType &
   FieldElementWrapperProps
 
-export const SliderField: React.FC<SliderFieldProps> = ({
+export const SliderField = ({
   css,
   hideLabel,
   label,
@@ -28,7 +28,7 @@ export const SliderField: React.FC<SliderFieldProps> = ({
   max = 100,
   steps = [],
   ...remainingProps
-}) => {
+}: SliderFieldProps) => {
   const { control } = useFormContext()
   const {
     field: { ref, onChange, value: innerValue, name: innerName }

--- a/lib/src/components/slider/SliderSteps.tsx
+++ b/lib/src/components/slider/SliderSteps.tsx
@@ -32,11 +32,7 @@ const getTransformValue = (value: number, min: number, max: number): number => {
   return 50
 }
 
-export const SliderSteps: React.FC<SliderStepsProps> = ({
-  min,
-  max,
-  steps = []
-}) => {
+export const SliderSteps = ({ min, max, steps = [] }: SliderStepsProps) => {
   if (steps.length === 0) return null
 
   return (

--- a/lib/src/components/slider/SliderValue.tsx
+++ b/lib/src/components/slider/SliderValue.tsx
@@ -10,10 +10,10 @@ type SliderValueProps = SliderValueType & {
   value?: number[]
 }
 
-export const SliderValue: React.FC<SliderValueProps> = ({
+export const SliderValue = ({
   value = [],
   outputLabel = (value) => `Current value is ${value}`
-}) => {
+}: SliderValueProps) => {
   return (
     <Text css={{ mt: '$4', color: '$tonal300', width: '100%' }}>
       {outputLabel(value.length === 1 ? value[0] : value)}

--- a/lib/src/components/sortable/SortableHandle.tsx
+++ b/lib/src/components/sortable/SortableHandle.tsx
@@ -9,12 +9,12 @@ export type TSortableHandleProps = {
   label?: string
 } & Omit<THandleProps, 'label'>
 
-export const SortableHandle: React.FC<TSortableHandleProps> = ({
+export const SortableHandle = ({
   targetId,
   disabled = false,
   label = 'drag handle',
   ...rest
-}) => {
+}: TSortableHandleProps) => {
   const { attributes, listeners, isDragging, setActivatorNodeRef } =
     useSortable({ id: targetId })
 

--- a/lib/src/components/sortable/SortableItem.tsx
+++ b/lib/src/components/sortable/SortableItem.tsx
@@ -23,7 +23,7 @@ export const SortableItem = ({
   isDragHandle = false,
   disabled,
   ...rest
-}: TSortableItemProps) => {
+}: React.PropsWithChildren<TSortableItemProps>) => {
   const { transform, setNodeRef, isDragging, listeners, attributes } =
     useSortable({ id })
 

--- a/lib/src/components/sortable/SortableItem.tsx
+++ b/lib/src/components/sortable/SortableItem.tsx
@@ -16,14 +16,14 @@ export type TSortableItemProps = {
 
 const StyledSlot = styled(Slot)
 
-export const SortableItem: React.FC<TSortableItemProps> = ({
+export const SortableItem = ({
   id,
   asChild = false,
   css,
   isDragHandle = false,
   disabled,
   ...rest
-}) => {
+}: TSortableItemProps) => {
   const { transform, setNodeRef, isDragging, listeners, attributes } =
     useSortable({ id })
 

--- a/lib/src/components/sortable/SortableRoot.tsx
+++ b/lib/src/components/sortable/SortableRoot.tsx
@@ -23,11 +23,11 @@ type TSortableRootProps = {
   }) => void
 }
 
-export const SortableRoot: React.FC<TSortableRootProps> = ({
+export const SortableRoot = ({
   sortableIds,
   onSortChange,
   children
-}) => {
+}: React.PropsWithChildren<TSortableRootProps>) => {
   const [order, setOrder] = React.useState<React.ReactText[]>(sortableIds)
   React.useEffect(() => {
     setOrder(sortableIds)

--- a/lib/src/components/stepper/Stepper.tsx
+++ b/lib/src/components/stepper/Stepper.tsx
@@ -8,11 +8,7 @@ import { StepperStepForward } from './StepperStepForward'
 import { StepperSteps } from './StepperSteps'
 import { IStepperProps } from './types'
 
-export const Stepper: React.FC<IStepperProps> & {
-  StepBack: typeof StepperStepBack
-  StepForward: typeof StepperStepForward
-  Steps: typeof StepperSteps
-} = ({
+const StepperComponent = ({
   children,
   stepCount,
   allowSkip,
@@ -23,7 +19,7 @@ export const Stepper: React.FC<IStepperProps> & {
   hideLabels = false,
   showCompletedIcons = false,
   css
-}) => {
+}: React.PropsWithChildren<IStepperProps>) => {
   invariant(
     !(stepCount && steps),
     '`Stepper` should only be given one of `stepCount` or `steps`. When both are provided, `steps` will be used and `stepCount` will be ignored.'
@@ -55,8 +51,10 @@ export const Stepper: React.FC<IStepperProps> & {
   )
 }
 
-Stepper.StepBack = StepperStepBack
-Stepper.StepForward = StepperStepForward
-Stepper.Steps = StepperSteps
+export const Stepper = Object.assign(StepperComponent, {
+  StepBack: StepperStepBack,
+  StepForward: StepperStepForward,
+  Steps: StepperSteps
+})
 
-Stepper.displayName = 'Stepper'
+StepperComponent.displayName = 'Stepper'

--- a/lib/src/components/stepper/StepperStepBack.tsx
+++ b/lib/src/components/stepper/StepperStepBack.tsx
@@ -4,9 +4,11 @@ import { Button } from '../button'
 import { useStepper } from './stepper-context/StepperContext'
 import { IStepperNavigateProps } from './types'
 
-export const StepperStepBack: React.FC<
-  IStepperNavigateProps & Omit<React.ComponentProps<typeof Button>, 'children'>
-> = ({ label, children, ...rest }) => {
+export const StepperStepBack = ({
+  label,
+  children,
+  ...rest
+}: IStepperNavigateProps & React.ComponentProps<typeof Button>) => {
   const { activeStep, goToPreviousStep } = useStepper()
   return (
     <Button

--- a/lib/src/components/stepper/StepperStepForward.tsx
+++ b/lib/src/components/stepper/StepperStepForward.tsx
@@ -4,9 +4,12 @@ import { Button } from '../button'
 import { useStepper } from './stepper-context/StepperContext'
 import { IStepperNavigateProps } from './types'
 
-export const StepperStepForward: React.FC<
-  IStepperNavigateProps & Omit<React.ComponentProps<typeof Button>, 'children'>
-> = ({ label, children, onClick, ...rest }) => {
+export const StepperStepForward = ({
+  label,
+  children,
+  onClick,
+  ...rest
+}: IStepperNavigateProps & React.ComponentProps<typeof Button>) => {
   const { goToNextStep, activeStep } = useStepper()
 
   const handleClick = () => {

--- a/lib/src/components/stepper/StepperSteps.tsx
+++ b/lib/src/components/stepper/StepperSteps.tsx
@@ -21,7 +21,7 @@ const StepperStepsContainer = styled(Flex, {
   }
 })
 
-export const StepperSteps: React.FC<IStepperStepsProps> = ({ css }) => {
+export const StepperSteps = ({ css }: IStepperStepsProps) => {
   const {
     steps,
     goToStep,

--- a/lib/src/components/stepper/stepper-context/StepperContext.tsx
+++ b/lib/src/components/stepper/stepper-context/StepperContext.tsx
@@ -16,7 +16,7 @@ const StepperContext = React.createContext<Context>({
   showCompletedIcons: false
 })
 
-export const StepperProvider: React.FC<StepperProviderProps> = ({
+export const StepperProvider = ({
   children,
   stepCount,
   allowSkip,
@@ -26,7 +26,7 @@ export const StepperProvider: React.FC<StepperProviderProps> = ({
   steps,
   hideLabels,
   showCompletedIcons
-}) => {
+}: React.PropsWithChildren<StepperProviderProps>) => {
   const [activeStep, setActiveStep] = React.useState(0)
 
   const [viewedSteps, setviewedSteps] = React.useState<number[]>([0])

--- a/lib/src/components/switch/Switch.tsx
+++ b/lib/src/components/switch/Switch.tsx
@@ -68,7 +68,7 @@ const StyledThumb = styled(RadixSwitch.Thumb, {
 
 type SwitchProps = React.ComponentProps<typeof StyledSwitch>
 
-export const Switch: React.FC<SwitchProps> = ({ size = 'md', ...rest }) => (
+export const Switch = ({ size = 'md', ...rest }: SwitchProps) => (
   <StyledSwitch size={size} {...rest}>
     <StyledThumb size={size} />
   </StyledSwitch>

--- a/lib/src/components/table/Table.tsx
+++ b/lib/src/components/table/Table.tsx
@@ -11,17 +11,6 @@ import { TableHeaderCell } from './TableHeaderCell'
 import { StyledRow, TableRow } from './TableRow'
 import { TableStickyColumnsContainer } from './TableStickyColumnsContainer'
 
-type TableSubComponents = {
-  Body: typeof TableBody
-  Cell: typeof TableCell
-  Footer: typeof TableFooter
-  FooterCell: typeof TableFooterCell
-  Header: typeof TableHeader
-  HeaderCell: typeof TableHeaderCell
-  Row: typeof TableRow
-  StickyColumnsContainer: typeof TableStickyColumnsContainer
-}
-
 const StyledTable = styled('table', {
   borderCollapse: 'separate',
   borderSpacing: 0,
@@ -70,7 +59,7 @@ type TableProps = React.ComponentProps<typeof StyledTable> & {
   scrollContainerCss?: CSS
 }
 
-export const Table: React.FC<TableProps> & TableSubComponents = ({
+const TableComponent = ({
   size = 'md',
   corners = 'round',
   numberOfStickyColumns = 0,
@@ -93,13 +82,15 @@ export const Table: React.FC<TableProps> & TableSubComponents = ({
   return tableComponent
 }
 
-Table.Body = TableBody
-Table.Cell = TableCell
-Table.Footer = TableFooter
-Table.FooterCell = TableFooterCell
-Table.Header = TableHeader
-Table.HeaderCell = TableHeaderCell
-Table.Row = TableRow
-Table.StickyColumnsContainer = TableStickyColumnsContainer
+export const Table = Object.assign(TableComponent, {
+  Body: TableBody,
+  Cell: TableCell,
+  Footer: TableFooter,
+  FooterCell: TableFooterCell,
+  Header: TableHeader,
+  HeaderCell: TableHeaderCell,
+  Row: TableRow,
+  StickyColumnsContainer: TableStickyColumnsContainer
+})
 
-Table.displayName = 'Table'
+TableComponent.displayName = 'Table'

--- a/lib/src/components/table/TableBody.tsx
+++ b/lib/src/components/table/TableBody.tsx
@@ -24,9 +24,8 @@ const StyledTableBody = styled('tbody', {
 
 type TableBodyProps = React.ComponentProps<typeof StyledTableBody>
 
-export const TableBody: React.FC<TableBodyProps> = ({
-  striped = true,
-  ...rest
-}) => <StyledTableBody striped={striped} {...rest} />
+export const TableBody = ({ striped = true, ...rest }: TableBodyProps) => (
+  <StyledTableBody striped={striped} {...rest} />
+)
 
 TableBody.displayName = 'TableBody'

--- a/lib/src/components/table/TableHeader.tsx
+++ b/lib/src/components/table/TableHeader.tsx
@@ -56,7 +56,7 @@ const StyledTableHeader = styled('thead', {
 
 type TableHeaderProps = React.ComponentProps<typeof StyledTableHeader>
 
-export const TableHeader: React.FC<TableHeaderProps> = ({
+export const TableHeader = ({
   theme = 'primaryDark',
   isSticky = false,
   ...rest

--- a/lib/src/components/table/TableStickyColumnsContainer.tsx
+++ b/lib/src/components/table/TableStickyColumnsContainer.tsx
@@ -4,15 +4,16 @@ import { CSS } from '~/stitches'
 
 import { Box } from '../box'
 import { useStickyColumnsCss } from './useStickyColumnsCss'
-interface ITableStickyColumnsContainerProps {
-  children: React.ReactNode
+
+export const TableStickyColumnsContainer = ({
+  children,
+  numberOfStickyColumns = 0,
+  css,
+  ...restProps
+}: React.PropsWithChildren<{
   numberOfStickyColumns?: number
   css?: CSS
-}
-
-export const TableStickyColumnsContainer: React.FC<
-  ITableStickyColumnsContainerProps
-> = ({ children, numberOfStickyColumns = 0, css, ...restProps }) => {
+}>) => {
   const [hasScroll, setHasScroll] = React.useState<boolean>(false)
   const scrollContainerRef = React.useRef(null)
   const { columnsCss } = useStickyColumnsCss(

--- a/lib/src/components/tabs/Tabs.tsx
+++ b/lib/src/components/tabs/Tabs.tsx
@@ -11,16 +11,10 @@ type TabsProps = React.ComponentProps<typeof StyledRoot>
 
 const StyledRoot = styled(Root, { width: '100%' })
 
-export const Tabs: React.FC<TabsProps> & {
-  TriggerList: typeof TabsTriggerList
-  Trigger: typeof TabsTrigger
-  Content: typeof TabsContent
-} = ({ children, ...remainingProps }) => {
-  return <StyledRoot {...remainingProps}>{children}</StyledRoot>
-}
+export const Tabs = Object.assign(StyledRoot, {
+  TriggerList: TabsTriggerList,
+  Trigger: TabsTrigger,
+  Content: TabsContent
+})
 
-Tabs.TriggerList = TabsTriggerList
-Tabs.Trigger = TabsTrigger
-Tabs.Content = TabsContent
-
-Tabs.displayName = 'Tabs'
+StyledRoot.displayName = 'Tabs'

--- a/lib/src/components/tabs/TabsTrigger.tsx
+++ b/lib/src/components/tabs/TabsTrigger.tsx
@@ -51,10 +51,7 @@ interface TabsTriggerProps
   value: string
 }
 
-export const TabsTrigger: React.FC<TabsTriggerProps> = ({
-  children,
-  ...rest
-}) => (
+export const TabsTrigger = ({ children, ...rest }: TabsTriggerProps) => (
   <StyledTabsTrigger {...rest}>
     <Text size="sm" as="span">
       {children}

--- a/lib/src/components/tabs/TabsTriggerList.tsx
+++ b/lib/src/components/tabs/TabsTriggerList.tsx
@@ -40,11 +40,13 @@ const StyledChevronActionIcon = styled(ActionIcon, {
 
 const SCROLL_STEP = 0.8 // Used to scroll 80% of clientWidth
 
-export const TabsTriggerList: React.FC<
-  React.ComponentProps<typeof StyledTriggerList> & {
-    colorScheme?: TcolorScheme
-  }
-> = ({ children, colorScheme = {}, ...rest }) => {
+export const TabsTriggerList = ({
+  children,
+  colorScheme = {},
+  ...rest
+}: React.ComponentProps<typeof StyledTriggerList> & {
+  colorScheme?: TcolorScheme
+}) => {
   const [listRef, setListRefCallback] = useCallbackRefState()
 
   const { width } = useSize({ element: listRef, delay: 500 })

--- a/lib/src/components/textarea-field/TextareaField.tsx
+++ b/lib/src/components/textarea-field/TextareaField.tsx
@@ -10,7 +10,7 @@ import { Textarea, TextareaProps } from '~/components/textarea'
 
 type TextareaFieldProps = TextareaProps & FieldElementWrapperProps
 
-export const TextareaField: React.FC<TextareaFieldProps> = ({
+export const TextareaField = ({
   css = undefined,
   hideLabel,
   label,
@@ -19,7 +19,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   prompt,
   description,
   ...remainingProps
-}) => {
+}: TextareaFieldProps) => {
   const { register } = useFormContext()
   const { error } = useFieldError(name)
 

--- a/lib/src/components/textarea/Textarea.tsx
+++ b/lib/src/components/textarea/Textarea.tsx
@@ -43,7 +43,7 @@ const StyledTextarea = styled('textarea', {
 
 export type TextareaProps = React.ComponentProps<typeof StyledTextarea>
 
-export const Textarea: React.FC<TextareaProps> = React.forwardRef(
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (props, ref) => <StyledTextarea {...props} ref={ref} />
 )
 

--- a/lib/src/components/tile-toggle-group/TileToggleGroupItem.tsx
+++ b/lib/src/components/tile-toggle-group/TileToggleGroupItem.tsx
@@ -34,10 +34,10 @@ const StyledTileToggleGroupItem = styled.withConfig({
 type TTileToggleGroupItem = React.ComponentProps<typeof ToggleGroup.Item> &
   React.ComponentProps<typeof StyledTileToggleGroupItem>
 
-export const TileToggleGroupItem: React.FC<TTileToggleGroupItem> = ({
+export const TileToggleGroupItem = ({
   children,
   ...rest
-}) => {
+}: TTileToggleGroupItem) => {
   return (
     <ToggleGroup.Item {...rest} asChild>
       <StyledTileToggleGroupItem as="button">

--- a/lib/src/components/toast/ToastProvider.tsx
+++ b/lib/src/components/toast/ToastProvider.tsx
@@ -67,7 +67,10 @@ const ToastContext = React.createContext<Pick<
   'type' | 'id' | 'message'
 > | null>(null)
 
-export const ToastProvider: React.FC<{ css?: CSS }> = ({ children, css }) => {
+export const ToastProvider = ({
+  children,
+  css
+}: React.PropsWithChildren<{ css?: CSS }>) => {
   const { toasts, handlers } = useToaster()
   const { startPause, endPause, calculateOffset, updateHeight } = handlers
 

--- a/lib/src/components/tooltip/Tooltip.tsx
+++ b/lib/src/components/tooltip/Tooltip.tsx
@@ -7,20 +7,21 @@ import { TooltipContent } from './TooltipContent'
 
 type TooltipProps = React.ComponentProps<typeof Root>
 
-export const Tooltip: React.FC<TooltipProps> & {
-  Content: typeof TooltipContent
-  Portal: typeof Portal
-  Trigger: typeof Trigger
-  Provider: typeof Provider
-} = ({ children, delayDuration = 350, ...remainingProps }) => (
+const TooltipComponent = ({
+  children,
+  delayDuration = 350,
+  ...remainingProps
+}: TooltipProps) => (
   <Root delayDuration={delayDuration} {...remainingProps}>
     {children}
   </Root>
 )
 
-Tooltip.Content = TooltipContent
-Tooltip.Trigger = styled(Trigger, {})
-Tooltip.Portal = Portal
-Tooltip.Provider = Provider
+export const Tooltip = Object.assign(TooltipComponent, {
+  Content: TooltipContent,
+  Trigger: styled(Trigger, {}),
+  Portal: Portal,
+  Provider: Provider
+})
 
-Tooltip.displayName = 'Tooltip'
+TooltipComponent.displayName = 'Tooltip'

--- a/lib/src/components/tooltip/TooltipContent.tsx
+++ b/lib/src/components/tooltip/TooltipContent.tsx
@@ -51,13 +51,13 @@ const StyledArrow = styled(Arrow, {
 type TooltipContentProps = React.ComponentProps<typeof StyledContent> &
   React.ComponentProps<typeof Content>
 
-export const TooltipContent: React.FC<TooltipContentProps> = ({
+export const TooltipContent = ({
   children,
   side = 'top',
   sideOffset = 4,
   size = 'md',
   ...remainingProps
-}) => (
+}: TooltipContentProps) => (
   <StyledContent
     side={side}
     sideOffset={sideOffset}

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -9,14 +9,6 @@ import { colorSchemes as topBarColorSchemes } from './stitches.topBar.colorschem
 import { TopBarActionIcon } from './TopBarActionIcon'
 import { TopBarBrand, TopBarBrandLogo, TopBarBrandName } from './TopBarBrand'
 
-interface TopBarSubComponents {
-  Brand: typeof TopBarBrand
-  BrandLogo: typeof TopBarBrandLogo
-  BrandName: typeof TopBarBrandName
-  ActionIcon: typeof TopBarActionIcon
-  Divider: typeof TopBarDivider
-}
-
 const TopBarDivider = () => (
   <Divider orientation="vertical" css={{ height: '$2', bg: '$divider' }} />
 )
@@ -77,11 +69,11 @@ interface TopBarProps extends StyledRootProps {
   className?: string
 }
 
-export const TopBar: React.FC<TopBarProps> & TopBarSubComponents = ({
+const TopBarComponent = ({
   size = 'md',
   className = topBarColorSchemes['light'],
   ...props
-}) => {
+}: TopBarProps) => {
   const { y: scrollPositionY } = useWindowScrollPosition()
 
   return (
@@ -95,10 +87,12 @@ export const TopBar: React.FC<TopBarProps> & TopBarSubComponents = ({
   )
 }
 
-TopBar.Brand = TopBarBrand
-TopBar.BrandLogo = TopBarBrandLogo
-TopBar.BrandName = TopBarBrandName
-TopBar.ActionIcon = TopBarActionIcon
-TopBar.Divider = TopBarDivider
+export const TopBar = Object.assign(TopBarComponent, {
+  Brand: TopBarBrand,
+  BrandLogo: TopBarBrandLogo,
+  BrandName: TopBarBrandName,
+  ActionIcon: TopBarActionIcon,
+  Divider: TopBarDivider
+})
 
-TopBar.displayName = 'TopBar'
+TopBarComponent.displayName = 'TopBar'

--- a/lib/src/utilities/optional-tooltip-wrapper/OptionalTooltipWrapper.tsx
+++ b/lib/src/utilities/optional-tooltip-wrapper/OptionalTooltipWrapper.tsx
@@ -8,12 +8,12 @@ export type TOptionalTooltipWrapperProps = {
   tooltipSide?: React.ComponentProps<typeof Tooltip.Content>['side']
 }
 
-export const OptionalTooltipWrapper: React.FC<TOptionalTooltipWrapperProps> = ({
+export const OptionalTooltipWrapper = ({
   hasTooltip,
   label,
   tooltipSide,
   children
-}) => {
+}: React.PropsWithChildren<TOptionalTooltipWrapperProps>) => {
   if (hasTooltip) {
     return (
       <Tooltip>

--- a/lib/src/utilities/optional-visually-hidden-wrapper/OptionalVisuallyHiddenWrapper.tsx
+++ b/lib/src/utilities/optional-visually-hidden-wrapper/OptionalVisuallyHiddenWrapper.tsx
@@ -1,9 +1,12 @@
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden'
 import * as React from 'react'
 
-export const OptionalVisuallyHiddenWrapper: React.FC<{
+export const OptionalVisuallyHiddenWrapper = ({
+  children,
+  hidden = false
+}: React.PropsWithChildren<{
   hidden?: boolean
-}> = ({ children, hidden = false }) => {
+}>) => {
   if (hidden) return <VisuallyHidden.Root>{children}</VisuallyHidden.Root>
 
   return children ? (


### PR DESCRIPTION
To prevent conflicts when we upgrade the main repo to React 18, where `React.FC` does not include the `children` prop anymore.

This PR removes usage of the type and instead types the props directly (with `React.PropsWithChildren` where needed).