### PR TITLE
feat: disableDeselect ToggleGroup functionality

### DIFF
--- a/documentation/content/components.toggle-group.md
+++ b/documentation/content/components.toggle-group.md
@@ -98,6 +98,22 @@ tabs:
       </ToggleGroup.Root>`} language={"tsx"} />
 
 
+      ## Disable Deselect
+
+
+      `disableDeselect={boolean}`
+
+
+      By default the `ToggleGroup` allows itself to be entirely deselected even after a value has been chosen. This property disables this deselect funcionality, always keeping a value selected after first selection. Similar to how radios work.
+
+
+      <CodeBlock live={true} preview={true} code={`<ToggleGroup.Root type="multiple" disableDeselect>
+        <ToggleGroup.Button value="a">A</ToggleGroup.Button>
+        <ToggleGroup.Button value="b">B</ToggleGroup.Button>
+        <ToggleGroup.Button value="c">C</ToggleGroup.Button>
+      </ToggleGroup.Root>`} language={"tsx"} />
+
+
       ### API Reference
 
 

--- a/lib/src/components/chip-toggle-group/ChipToggleGroupRoot.tsx
+++ b/lib/src/components/chip-toggle-group/ChipToggleGroupRoot.tsx
@@ -1,7 +1,7 @@
-import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as React from 'react'
 
 import { ChipGroup } from '~/components/chip'
+import { ToggleGroup } from '~/utilities/radix-overrides/toggle-group'
 
 type TChipToggleGroupRootProps = React.ComponentProps<typeof ChipGroup> &
   React.ComponentProps<typeof ToggleGroup.Root>

--- a/lib/src/components/tile-toggle-group/TileToggleGroupRoot.tsx
+++ b/lib/src/components/tile-toggle-group/TileToggleGroupRoot.tsx
@@ -1,7 +1,7 @@
-import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as React from 'react'
 
 import { TileGroup } from '~/components/tile'
+import { ToggleGroup } from '~/utilities/radix-overrides/toggle-group'
 
 type TTileToggleGroupRootProps = React.ComponentProps<typeof TileGroup> &
   React.ComponentProps<typeof ToggleGroup.Root>

--- a/lib/src/components/toggle-group/ToggleGroupRoot.tsx
+++ b/lib/src/components/toggle-group/ToggleGroupRoot.tsx
@@ -1,14 +1,15 @@
-import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as React from 'react'
 
 import { Flex } from '~/components/flex'
 import { styled } from '~/stitches'
+import { ToggleGroup } from '~/utilities/radix-overrides/toggle-group'
 
 import { StyledItem } from './ToggleGroupItem'
 
 type RootType = {
   orientation?: 'horizontal' | 'vertical'
   isFullWidth?: boolean
+  disableDeselect?: boolean
 }
 
 export const StyledRoot = styled(ToggleGroup.Root, {

--- a/lib/src/components/toggle-group/ToggleGroupRoot.tsx
+++ b/lib/src/components/toggle-group/ToggleGroupRoot.tsx
@@ -9,7 +9,6 @@ import { StyledItem } from './ToggleGroupItem'
 type RootType = {
   orientation?: 'horizontal' | 'vertical'
   isFullWidth?: boolean
-  disableDeselect?: boolean
 }
 
 export const StyledRoot = styled(ToggleGroup.Root, {

--- a/lib/src/utilities/radix-overrides/index.ts
+++ b/lib/src/utilities/radix-overrides/index.ts
@@ -1,0 +1,1 @@
+export { ToggleGroup } from './toggle-group'

--- a/lib/src/utilities/radix-overrides/toggle-group/ToggleGroupRoot.tsx
+++ b/lib/src/utilities/radix-overrides/toggle-group/ToggleGroupRoot.tsx
@@ -5,24 +5,35 @@ type RootType = {
   disableDeselect?: boolean
 }
 
-export const ToggleGroupRoot: React.ForwardRefExoticComponent<
-  React.ComponentProps<typeof ToggleGroup.Root> & RootType
-> = React.forwardRef(
-  ({ disableDeselect = false, onValueChange, defaultValue, ...rest }, ref) => {
-    const [internalValue, setInternalValue] = React.useState(defaultValue)
-    const handleValueChange = (newValue) => {
-      if (disableDeselect && (newValue === '' || newValue.length === 0)) return
-      setInternalValue(newValue)
-      onValueChange?.(newValue)
-    }
+type ToggleGroupRootProps = React.ComponentProps<typeof ToggleGroup.Root> &
+  RootType
 
-    return (
-      <ToggleGroup.Root
-        ref={ref}
-        onValueChange={handleValueChange}
-        value={internalValue}
-        {...rest}
-      />
-    )
-  }
-)
+export const ToggleGroupRoot: React.ForwardRefExoticComponent<ToggleGroupRootProps> =
+  React.forwardRef(
+    (
+      { disableDeselect = false, onValueChange, defaultValue, ...rest },
+      ref
+    ) => {
+      const [internalValue, setInternalValue] =
+        React.useState<ToggleGroupRootProps['value']>(defaultValue)
+      const handleValueChange: ToggleGroupRootProps['onValueChange'] = (
+        newValue
+      ) => {
+        if (disableDeselect && (newValue === '' || newValue?.length === 0))
+          return
+        setInternalValue(newValue)
+        onValueChange?.(newValue)
+      }
+
+      return (
+        // eslint-disable-next-line
+        // @ts-ignore Radix types complain on properties depending on whether `type="single"` or `"multiple"`. Works correctly so muting.
+        <ToggleGroup.Root
+          ref={ref}
+          onValueChange={handleValueChange}
+          value={internalValue}
+          {...rest}
+        />
+      )
+    }
+  )

--- a/lib/src/utilities/radix-overrides/toggle-group/ToggleGroupRoot.tsx
+++ b/lib/src/utilities/radix-overrides/toggle-group/ToggleGroupRoot.tsx
@@ -1,0 +1,28 @@
+import * as ToggleGroup from '@radix-ui/react-toggle-group'
+import * as React from 'react'
+
+type RootType = {
+  disableDeselect?: boolean
+}
+
+export const ToggleGroupRoot: React.ForwardRefExoticComponent<
+  React.ComponentProps<typeof ToggleGroup.Root> & RootType
+> = React.forwardRef(
+  ({ disableDeselect = false, onValueChange, defaultValue, ...rest }, ref) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue)
+    const handleValueChange = (newValue) => {
+      if (disableDeselect && (newValue === '' || newValue.length === 0)) return
+      setInternalValue(newValue)
+      onValueChange?.(newValue)
+    }
+
+    return (
+      <ToggleGroup.Root
+        ref={ref}
+        onValueChange={handleValueChange}
+        value={internalValue}
+        {...rest}
+      />
+    )
+  }
+)

--- a/lib/src/utilities/radix-overrides/toggle-group/index.ts
+++ b/lib/src/utilities/radix-overrides/toggle-group/index.ts
@@ -1,0 +1,5 @@
+import { ToggleGroupRoot } from './ToggleGroupRoot'
+
+export const ToggleGroup = {
+  Root: ToggleGroupRoot
+}


### PR DESCRIPTION
@AtanasKovachev pointed out that fields using `ToggleGroup` component were deselecting values on double click.
After @mzeenkala23 and @Marcdup1 investigated they pointed out that the radix component itself has this functionality.
This makes sense in the context radix is using this component but not the context we sometimes are.

This PR adds an override to radix's base root component to `disableDeselect` (open to prop renaming suggestions) which doesn't let the component become empty after a value has been originally selected.

It then uses the root override in all the places where we have toggle groups so the functionality is shared across them.

## Videos
**before**

https://github.com/Atom-Learning/components/assets/6905473/ce2da80c-65a5-4f21-aa7c-91489d7bbbbe

**after**
_(when cursor is over toggle item for a while, I'm clicking :p )_

https://github.com/Atom-Learning/components/assets/6905473/c30ef8c3-fcb0-46d6-8f0e-3a5439fe426d

https://github.com/Atom-Learning/components/assets/6905473/491a95b0-1da4-4d80-807d-6c2a09b893be



