### PR TITLE
fix: update forward ref types to prevent conflicts in core repo

### DIFF
--- a/lib/src/components/action-icon/ActionIcon.tsx
+++ b/lib/src/components/action-icon/ActionIcon.tsx
@@ -137,73 +137,74 @@ type ActionIconProps = Override<
     NavigatorActions
 >
 
-export const ActionIcon = React.forwardRef<HTMLButtonElement, ActionIconProps>(
-  (
-    {
-      children,
-      theme = 'primary',
-      appearance = 'simple',
-      size = 'sm',
-      label,
-      href,
-      disabled,
-      hasTooltip = true,
-      tooltipSide,
-      ...remainingProps
-    },
-    ref
-  ) => {
-    const INVALID_CHILDREN_MESSAGE = `A single ${Icon.displayName} component is permitted as a child of ${ActionIcon.displayName}`
+export const ActionIcon: React.ForwardRefExoticComponent<ActionIconProps> =
+  React.forwardRef(
+    (
+      {
+        children,
+        theme = 'primary',
+        appearance = 'simple',
+        size = 'sm',
+        label,
+        href,
+        disabled,
+        hasTooltip = true,
+        tooltipSide,
+        ...remainingProps
+      },
+      ref
+    ) => {
+      const INVALID_CHILDREN_MESSAGE = `A single ${Icon.displayName} component is permitted as a child of ${ActionIcon.displayName}`
 
-    invariant(React.Children.count(children) === 1, INVALID_CHILDREN_MESSAGE)
+      invariant(React.Children.count(children) === 1, INVALID_CHILDREN_MESSAGE)
 
-    const optionalLinkProps = href
-      ? ({
-          as: 'a',
-          href: disabled ? null : href,
-          onClick: undefined,
-          'aria-disabled': !!disabled
-        } as const)
-      : ({ type: 'button' } as const)
+      const optionalLinkProps = href
+        ? ({
+            as: 'a',
+            href: disabled ? null : href,
+            onClick: undefined,
+            'aria-disabled': !!disabled
+          } as const)
+        : ({ type: 'button' } as const)
 
-    return (
-      <OptionalTooltipWrapper
-        hasTooltip={hasTooltip}
-        label={label}
-        tooltipSide={tooltipSide}
-      >
-        <StyledButton
-          {...optionalLinkProps}
-          {...getExternalAnchorProps(href)}
-          {...remainingProps}
-          aria-label={label}
-          theme={theme}
-          appearance={appearance}
-          size={size}
-          ref={ref}
-          disabled={disabled}
+      return (
+        <OptionalTooltipWrapper
+          hasTooltip={hasTooltip}
+          label={label}
+          tooltipSide={tooltipSide}
         >
-          {React.Children.map(children, (child) => {
-            // TS needs this check for any following code to access child.type
-            // even with optional chaining
-            if (!React.isValidElement(child)) {
-              throw new Error(INVALID_CHILDREN_MESSAGE)
-            }
+          <StyledButton
+            {...optionalLinkProps}
+            {...getExternalAnchorProps(href)}
+            {...remainingProps}
+            aria-label={label}
+            theme={theme}
+            appearance={appearance}
+            size={size}
+            ref={ref}
+            disabled={disabled}
+          >
+            {React.Children.map(children, (child) => {
+              // TS needs this check for any following code to access child.type
+              // even with optional chaining
+              if (!React.isValidElement(child)) {
+                throw new Error(INVALID_CHILDREN_MESSAGE)
+              }
 
-            invariant(
-              child.type === Icon,
-              `Children of type ${child?.type} aren't permitted. Only an ${Icon.displayName} component is allowed in ${ActionIcon.displayName}`
-            )
+              invariant(
+                child.type === Icon,
+                `Children of type ${child?.type} aren't permitted. Only an ${Icon.displayName} component is allowed in ${ActionIcon.displayName}`
+              )
 
-            return React.cloneElement(child, {
-              size: ActionIconSizeMap[size as string],
-              css: { ...(child.props.css ? child.props.css : {}) }
-            })
-          })}
-        </StyledButton>
-      </OptionalTooltipWrapper>
-    )
-  }
-)
+              return React.cloneElement(child, {
+                size: ActionIconSizeMap[size as string],
+                css: { ...(child.props.css ? child.props.css : {}) }
+              })
+            })}
+          </StyledButton>
+        </OptionalTooltipWrapper>
+      )
+    }
+  )
 
 ActionIcon.displayName = 'ActionIcon'

--- a/lib/src/components/badge/Badge.tsx
+++ b/lib/src/components/badge/Badge.tsx
@@ -53,59 +53,57 @@ export type TBadgeProps = React.ComponentProps<typeof StyledBadge> & {
   overflow?: React.ComponentProps<typeof BadgeText>['overflow']
 }
 
-type TBadge = React.ForwardRefExoticComponent<TBadgeProps> & {
-  Icon: typeof BadgeIcon
-  Text: typeof BadgeText
-}
+type TBadgeInnerProps = Omit<TBadgeProps, 'size' | 'overflow'>
 
