### PR TITLE
B2B-651 - Custom popover view for pagination

### DIFF
--- a/lib/src/components/pagination/Pagination.test.tsx
+++ b/lib/src/components/pagination/Pagination.test.tsx
@@ -12,6 +12,8 @@ import { Pagination } from './index'
 import { Flex } from '../flex'
 import { Text } from '../text'
 import userEvent from '@testing-library/user-event'
+import { Icon } from '../icon'
+import { ChevronDown } from '@atom-learning/icons'
 
 const pageChangeSpy = jest.fn()
 
@@ -226,6 +228,7 @@ describe('Pagination component', () => {
         <Pagination.Popover>
           <Flex gap={1} align="center" css={{ cursor: 'pointer' }}>
             <Text>{`Question 1 / 10`}</Text>
+            <Icon is={ChevronDown} size="sm" />
           </Flex>
         </Pagination.Popover>
       </Pagination>

--- a/lib/src/components/pagination/Pagination.test.tsx
+++ b/lib/src/components/pagination/Pagination.test.tsx
@@ -9,6 +9,9 @@ import { axe } from 'jest-axe'
 import * as React from 'react'
 
 import { Pagination } from './index'
+import { Flex } from '../flex'
+import { Text } from '../text'
+import userEvent from '@testing-library/user-event'
 
 const pageChangeSpy = jest.fn()
 
@@ -215,5 +218,29 @@ describe('Pagination component', () => {
     expect(
       await waitFor(() => axe(container), { timeout: 5000 })
     ).toHaveNoViolations()
+  })
+
+  it('renders with custom popover trigger if turned on', async () => {
+    await render(
+      <Pagination
+        pagesCount={10}
+        selectedPage={1}
+        showPopoverTrigger={true}
+        popoverTriggerLabel={
+          <Flex gap={1} align="center" css={{ cursor: 'pointer' }}>
+            <Text>{`Question 1 / 10`}</Text>
+          </Flex>
+        }
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: '1' })).not.toBeInTheDocument()
+    expect(screen.getByText('Question 1 / 10')).toBeVisible()
+
+    userEvent.click(screen.getByText('Question 1 / 10'))
+
+    const dialog = await screen.findByRole('dialog')
+
+    expect(within(dialog).getByText('1')).toBeVisible()
   })
 })

