### PR TITLE
chore: add stale githubaction

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,21 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * 2'
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open for a year with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open for 3 months with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for a year with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 3 months with no activity.'
+          days-before-issue-stale: 365
+          days-before-pr-stale: 90
+          days-before-issue-close: 7
+          days-before-pr-close: 7


### PR DESCRIPTION
**Description:**

After running the stale GH action successfully on our main repo, this PR introduces the same conditions in this repo

This task will use the off the box functionality of GitHub to close PRs and issues that had no activity in a long time.

NOTE: the PRs and issues are closed, not deleted, so there is no loss of code or information.

**Why?**

- To avoid the temptation of trying to reinstate a PR that has been stale ( has been the source of many bugs in the past as the code base evolves too quickly now that we are a larger team)
- To avoid clutter and make it easier to see what is pending
- To avoid having people be tagged in notifications (in Slack) on PRs that are stale

**Implementation**
This current config which we can adapt,

- will comment on the PR if it had no activity for about 4 months (120 days) and close it after 7 days, if it doesn't receive any activity(ie code changes or comments or the removal of the stale label)
- will comment on the Issue if it had no activity for a year (365 days - ignoring leap years as it is not a big difference to warrant the effort to address that) and close it after 7 days if it doesn't receive any activity(ie code changes or comments)

**Resources**
https://github.com/actions/stale
https://docs.github.com/en/actions/using-workflows/about-workflows
Quick example https://medium.com/@saurabhdeshpande49/how-i-solved-the-problem-of-stale-github-pull-requests-12eb9f9e1971