-type TBadgeInnerProps = Omit<Omit<TBadgeProps, 'size'>, 'overflow'>
+const BadgeInner: React.ForwardRefExoticComponent<TBadgeInnerProps> =
+  React.forwardRef(
+    ({ theme = 'info', emphasis = 'subtle', children, ...rest }, ref) => {
+      const { size, overflow, isOverflowing } = React.useContext(BadgeContext)
+      const [badgeElRef, setBadgeElRef] = useCallbackRefState()
+      React.useImperativeHandle(ref, () => badgeElRef as HTMLDivElement)
 
-const BadgeInner = React.forwardRef<HTMLDivElement, TBadgeInnerProps>(
-  ({ theme = 'info', emphasis = 'subtle', children, ...rest }, ref) => {
-    const { size, overflow, isOverflowing } = React.useContext(BadgeContext)
-    const [badgeElRef, setBadgeElRef] = useCallbackRefState()
-    React.useImperativeHandle(ref, () => badgeElRef as HTMLDivElement)
+      const label = badgeElRef?.textContent
 
-    const label = badgeElRef?.textContent
-
-    return (
-      <OptionalTooltipWrapper
-        hasTooltip={overflow === 'ellipsis' && isOverflowing}
-        label={label}
-      >
-        <StyledBadge
-          role="status"
-          emphasis={emphasis}
-          size={size}
-          {...rest}
-          className={badgeColorSchemes[theme]}
-          ref={setBadgeElRef}
+      return (
+        <OptionalTooltipWrapper
+          hasTooltip={overflow === 'ellipsis' && isOverflowing}
+          label={label}
         >
-          {React.Children.map(children, (child) => {
-            if (typeof child === 'string' || typeof child === 'number') {
-              return <BadgeText>{child}</BadgeText>
-            }
-            if (React.isValidElement(child) && child.type === Icon) {
-              return <BadgeIcon {...child.props} />
-            }
-            return child
-          })}
-        </StyledBadge>
-      </OptionalTooltipWrapper>
-    )
-  }
-)
+          <StyledBadge
+            role="status"
+            emphasis={emphasis}
+            size={size}
+            {...rest}
+            className={badgeColorSchemes[theme]}
+            ref={setBadgeElRef}
+          >
+            {React.Children.map(children, (child) => {
+              if (typeof child === 'string' || typeof child === 'number') {
+                return <BadgeText>{child}</BadgeText>
+              }
+              if (React.isValidElement(child) && child.type === Icon) {
+                return <BadgeIcon {...child.props} />
+              }
+              return child
+            })}
+          </StyledBadge>
+        </OptionalTooltipWrapper>
+      )
+    }
+  )
 
-export const Badge = React.forwardRef<HTMLDivElement, TBadgeProps>(
-  ({ size = 'sm', overflow = 'wrap', ...rest }, ref) => {
+const BadgeComponent: React.ForwardRefExoticComponent<TBadgeProps> =
+  React.forwardRef(({ size = 'sm', overflow = 'wrap', ...rest }, ref) => {
     return (
       <BadgeProvider size={size} overflow={overflow}>
         <BadgeInner {...rest} ref={ref} />
       </BadgeProvider>
     )
-  }
-) as TBadge
+  })
 
-Badge.displayName = 'Badge'
-Badge.Icon = BadgeIcon
-Badge.Text = BadgeText
+export const Badge = Object.assign(BadgeComponent, {
+  Icon: BadgeIcon,
+  Text: BadgeText
+})
+
+BadgeComponent.displayName = 'Badge'

--- a/lib/src/components/button/Button.tsx
+++ b/lib/src/components/button/Button.tsx
@@ -177,25 +177,26 @@ type ButtonProps = Override<
   } & NavigatorActions
 >
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, as, href, isLoading = false, onClick, ...rest }, ref) => (
-    <StyledButton
-      as={as || (href ? 'a' : undefined)}
-      href={href}
-      isLoading={isLoading}
-      onClick={!isLoading ? onClick : undefined}
-      type={!href ? 'button' : undefined}
-      {...rest}
-      {...getExternalAnchorProps(href)}
-      ref={ref}
-    >
-      {isLoading ? (
-        <WithLoader size={rest.size}>{children}</WithLoader>
-      ) : (
-        children
-      )}
-    </StyledButton>
+export const Button: React.ForwardRefExoticComponent<ButtonProps> =
+  React.forwardRef(
+    ({ children, as, href, isLoading = false, onClick, ...rest }, ref) => (
+      <StyledButton
+        as={as || (href ? 'a' : undefined)}
+        href={href}
+        isLoading={isLoading}
+        onClick={!isLoading ? onClick : undefined}
+        type={!href ? 'button' : undefined}
+        {...rest}
+        {...getExternalAnchorProps(href)}
+        ref={ref}
+      >
+        {isLoading ? (
+          <WithLoader size={rest.size}>{children}</WithLoader>
+        ) : (
+          children
+        )}
+      </StyledButton>
+    )
   )
-)
 
 Button.displayName = 'Button'

--- a/lib/src/components/checkbox/Checkbox.tsx
+++ b/lib/src/components/checkbox/Checkbox.tsx
@@ -66,10 +66,9 @@ const toIconSize = {
   lg: 'md'
 }
 
-export const Checkbox = React.forwardRef<
-  HTMLButtonElement,
+export const Checkbox: React.ForwardRefExoticComponent<
   React.ComponentProps<typeof StyledCheckbox>
