### PR TITLE
Fix: Checkbox Tree flash of checked

### DIFF
--- a/lib/src/components/checkbox-group/CheckboxGroupAllItem.tsx
+++ b/lib/src/components/checkbox-group/CheckboxGroupAllItem.tsx
@@ -32,6 +32,8 @@ export const CheckboxGroupAllItem = ({
   }
 
   const isAllChecked = (() => {
+    if (!checkedItems.length || !mountedItems.length) return false
+
     if (mountedItems.every((mountedItem) => checkedItems.includes(mountedItem)))
       return true
 

--- a/lib/src/components/checkbox-group/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/lib/src/components/checkbox-group/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -2,16 +2,6 @@
 
 exports[`CheckboxGroup component renders a checkbox 1`] = `
 @media  {
-  .c-hMRxhp {
-    display: inline-block;
-    fill: none;
-    flex-shrink: 0;
-    stroke: currentcolor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    vertical-align: middle;
-  }
-
   .c-jgUzPy {
     position: absolute;
     top: 50%;
@@ -60,12 +50,6 @@ exports[`CheckboxGroup component renders a checkbox 1`] = `
 }
 
 @media  {
-  .c-hMRxhp-cyeZeh-size-sm {
-    height: var(--sizes-1);
-    width: var(--sizes-1);
-    stroke-width: 1.5;
-  }
-
   .c-dScekx-kupcZn-size-md {
     height: var(--sizes-1);
     width: var(--sizes-1);

--- a/lib/src/components/checkbox-tree/__snapshots__/CheckboxTree.test.tsx.snap
+++ b/lib/src/components/checkbox-tree/__snapshots__/CheckboxTree.test.tsx.snap
@@ -228,12 +228,6 @@ exports[`CheckboxTree component renders a checkbox 1`] = `
   }
 }
 
-@media  {
-  .c-hMRxhp-igiJmlC-css {
-    stroke-width: 3;
-  }
-}
-
 <div>
   <ul
     class="c-dhzjXW c-gkooaz c-dhzjXW-iTKOFX-direction-column c-PJLV PJLV"


### PR DESCRIPTION
Ensure all checkbox items in a group are not checked when mounted. 

### Before


https://github.com/Atom-Learning/components/assets/3226804/c4ce0cf7-dbf1-4932-995c-1f1765ef7303

https://github.com/Atom-Learning/components/assets/3226804/e695cd38-7d41-462a-bc3d-c50473751f28

### After

https://github.com/Atom-Learning/components/assets/3226804/cdae8d5e-af3a-40cf-b71a-3fac1e42b8d4

https://github.com/Atom-Learning/components/assets/3226804/8c65866e-c5c9-49c9-b909-31e419470575