--- a/lib/src/components/pagination/Pagination.test.tsx
+++ b/lib/src/components/pagination/Pagination.test.tsx
@@ -222,16 +222,13 @@ describe('Pagination component', () => {
 
   it('renders with custom popover trigger if turned on', async () => {
     await render(
-      <Pagination
-        pagesCount={10}
-        selectedPage={1}
-        showPopoverTrigger={true}
-        popoverTriggerLabel={
+      <Pagination pagesCount={10} selectedPage={1}>
+        <Pagination.Popover>
           <Flex gap={1} align="center" css={{ cursor: 'pointer' }}>
             <Text>{`Question 1 / 10`}</Text>
           </Flex>
-        }
-      />
+        </Pagination.Popover>
+      </Pagination>
     )
 
     expect(screen.queryByRole('button', { name: '1' })).not.toBeInTheDocument()

--- a/lib/src/components/pagination/Pagination.tsx
+++ b/lib/src/components/pagination/Pagination.tsx
@@ -5,7 +5,8 @@ import { Flex } from '../flex'
 import { VisibleElementsAmount } from './pagination.constants'
 import { PaginationProvider } from './pagination-context/PaginationContext'
 import { PaginationItems } from './PaginationItems'
-import type { PaginationProps } from './types'
+import { PaginationPopover } from './PaginationPopover'
+import type { PaginationProps, PaginationProviderProps } from './types'
 
 export const Pagination = ({
   colorScheme,
@@ -17,11 +18,13 @@ export const Pagination = ({
   disabledPages = [],
   onItemHover = () => null,
   labels = {},
+  showPopoverTrigger = false,
+  popoverTriggerLabel = null,
   ...rest
 }: PaginationProps) => {
   if (!pagesCount) return null
 
-  const paginationProviderProps = {
+  const paginationProviderProps: PaginationProviderProps = {
     onSelectedPageChange,
     selectedPage,
     visibleElementsCount,
@@ -35,9 +38,13 @@ export const Pagination = ({
   return (
     <PaginationProvider {...paginationProviderProps}>
       <ColorScheme base="grey1" accent="primary1" {...colorScheme} asChild>
-        <Flex gap={1} {...rest}>
-          <PaginationItems />
-        </Flex>
+        {showPopoverTrigger ? (
+          <PaginationPopover>{popoverTriggerLabel}</PaginationPopover>
+        ) : (
+          <Flex gap={1} {...rest}>
+            <PaginationItems />
+          </Flex>
+        )}
       </ColorScheme>
     </PaginationProvider>
   )

--- a/lib/src/components/pagination/Pagination.tsx
+++ b/lib/src/components/pagination/Pagination.tsx
@@ -8,7 +8,7 @@ import { PaginationItems } from './PaginationItems'
 import { PaginationPopover } from './PaginationPopover'
 import type { PaginationProps, PaginationProviderProps } from './types'
 
-export const Pagination = ({
+const PaginationComponent = ({
   colorScheme,
   onSelectedPageChange,
   selectedPage,
@@ -18,8 +18,7 @@ export const Pagination = ({
   disabledPages = [],
   onItemHover = () => null,
   labels = {},
-  showPopoverTrigger = false,
-  popoverTriggerLabel = null,
+  children,
   ...rest
 }: PaginationProps) => {
   if (!pagesCount) return null
@@ -38,9 +37,7 @@ export const Pagination = ({
   return (
     <PaginationProvider {...paginationProviderProps}>
       <ColorScheme base="grey1" accent="primary1" {...colorScheme} asChild>
-        {showPopoverTrigger ? (
-          <PaginationPopover>{popoverTriggerLabel}</PaginationPopover>
-        ) : (
+        {children || (
           <Flex gap={1} {...rest}>
             <PaginationItems />
           </Flex>
@@ -50,4 +47,8 @@ export const Pagination = ({
   )
 }
 
-Pagination.displayName = 'Pagination'
+export const Pagination = Object.assign(PaginationComponent, {
+  Popover: PaginationPopover
+})
+
+PaginationComponent.displayName = 'Pagination'

--- a/lib/src/components/pagination/PaginationPopover.tsx
+++ b/lib/src/components/pagination/PaginationPopover.tsx
@@ -5,7 +5,9 @@ import { ActionIcon, Flex, Icon, Popover } from '..'
 import { PaginationPage } from './PaginationPage'
 import { usePagination } from './usePagination'
 
-export const PaginationPopover = () => {
+export const PaginationPopover = ({
+  children
+}: React.PropsWithChildren<unknown>) => {
   const { pagesCount, labels } = usePagination()
   const paginationItems = Array.from(
     { length: pagesCount },
@@ -15,15 +17,19 @@ export const PaginationPopover = () => {
   return (
     <Popover>
       <Popover.Trigger asChild>
-        <ActionIcon
-          hasTooltip={false}
-          size="md"
-          theme="neutral"
-          label={labels?.popoverTriggerLabel || 'Open pagination popover'}
-          data-testid="pagination_popover_trigger"
-        >
-          <Icon is={Ellypsis} />
-        </ActionIcon>
+        {children ? (
+          children
+        ) : (
+          <ActionIcon
+            hasTooltip={false}
+            size="md"
+            theme="neutral"
+            label={labels?.popoverTriggerLabel || 'Open pagination popover'}
+            data-testid="pagination_popover_trigger"
+          >
+            <Icon is={Ellypsis} />
+          </ActionIcon>
+        )}
       </Popover.Trigger>
       <Popover.Content size="md" showCloseButton={false} css={{ p: 0 }}>
         <Flex

--- a/lib/src/components/pagination/PaginationPopover.tsx
+++ b/lib/src/components/pagination/PaginationPopover.tsx
@@ -17,9 +17,7 @@ export const PaginationPopover = ({
   return (
     <Popover>
       <Popover.Trigger asChild>
-        {children ? (
-          children
-        ) : (
+        {children || (
           <ActionIcon
             hasTooltip={false}
             size="md"

--- a/lib/src/components/pagination/types.ts
+++ b/lib/src/components/pagination/types.ts
@@ -53,4 +53,6 @@ export type PaginationProviderProps = Pick<BasePaginationProps, 'pagesCount'> &
 export interface PaginationProps extends PaginationProviderProps {
   colorScheme?: TcolorScheme
   css?: CSS
+  showPopoverTrigger?: boolean
+  popoverTriggerLabel?: React.ReactNode
 }

--- a/lib/src/components/pagination/types.ts
+++ b/lib/src/components/pagination/types.ts
@@ -53,6 +53,5 @@ export type PaginationProviderProps = Pick<BasePaginationProps, 'pagesCount'> &
 export interface PaginationProps extends PaginationProviderProps {
   colorScheme?: TcolorScheme
   css?: CSS
-  showPopoverTrigger?: boolean
-  popoverTriggerLabel?: React.ReactNode
+  children?: React.ReactNode
 }


### PR DESCRIPTION
This ticket is part of this B2B ticket:
https://atomlearningltd.atlassian.net/browse/B2B-651
AS A Quest student
I WANT to find the navigation easy and intuitive, even if I am a 5-year-old
SO THAT I can do my best in the assessment without being confused or distracted

The pagination popover is exactly what we needed to display, just with a different trigger, and no horizontal numbered list of pages.

I considered pulling the <PaginationPopover> component out so it could be added directly, but it would need the Provider and ColorScheme around it, and that quickly seemed impractical.

So I have added a couple of new props, to turn the "popover only" view on, and specify what the trigger looks like. 
I'm open to suggestions on naming and other alternatives but this seems like a really neat way to achieve what we want.

<img width="482" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/8d68a144-8f34-49e0-bdde-c16ff20a5bba">