->(({ size = 'md', checked, ...rest }, ref) => {
+> = React.forwardRef(({ size = 'md', checked, ...rest }, ref) => {
   const iconSize = React.useMemo(
     () => overrideStitchesVariantValue(size, (s) => toIconSize[s]),
     [size]

--- a/lib/src/components/chip-dismissible-group/ChipDismissibleGroupRoot.tsx
+++ b/lib/src/components/chip-dismissible-group/ChipDismissibleGroupRoot.tsx
@@ -6,9 +6,7 @@ import { DismissibleGroup } from '~/components/dismissible-group'
 type TChipDismissibleGroupRootProps = React.ComponentProps<typeof ChipGroup> &
   React.ComponentProps<typeof DismissibleGroup>
 
-export const ChipDismissibleGroupRoot = React.forwardRef<
-  HTMLDivElement,
-  TChipDismissibleGroupRootProps
->((props, ref) => {
-  return <ChipGroup as={DismissibleGroup} ref={ref} {...props} />
-})
+export const ChipDismissibleGroupRoot: React.ForwardRefExoticComponent<TChipDismissibleGroupRootProps> =
+  React.forwardRef((props, ref) => {
+    return <ChipGroup as={DismissibleGroup} ref={ref} {...props} />
+  })

--- a/lib/src/components/chip-toggle-group/ChipToggleGroupRoot.tsx
+++ b/lib/src/components/chip-toggle-group/ChipToggleGroupRoot.tsx
@@ -6,16 +6,14 @@ import { ChipGroup } from '~/components/chip'
 type TChipToggleGroupRootProps = React.ComponentProps<typeof ChipGroup> &
   React.ComponentProps<typeof ToggleGroup.Root>
 
-export const ChipToggleGroupRoot = React.forwardRef<
-  HTMLDivElement,
-  TChipToggleGroupRootProps
->((props, ref) => {
-  return (
-    <ChipGroup
-      ref={ref}
-      as={ToggleGroup.Root}
-      orientation="horizontal"
-      {...props}
-    />
-  )
-})
+export const ChipToggleGroupRoot: React.ForwardRefExoticComponent<TChipToggleGroupRootProps> =
+  React.forwardRef((props, ref) => {
+    return (
+      <ChipGroup
+        ref={ref}
+        as={ToggleGroup.Root}
+        orientation="horizontal"
+        {...props}
+      />
+    )
+  })

--- a/lib/src/components/combobox/ComboboxInput.tsx
+++ b/lib/src/components/combobox/ComboboxInput.tsx
@@ -67,9 +67,7 @@ export type ComboboxInputProps = React.ComponentProps<
   typeof StyledComboboxInput
 >
 
-export const ComboboxInput = React.forwardRef<
-  HTMLInputElement,
-  ComboboxInputProps
->(({ size = 'md', ...rest }, ref) => (
-  <StyledComboboxInput size={size} {...rest} ref={ref} />
-))
+export const ComboboxInput: React.ForwardRefExoticComponent<ComboboxInputProps> =
+  React.forwardRef(({ size = 'md', ...rest }, ref) => (
+    <StyledComboboxInput size={size} {...rest} ref={ref} />
+  ))

--- a/lib/src/components/date-input/DateInput.tsx
+++ b/lib/src/components/date-input/DateInput.tsx
@@ -31,155 +31,156 @@ export type DateInputProps = Omit<DayzedInterface, 'onDateSelected'> &
 const formatDateToString = (date?: Date, dateFormat = DEFAULT_DATE_FORMAT) =>
   date ? dayjs(date).format(dateFormat) : ''
 
-export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
-  (
-    {
-      initialDate,
-      dateFormat = DEFAULT_DATE_FORMAT,
-      firstDayOfWeek = 1,
-      disabled,
-      monthNames,
-      weekdayNames,
-      size = 'md',
-      labels,
-      revalidate,
-      onChange,
-      minDate,
-      maxDate,
-      ...remainingProps
-    },
-    ref
-  ) => {
-    const [date, setDate] = React.useState(
-      initialDate ? dayjs(initialDate).toDate() : undefined
-    )
-
-    const [inputElRef, setInputElRef] = useCallbackRefState()
-    React.useImperativeHandle(ref, () => inputElRef as HTMLInputElement)
-
-    const dateString = formatDateToString(date, dateFormat)
-
-    const handleInputChange = React.useCallback(
-      (event) => {
-        const newDateString = event.target.value
-        const parsedInputDate = dayjs(newDateString, dateFormat)
-        const newDate = parsedInputDate.isValid()
-          ? parsedInputDate.toDate()
-          : undefined
-        setDate(newDate)
-        onChange?.(newDate)
+export const DateInput: React.ForwardRefExoticComponent<DateInputProps> =
+  React.forwardRef(
+    (
+      {
+        initialDate,
+        dateFormat = DEFAULT_DATE_FORMAT,
+        firstDayOfWeek = 1,
+        disabled,
+        monthNames,
+        weekdayNames,
+        size = 'md',
+        labels,
+        revalidate,
+        onChange,
+        minDate,
+        maxDate,
+        ...remainingProps
       },
-      [dateFormat, onChange]
-    )
+      ref
+    ) => {
+      const [date, setDate] = React.useState(
+        initialDate ? dayjs(initialDate).toDate() : undefined
+      )
 
-    const handleCalendarChange = React.useCallback(
-      (newDate) => {
-        setDate(newDate)
+      const [inputElRef, setInputElRef] = useCallbackRefState()
+      React.useImperativeHandle(ref, () => inputElRef as HTMLInputElement)
 
-        const mirrorChangeToInputElement = () => {
-          if (!inputElRef) return
+      const dateString = formatDateToString(date, dateFormat)
 
-          // Call the `set` function on the input value directly to mirror the change.
-          // Props to: https://stackoverflow.com/a/46012210
-          const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-            window.HTMLInputElement.prototype,
-            'value'
-          )?.set
-          nativeInputValueSetter?.call(
-            inputElRef,
-            formatDateToString(newDate, dateFormat)
-          )
-          const event = new Event('input', { bubbles: true })
-          inputElRef.dispatchEvent(event)
-        }
-        mirrorChangeToInputElement()
-      },
-      [dateFormat, inputElRef]
-    )
+      const handleInputChange = React.useCallback(
+        (event) => {
+          const newDateString = event.target.value
+          const parsedInputDate = dayjs(newDateString, dateFormat)
+          const newDate = parsedInputDate.isValid()
+            ? parsedInputDate.toDate()
+            : undefined
+          setDate(newDate)
+          onChange?.(newDate)
+        },
+        [dateFormat, onChange]
+      )
 
-    const updatedLabels = {
-      ...DEFAULT_LABELS,
-      ...labels
+      const handleCalendarChange = React.useCallback(
+        (newDate) => {
+          setDate(newDate)
+
+          const mirrorChangeToInputElement = () => {
+            if (!inputElRef) return
+
+            // Call the `set` function on the input value directly to mirror the change.
+            // Props to: https://stackoverflow.com/a/46012210
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+              window.HTMLInputElement.prototype,
+              'value'
+            )?.set
+            nativeInputValueSetter?.call(
+              inputElRef,
+              formatDateToString(newDate, dateFormat)
+            )
+            const event = new Event('input', { bubbles: true })
+            inputElRef.dispatchEvent(event)
+          }
+          mirrorChangeToInputElement()
+        },
+        [dateFormat, inputElRef]
+      )
+
+      const updatedLabels = {
+        ...DEFAULT_LABELS,
+        ...labels
+      }
+
+      const [calendarOpen, setCalendarOpen] = React.useState(false)
+
+      const refDateToday = React.useRef<HTMLButtonElement>(null)
+      const refDateSelected = React.useRef<HTMLButtonElement>(null)
+
+      const iconSize = React.useMemo(() => getFieldIconSize(size), [size])
+
+      return (
+        <Box css={{ position: 'relative', height: 'max-content' }}>
+          <Input
+            name="date"
+            disabled={disabled}
+            size={size}
+            {...remainingProps}
+            onChange={handleInputChange}
+            ref={setInputElRef}
+            defaultValue={dateString}
+          />
+          <Popover modal open={calendarOpen} onOpenChange={setCalendarOpen}>
+            <Popover.Trigger asChild>
+              <ActionIcon
+                css={{
+                  position: 'absolute',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  right: '0'
+                }}
+                disabled={disabled}
+                label={updatedLabels.open}
+                size={iconSize}
+                theme="neutral"
+                hasTooltip={false}
+              >
+                <Icon is={CalendarEvent} />
+              </ActionIcon>
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Content
+                css={{ pr: '$sizes$2', zIndex: DIALOG_Z_INDEX }}
+                side="bottom"
+                align="end"
+                showCloseButton={false}
+                onOpenAutoFocus={(e) => {
+                  e.preventDefault()
+                  if (date) {
+                    refDateSelected.current?.focus()
+                  } else {
+                    refDateToday.current?.focus()
+                  }
+                }}
+              >
+                <Calendar
+                  date={date || new Date()}
+                  selected={date}
+                  onDateSelected={async (date) => {
+                    setCalendarOpen(false)
+                    await handleCalendarChange(date.date)
+                    if (revalidate) revalidate()
+                  }}
+                  setYear={async (date) => {
+                    await handleCalendarChange(date)
+                    if (revalidate) revalidate()
+                  }}
+                  minDate={minDate}
+                  maxDate={maxDate}
+                  refDateToday={refDateToday}
+                  refDateSelected={refDateSelected}
+                  firstDayOfWeek={firstDayOfWeek}
+                  monthNames={monthNames}
+                  weekdayNames={weekdayNames}
+                  labels={updatedLabels}
+                />
+              </Popover.Content>
+            </Popover.Portal>
+          </Popover>
+        </Box>
+      )
     }
-
-    const [calendarOpen, setCalendarOpen] = React.useState(false)
-
-    const refDateToday = React.useRef<HTMLButtonElement>(null)
-    const refDateSelected = React.useRef<HTMLButtonElement>(null)
-
-    const iconSize = React.useMemo(() => getFieldIconSize(size), [size])
-
-    return (
-      <Box css={{ position: 'relative', height: 'max-content' }}>
-        <Input
-          name="date"
-          disabled={disabled}
-          size={size}
-          {...remainingProps}
-          onChange={handleInputChange}
-          ref={setInputElRef}
-          defaultValue={dateString}
-        />
-        <Popover modal open={calendarOpen} onOpenChange={setCalendarOpen}>
-          <Popover.Trigger asChild>
-            <ActionIcon
-              css={{
-                position: 'absolute',
-                top: '50%',
-                transform: 'translateY(-50%)',
-                right: '0'
-              }}
-              disabled={disabled}
-              label={updatedLabels.open}
-              size={iconSize}
-              theme="neutral"
-              hasTooltip={false}
-            >
-              <Icon is={CalendarEvent} />
-            </ActionIcon>
-          </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Content
-              css={{ pr: '$sizes$2', zIndex: DIALOG_Z_INDEX }}
-              side="bottom"
-              align="end"
-              showCloseButton={false}
-              onOpenAutoFocus={(e) => {
-                e.preventDefault()
-                if (date) {
-                  refDateSelected.current?.focus()
-                } else {
-                  refDateToday.current?.focus()
-                }
-              }}
-            >
-              <Calendar
-                date={date || new Date()}
-                selected={date}
-                onDateSelected={async (date) => {
-                  setCalendarOpen(false)
-                  await handleCalendarChange(date.date)
-                  if (revalidate) revalidate()
-                }}
-                setYear={async (date) => {
-                  await handleCalendarChange(date)
-                  if (revalidate) revalidate()
-                }}
-                minDate={minDate}
-                maxDate={maxDate}
-                refDateToday={refDateToday}
-                refDateSelected={refDateSelected}
-                firstDayOfWeek={firstDayOfWeek}
-                monthNames={monthNames}
-                weekdayNames={weekdayNames}
-                labels={updatedLabels}
-              />
-            </Popover.Content>
-          </Popover.Portal>
-        </Popover>
-      </Box>
-    )
-  }
-)
+  )
 
 DateInput.displayName = 'DateInput'

--- a/lib/src/components/heading/Heading.tsx
+++ b/lib/src/components/heading/Heading.tsx
@@ -52,7 +52,7 @@ export const StyledHeading = styled('h2', {
 })
 
 export type HeadingProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledHeading>,
+  React.ComponentProps<typeof StyledHeading>,
   {
     as?:
       | 'h1'

--- a/lib/src/components/icon/Icon.tsx
+++ b/lib/src/components/icon/Icon.tsx
@@ -28,8 +28,8 @@ type IconProps = Override<
   }
 >
 
-export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
-  ({ is: SVG, size = 'md', ...remainingProps }, ref) => (
+export const Icon: React.ForwardRefExoticComponent<IconProps> =
+  React.forwardRef(({ is: SVG, size = 'md', ...remainingProps }, ref) => (
     <StyledIcon
       size={size}
       aria-hidden="true"
@@ -37,5 +37,4 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
       as={SVG}
       ref={ref}
     />
-  )
-)
+  ))

--- a/lib/src/components/input/Input.tsx
+++ b/lib/src/components/input/Input.tsx
@@ -63,8 +63,8 @@ export type InputProps = Override<
   }
 >
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ type = 'text', size = 'md', ...rest }, ref) => {
+export const Input: React.ForwardRefExoticComponent<InputProps> =
+  React.forwardRef(({ type = 'text', size = 'md', ...rest }, ref) => {
     if (type === 'number') {
       return (
         <StyledInput
@@ -79,7 +79,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     }
 
     return <StyledInput type={type} size={size} {...rest} ref={ref} />
-  }
-)
+  })
 
 Input.displayName = 'Input'

