### PR TITLE
B2B-651 - Indicated page style on popover

### DIFF
--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -96,7 +96,11 @@ const StyledButton = styled('button', {
   }
 })
 
-export const PaginationPage = ({ pageNumber, css }: PaginationPageProps) => {
+export const PaginationPage = ({
+  pageNumber,
+  css,
+  indicatedCSS
+}: PaginationPageProps) => {
   const { currentPage, goToPage, indicatedPages, disabledPages, onItemHover } =
     usePagination()
 
@@ -115,7 +119,7 @@ export const PaginationPage = ({ pageNumber, css }: PaginationPageProps) => {
       selected={isSelected}
       size="md"
       onClick={() => goToPage(pageNumber)}
-      css={css}
+      css={{ ...css, ...(isIndicated ? { ...indicatedCSS } : {}) }}
       indicated={isIndicated}
       disabled={isDisabled}
       aria-current={isSelected && 'page'}

--- a/lib/src/components/pagination/PaginationPopover.tsx
+++ b/lib/src/components/pagination/PaginationPopover.tsx
@@ -4,10 +4,19 @@ import React from 'react'
 import { ActionIcon, Flex, Icon, Popover } from '..'
 import { PaginationPage } from './PaginationPage'
 import { usePagination } from './usePagination'
+import { CSS } from '@stitches/react'
+
+interface PaginationPopoverProps {
+  pageCSS?: CSS
+  indicatedPageCSS?: CSS
+  children: React.ReactNode
+}
 
 export const PaginationPopover = ({
+  pageCSS,
+  indicatedPageCSS,
   children
-}: React.PropsWithChildren<unknown>) => {
+}: PaginationPopoverProps) => {
   const { pagesCount, labels } = usePagination()
   const paginationItems = Array.from(
     { length: pagesCount },
@@ -44,7 +53,8 @@ export const PaginationPopover = ({
               <PaginationPage
                 key={pageNumber}
                 pageNumber={pageNumber}
-                css={{ bg: '$white' }}
+                css={{ bg: '$white', ...pageCSS }}
+                indicatedCSS={indicatedPageCSS}
               />
             )
           })}

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -506,14 +506,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md c-fmWFdu-bxzneo-selected-true"
+      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md c-fmWFdu-bxzneo-selected-true c-fmWFdu-iPJLV-css"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md"
+      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md c-fmWFdu-iPJLV-css"
     >
       2
     </button>
@@ -553,7 +553,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md"
+      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md c-fmWFdu-iPJLV-css"
     >
       6
     </button>

--- a/lib/src/components/pagination/types.ts
+++ b/lib/src/components/pagination/types.ts
@@ -33,6 +33,7 @@ export type TVisibleElementsCount = 6 | 8
 export interface PaginationPageProps {
   pageNumber: number
   css?: CSS
+  indicatedCSS?: CSS
 }
 export interface PaginationContextValue extends BasePaginationProps {
   currentPage: number


### PR DESCRIPTION
We need the ability to define custom indicated styles for the indicated pages in the popover, primarily a solid coloured background, but we want to keep the circle indicator as a default for the normal list of pages.

I added a prop to handle the extra css to the page and the popover.

<img width="529" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/9dc3b109-c90e-4de8-ac5c-d0971dcf7ab4">

<img width="528" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/74fcb0b9-407a-435f-a7c8-a21535303bad">
