### PR TITLE
fix: make the children prop optional on the Stepper.StepForward component

### DIFF
--- a/lib/src/components/stepper/StepperStepForward.tsx
+++ b/lib/src/components/stepper/StepperStepForward.tsx
@@ -9,7 +9,7 @@ export const StepperStepForward = ({
   children,
   onClick,
   ...rest
-}: IStepperNavigateProps & React.ComponentProps<typeof Button>) => {
+}: IStepperNavigateProps & Partial<React.ComponentProps<typeof Button>>) => {
   const { goToNextStep, activeStep } = useStepper()
 
   const handleClick = () => {


### PR DESCRIPTION
We have a condition in the component that makes the `children` prop optional. This wasn't reflected in the types.