--- a/lib/src/components/link/Link.tsx
+++ b/lib/src/components/link/Link.tsx
@@ -51,8 +51,8 @@ type LinkProps = Override<
   } & NavigatorActions
 >
 
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ as, href, ...rest }, ref) => (
+export const Link: React.ForwardRefExoticComponent<LinkProps> =
+  React.forwardRef(({ as, href, ...rest }, ref) => (
     <StyledLink
       as={as || (!href ? 'button' : undefined)}
       noCapsize={!href ? true : undefined}
@@ -61,7 +61,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       {...getExternalAnchorProps(href)}
       ref={ref}
     />
-  )
-)
+  ))
 
 Link.displayName = 'Link'

--- a/lib/src/components/navigation/NavigationMenuDropdownItem.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownItem.tsx
@@ -5,10 +5,9 @@ import { styled } from '~/stitches'
 import { Text } from '../text'
 import { NavigationMenuLink } from './NavigationMenuLink'
 
-export const NavigationMenuDropdownItem = React.forwardRef<
-  HTMLAnchorElement,
+export const NavigationMenuDropdownItem: React.ForwardRefExoticComponent<
   React.PropsWithChildren<React.ComponentProps<typeof NavigationMenuLink>>
->((props, forwardedRef) => {
+> = React.forwardRef((props, forwardedRef) => {
   return (
     <NavigationMenuLink ref={forwardedRef} variant="dropdownItem" {...props} />
   )

--- a/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
+++ b/lib/src/components/navigation/NavigationMenuDropdownTrigger.tsx
@@ -28,10 +28,9 @@ const StyledTrigger = styled(
   }
 )
 
-export const NavigationMenuDropdownTrigger = React.forwardRef<
-  HTMLButtonElement,
-  React.PropsWithChildren<{ active?: boolean }>
->(({ children, active, ...props }, forwardedRef) => (
+export const NavigationMenuDropdownTrigger: React.ForwardRefExoticComponent<
+  React.ComponentProps<typeof StyledTrigger>
+> = React.forwardRef(({ children, active, ...props }, forwardedRef) => (
   <StyledTrigger
     active={active}
     {...props}

--- a/lib/src/components/navigation/NavigationMenuLink.tsx
+++ b/lib/src/components/navigation/NavigationMenuLink.tsx
@@ -1,7 +1,7 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import React from 'react'
 
-import { CSS, styled } from '~/stitches'
+import { styled } from '~/stitches'
 import { getExternalAnchorProps } from '~/utilities/uri'
 
 import {
@@ -52,25 +52,19 @@ const StyledLink = styled(
   }
 )
 
-type NavigationMenuLinkProps = {
-  href: string
-  active?: boolean
-  disabled?: boolean
-  variant?: 'link' | 'dropdownItem'
-  css?: CSS
-}
-
-export const NavigationMenuLink = React.forwardRef<
-  HTMLAnchorElement,
-  React.PropsWithChildren<NavigationMenuLinkProps>
->(
+export const NavigationMenuLink: React.ForwardRefExoticComponent<
+  Omit<React.ComponentProps<typeof StyledLink>, 'elementType'> & {
+    disabled?: boolean
+    variant?: React.ComponentProps<typeof StyledLink>['elementType']
+  }
+> = React.forwardRef(
   (
-    { children, href, disabled, css, variant = 'link', ...props },
+    { children, href, disabled, css, variant = 'link', ref, ...props },
     forwardedRef
   ) => (
     <ListItem>
       {disabled ? (
-        <DisabledButton disabled {...props}>
+        <DisabledButton disabled css={css}>
           {children}
         </DisabledButton>
       ) : (

--- a/lib/src/components/number-input/NumberInput.tsx
+++ b/lib/src/components/number-input/NumberInput.tsx
@@ -24,7 +24,7 @@ export interface NumberInputProps {
   css?: CSS
 }
 
-export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
+export const NumberInput: React.ForwardRefExoticComponent<NumberInputProps & { ref: React.Ref<HTMLInputElement>}> = React.forwardRef(
   (
     {
       value,

--- a/lib/src/components/password-input/PasswordInput.tsx
+++ b/lib/src/components/password-input/PasswordInput.tsx
@@ -15,53 +15,51 @@ type PasswordInputProps = Omit<InputProps, 'type'> & {
   showPasswordText?: string
 }
 
-export const PasswordInput = React.forwardRef<
-  HTMLInputElement,
-  PasswordInputProps
->(
-  (
-    {
-      css,
-      hidePasswordText = 'Hide password',
-      showPasswordText = 'Show password',
-      size = 'md',
-      ...restProps
-    },
-    ref
-  ) => {
-    const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false)
-    const togglePasswordVisibility = () =>
-      setIsPasswordVisible((currentState) => !currentState)
+export const PasswordInput: React.ForwardRefExoticComponent<PasswordInputProps> =
+  React.forwardRef(
+    (
+      {
+        css,
+        hidePasswordText = 'Hide password',
+        showPasswordText = 'Show password',
+        size = 'md',
+        ...restProps
+      },
+      ref
+    ) => {
+      const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false)
+      const togglePasswordVisibility = () =>
+        setIsPasswordVisible((currentState) => !currentState)
 
-    const iconSize = React.useMemo(() => getFieldIconSize(size), [size])
+      const iconSize = React.useMemo(() => getFieldIconSize(size), [size])
 
-    return (
-      <Box css={{ position: 'relative', ...css } as CSS}>
-        <Input
-          {...restProps}
-          size={size}
-          type={isPasswordVisible ? 'text' : 'password'}
-          ref={ref}
-          css={{ pr: '$sizes$2' }}
-        />
-        <ActionIcon
-          appearance="simple"
-          theme="neutral"
-          css={{
-            bottom: size === 'lg' ? '4px' : 0,
-            position: 'absolute',
-            right: 0
-          }}
-          label={isPasswordVisible ? hidePasswordText : showPasswordText}
-          onClick={togglePasswordVisibility}
-          onMouseDown={(e) => e.preventDefault()} // prevent focus being lost from password input
-          size={iconSize}
-        >
-          <Icon is={isPasswordVisible ? Eye : EyeCrossed} />
-        </ActionIcon>
-      </Box>
-    )
-  }
-)
+      return (
+        <Box css={{ position: 'relative', ...css } as CSS}>
+          <Input
+            {...restProps}
+            size={size}
+            type={isPasswordVisible ? 'text' : 'password'}
+            ref={ref}
+            css={{ pr: '$sizes$2' }}
+          />
+          <ActionIcon
+            appearance="simple"
+            theme="neutral"
+            css={{
+              bottom: size === 'lg' ? '4px' : 0,
+              position: 'absolute',
+              right: 0
+            }}
+            label={isPasswordVisible ? hidePasswordText : showPasswordText}
+            onClick={togglePasswordVisibility}
+            onMouseDown={(e) => e.preventDefault()} // prevent focus being lost from password input
+            size={iconSize}
+          >
+            <Icon is={isPasswordVisible ? Eye : EyeCrossed} />
+          </ActionIcon>
+        </Box>
+      )
+    }
+  )
 
 PasswordInput.displayName = 'PasswordInput'

--- a/lib/src/components/radio-button/RadioButton.tsx
+++ b/lib/src/components/radio-button/RadioButton.tsx
@@ -62,7 +62,7 @@ const StyledIndicator = styled(RadioGroup.Indicator, {
 })
 
 type RadioButtonProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledRadioButton>,
+  React.ComponentProps<typeof StyledRadioButton>,
   {
     as?: never
   } & {

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -53,109 +53,113 @@ const StyledSearchInput = styled(Input, {
     }
 })
 
-export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
-  (
-    {
-      size = 'md',
-      css,
-      value,
-      defaultValue = '',
-      onValueChange,
-      clearText = 'Clear',
-      onChange,
-      ...remainingProps
-    },
-    ref
-  ) => {
-    const [inputElRef, setInputElRef] = useCallbackRef()
-    const [innerValue, setInnerValue] = React.useState(defaultValue)
-    const [activeIcon, setActiveIcon] = React.useState<INPUT_ICON>(
-      defaultValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
-    )
-    React.useEffect(() => {
-      if (typeof value === 'undefined') return
-      setInnerValue(value)
-      setActiveIcon(value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
-    }, [value])
+export const SearchInput: React.ForwardRefExoticComponent<SearchInputProps> =
+  React.forwardRef(
+    (
+      {
+        size = 'md',
+        css,
+        value,
+        defaultValue = '',
+        onValueChange,
+        clearText = 'Clear',
+        onChange,
+        ...remainingProps
+      },
+      ref
+    ) => {
+      const [inputElRef, setInputElRef] = useCallbackRef()
+      const [innerValue, setInnerValue] = React.useState(defaultValue)
+      const [activeIcon, setActiveIcon] = React.useState<INPUT_ICON>(
+        defaultValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH
+      )
+      React.useEffect(() => {
+        if (typeof value === 'undefined') return
+        setInnerValue(value)
+        setActiveIcon(value ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
+      }, [value])
 
-    const iconSize = React.useMemo(() => getFieldIconSize(size), [size])
+      const iconSize = React.useMemo(() => getFieldIconSize(size), [size])
 
-    React.useImperativeHandle(ref, () => inputElRef.current as HTMLInputElement)
+      React.useImperativeHandle(
+        ref,
+        () => inputElRef.current as HTMLInputElement
+      )
 
-    const handleClear = () => {
-      const inputEl = inputElRef.current
-      if (!inputEl) return
+      const handleClear = () => {
+        const inputEl = inputElRef.current
+        if (!inputEl) return
 
-      // https://stackoverflow.com/a/46012210
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        'value'
-      )?.set
-      nativeInputValueSetter?.call?.(inputEl, '')
-      const ev2 = new Event('input', {
-        bubbles: true
-      })
-      inputEl.dispatchEvent(ev2)
-      inputEl.focus()
-      onValueChange?.('')
-    }
+        // https://stackoverflow.com/a/46012210
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value'
+        )?.set
+        nativeInputValueSetter?.call?.(inputEl, '')
+        const ev2 = new Event('input', {
+          bubbles: true
+        })
+        inputEl.dispatchEvent(ev2)
+        inputEl.focus()
+        onValueChange?.('')
+      }
 
-    const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange?.(event)
+      const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange?.(event)
 
-      const newValue = event.target.value
-      setInnerValue(newValue)
-      onValueChange?.(newValue)
-      setActiveIcon(newValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
-    }
+        const newValue = event.target.value
+        setInnerValue(newValue)
+        onValueChange?.(newValue)
+        setActiveIcon(newValue ? INPUT_ICON.CLEAR : INPUT_ICON.SEARCH)
+      }
 
-    const getIcon = () => {
-      if (activeIcon === INPUT_ICON.SEARCH)
+      const getIcon = () => {
+        if (activeIcon === INPUT_ICON.SEARCH)
+          return (
+            <StyledIcon
+              is={Search}
+              size={size}
+              css={{
+                size: size == 'sm' ? '$1' : 20,
+                top: '50%',
+                transform: 'translateY(-50%)'
+              }}
+            />
+          )
+
         return (
-          <StyledIcon
-            is={Search}
-            size={size}
+          <ActionIcon
+            label={clearText}
+            theme="neutral"
+            size={iconSize}
             css={{
-              size: size == 'sm' ? '$1' : 20,
+              position: 'absolute',
               top: '50%',
-              transform: 'translateY(-50%)'
+              transform: 'translateY(-50%)',
+              right: '$1'
             }}
-          />
+            onClick={handleClear}
+          >
+            <Icon is={Close} />
+          </ActionIcon>
         )
+      }
 
       return (
-        <ActionIcon
-          label={clearText}
-          theme="neutral"
-          size={iconSize}
-          css={{
-            position: 'absolute',
-            top: '50%',
-            transform: 'translateY(-50%)',
-            right: '$1'
-          }}
-          onClick={handleClear}
-        >
-          <Icon is={Close} />
-        </ActionIcon>
+        <Box css={{ position: 'relative', height: 'max-content', ...css }}>
+          <StyledSearchInput
+            ref={setInputElRef}
+            size={size}
+            type="search"
+            {...remainingProps}
+            value={innerValue}
+            onChange={handleOnChange}
+            css={{ pr: size === 'sm' ? '$5' : '$6' }}
+          />
+          {getIcon()}
+        </Box>
       )
     }
-
-    return (
-      <Box css={{ position: 'relative', height: 'max-content', ...css }}>
-        <StyledSearchInput
-          ref={setInputElRef}
-          size={size}
-          type="search"
-          {...remainingProps}
-          value={innerValue}
-          onChange={handleOnChange}
-          css={{ pr: size === 'sm' ? '$5' : '$6' }}
-        />
-        {getIcon()}
-      </Box>
-    )
-  }
-)
+  )
 
 SearchInput.displayName = 'SearchInput'

--- a/lib/src/components/select/Select.tsx
+++ b/lib/src/components/select/Select.tsx
@@ -78,7 +78,7 @@ export type SelectProps = Override<
   // )
 >
 
-export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+export const Select: React.ForwardRefExoticComponent<SelectProps> = React.forwardRef(
   ({ placeholder, children, size = 'md', ...remainingProps }, ref) => {
     const props = { size, ref, ...remainingProps }
 

--- a/lib/src/components/table/TableRow.tsx
+++ b/lib/src/components/table/TableRow.tsx
@@ -6,9 +6,8 @@ export const StyledRow = styled('tr', {
   bg: 'unset'
 })
 
-export const TableRow = React.forwardRef<
-  HTMLTableRowElement,
+export const TableRow: React.ForwardRefExoticComponent<
   React.ComponentProps<typeof StyledRow>
->((props, ref) => <StyledRow {...props} ref={ref} />)
+> = React.forwardRef((props, ref) => <StyledRow {...props} ref={ref} />)
 
 TableRow.displayName = 'TableRow'

--- a/lib/src/components/tabs/TabsTrigger.tsx
+++ b/lib/src/components/tabs/TabsTrigger.tsx
@@ -46,12 +46,10 @@ const StyledTabsTrigger = styled(Trigger, {
   }
 })
 
-interface TabsTriggerProps
-  extends React.ComponentProps<typeof StyledTabsTrigger> {
-  value: string
-}
-
-export const TabsTrigger = ({ children, ...rest }: TabsTriggerProps) => (
+export const TabsTrigger = ({
+  children,
+  ...rest
+}: React.ComponentProps<typeof StyledTabsTrigger> & { value: string }) => (
   <StyledTabsTrigger {...rest}>
     <Text size="sm" as="span">
       {children}

--- a/lib/src/components/textarea/Textarea.tsx
+++ b/lib/src/components/textarea/Textarea.tsx
@@ -43,8 +43,7 @@ const StyledTextarea = styled('textarea', {
 
 export type TextareaProps = React.ComponentProps<typeof StyledTextarea>
 
-export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  (props, ref) => <StyledTextarea {...props} ref={ref} />
-)
+export const Textarea: React.ForwardRefExoticComponent<TextareaProps> =
+  React.forwardRef((props, ref) => <StyledTextarea {...props} ref={ref} />)
 
 Textarea.displayName = 'Textarea'

--- a/lib/src/components/tile-interactive/TileInteractive.tsx
+++ b/lib/src/components/tile-interactive/TileInteractive.tsx
@@ -47,20 +47,20 @@ type TTileInteractiveProps = React.ComponentProps<
   React.ButtonHTMLAttributes<HTMLButtonElement> &
   NavigatorActions
 
-export const TileInteractive = React.forwardRef<
-  HTMLButtonElement,
-  TTileInteractiveProps
->(({ onClick, href, type = 'button', ...rest }, ref) => {
-  const isLink = !!href
-  const elementSpecificProps = isLink
-    ? {
-        as: 'a' as React.ElementType,
-        href,
-        onClick: undefined
-      }
-    : { as: 'button' as React.ElementType, type, onClick }
+export const TileInteractive: React.ForwardRefExoticComponent<TTileInteractiveProps> =
+  React.forwardRef(({ onClick, href, type = 'button', ...rest }, ref) => {
+    const isLink = !!href
+    const elementSpecificProps = isLink
+      ? {
+          as: 'a' as React.ElementType,
+          href,
+          onClick: undefined
+        }
+      : { as: 'button' as React.ElementType, type, onClick }
 
-  return <StyledTileInteractive {...rest} {...elementSpecificProps} ref={ref} />
-})
+    return (
+      <StyledTileInteractive {...rest} {...elementSpecificProps} ref={ref} />
+    )
+  })
 
 TileInteractive.displayName = 'TileInteractive'

--- a/lib/src/components/tile-toggle-group/TileToggleGroupRoot.tsx
+++ b/lib/src/components/tile-toggle-group/TileToggleGroupRoot.tsx
@@ -13,19 +13,17 @@ const orientationToDirection = (orientation) =>
     ? 'column'
     : undefined
 
-export const TileToggleGroupRoot = React.forwardRef<
-  HTMLDivElement,
-  TTileToggleGroupRootProps
->((props, ref) => {
-  const direction = orientationToDirection(props.orientation)
-  return (
-    <TileGroup
-      ref={ref}
-      as={ToggleGroup.Root}
-      direction={direction}
-      gap="2"
-      wrap="wrap"
-      {...props}
-    />
-  )
-})
+export const TileToggleGroupRoot: React.ForwardRefExoticComponent<TTileToggleGroupRootProps> =
+  React.forwardRef((props, ref) => {
+    const direction = orientationToDirection(props.orientation)
+    return (
+      <TileGroup
+        ref={ref}
+        as={ToggleGroup.Root}
+        direction={direction}
+        gap="2"
+        wrap="wrap"
+        {...props}
+      />
+    )
+  })

--- a/lib/src/components/tile/Tile.tsx
+++ b/lib/src/components/tile/Tile.tsx
@@ -29,7 +29,7 @@ type TTileProps = React.ComponentProps<typeof StyledTile> & {
   colorScheme?: TcolorScheme
 }
 
-export const Tile = React.forwardRef<HTMLDivElement, TTileProps>(
+export const Tile: React.ForwardRefExoticComponent<TTileProps> = React.forwardRef(
   ({ children, colorScheme = {}, ...rest }, ref) => (
     <ColorScheme
       asChild

--- a/lib/src/components/tree/Tree.tsx
+++ b/lib/src/components/tree/Tree.tsx
@@ -14,18 +14,14 @@ const StyledRoot = styled(TreeList, {})
 
 type TreeProps = React.ComponentProps<typeof StyledRoot>
 
-export const TreeRoot = React.forwardRef(
-  (
-    { children, ...rest }: TreeProps,
-    ref: React.ForwardedRef<HTMLUListElement>
-  ) => {
+export const TreeRoot: React.ForwardRefExoticComponent<TreeProps> =
+  React.forwardRef(({ children, ...rest }, ref) => {
     return (
       <StyledRoot {...rest} ref={ref} role="tree">
         {children}
       </StyledRoot>
     )
-  }
-)
+  })
 
 export const Tree = Object.assign(TreeRoot, {
   Collapsible: TreeCollapsible,

--- a/lib/src/components/tree/TreeCollapsibleContent.tsx
+++ b/lib/src/components/tree/TreeCollapsibleContent.tsx
@@ -18,11 +18,8 @@ type TreeCollapsibleContentProps = React.ComponentProps<
 > &
   React.ComponentProps<typeof TreeList>
 
-export const TreeCollapsibleContent = React.forwardRef(
-  (
-    { children, ...rest }: TreeCollapsibleContentProps,
-    ref: React.ForwardedRef<HTMLUListElement>
-  ): JSX.Element => {
+export const TreeCollapsibleContent: React.ForwardRefExoticComponent<TreeCollapsibleContentProps> =
+  React.forwardRef(({ children, ...rest }, ref): JSX.Element => {
     const { triggerRef } = React.useContext(TreeCollapsibleContext)
 
     const handleOnKeydown = (e) => {
@@ -46,5 +43,4 @@ export const TreeCollapsibleContent = React.forwardRef(
         </TreeList>
       </StyledTreeCollapsibleContent>
     )
-  }
-)
+  })

--- a/lib/src/components/tree/TreeList.tsx
+++ b/lib/src/components/tree/TreeList.tsx
@@ -13,18 +13,11 @@ const StyledList = styled(Flex, {
   }
 })
 
-type TreeListProps = Omit<
-  React.ComponentPropsWithoutRef<typeof Flex>,
-  'direction'
->
+type TreeListProps = Omit<React.ComponentProps<typeof Flex>, 'direction'>
 
-export const TreeList = React.forwardRef(
-  (
-    props: TreeListProps,
-    ref: React.ForwardedRef<HTMLUListElement>
-  ): JSX.Element => (
+export const TreeList: React.ForwardRefExoticComponent<TreeListProps> =
+  React.forwardRef((props, ref) => (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: Stitches polymorphic components issue due to `as="ul"`
     <StyledList as="ul" ref={ref} {...props} direction="column" />
-  )
-)
+  ))

--- a/lib/src/components/video/Video.tsx
+++ b/lib/src/components/video/Video.tsx
@@ -10,7 +10,7 @@ import { Override } from '~/utilities/types'
 const StyledVideo = styled(ReactPlayer, {})
 
 type VideoProps = Override<
-  React.ComponentPropsWithoutRef<typeof StyledVideo>,
+  React.ComponentProps<typeof StyledVideo>,
   {
     id: string
     ratio?: number
@@ -18,8 +18,8 @@ type VideoProps = Override<
   }
 >
 
-export const Video = React.forwardRef<typeof StyledVideo, VideoProps>(
-  ({ id, ratio = 9 / 16, css, ...remainingProps }, ref) => (
+export const Video: React.ForwardRefExoticComponent<VideoProps> =
+  React.forwardRef(({ id, ratio = 9 / 16, css, ...remainingProps }, ref) => (
     <CSSWrapper css={css}>
       <Box
         css={{
@@ -42,7 +42,6 @@ export const Video = React.forwardRef<typeof StyledVideo, VideoProps>(
         />
       </Box>
     </CSSWrapper>
-  )
-)
+  ))
 
 Video.displayName = 'Video'

--- a/lib/src/experiments/color-scheme/ColorScheme.tsx
+++ b/lib/src/experiments/color-scheme/ColorScheme.tsx
@@ -23,30 +23,31 @@ type TColorSchemeProps = React.ComponentProps<typeof StyledColorScheme> &
 /**
  * @experimental Component has not been finalised. Further design input required. Use with caution.
  */
-export const ColorScheme = React.forwardRef<HTMLDivElement, TColorSchemeProps>(
-  (
-    {
-      base = '',
-      accent = '',
-      interactive = '',
-      className,
-      asChild = false,
-      ...rest
-    },
-    ref
-  ) => {
-    const c = [
-      className,
-      colorSchemes[`interactive-${interactive}`],
-      colorSchemes[`accent-${accent}`],
-      colorSchemes[`base-${base}`]
-    ]
-      .filter(Boolean)
-      .join(' ')
+export const ColorScheme: React.ForwardRefExoticComponent<TColorSchemeProps> =
+  React.forwardRef(
+    (
+      {
+        base = '',
+        accent = '',
+        interactive = '',
+        className,
+        asChild = false,
+        ...rest
+      },
+      ref
+    ) => {
+      const c = [
+        className,
+        colorSchemes[`interactive-${interactive}`],
+        colorSchemes[`accent-${accent}`],
+        colorSchemes[`base-${base}`]
+      ]
+        .filter(Boolean)
+        .join(' ')
 
-    const Component = asChild ? Slot : StyledColorScheme
-    return <Component ref={ref} className={c} {...rest} />
-  }
-)
+      const Component = asChild ? Slot : StyledColorScheme
+      return <Component ref={ref} className={c} {...rest} />
+    }
+  )
 
 ColorScheme.displayName = 'ColorScheme'


### PR DESCRIPTION
The way we typed our `forwardRef`s caused issues when upgrading to React 18 in the core repo. It would pick all properties from the HTML element and make them mandatory.

This PR replaces them with `React.ForwardRefExoticComponent`.