### PR TITLE
B2B-651 - Pagination - Replace dot indication style with solid bg

### DIFF
--- a/documentation/content/components.pagination.md
+++ b/documentation/content/components.pagination.md
@@ -108,7 +108,10 @@ tabs:
       ## API Reference
 
 
-      <ComponentProps component="Pagination" /> <ComponentProps component="PaginationProvider" />
+      <ComponentProps component="Pagination" />
+
+      <ComponentProps component="PaginationProvider" />
+
   - title: Visual
     content: >-
       ## Structure

--- a/documentation/content/components.pagination.md
+++ b/documentation/content/components.pagination.md
@@ -22,7 +22,7 @@ tabs:
       It can also take in a `selectedPage` prop which allows the parent component to pass in a numerical value indicating which page the parent component is currently showing, if the `selectedPage` prop is not passed in, the `Pagination` component as an internal state to keep track of the current page, by default this state is set to the first page.
 
 
-      The `Pagination` component also takes in a `disabledPages` props which is an array of numbers, which indicate which pagination items should be disabled, and it also takes in a `indicatedPages` prop which is also an array of numbers to indicate which pagination item should be display a dot under the page number, which represents the page as completed.
+      The `Pagination` component also takes in a `disabledPages` props which is an array of numbers, which indicate which pagination items should be disabled, and it also takes in a `indicatedPages` prop which is also an array of numbers to indicate which pagination item should be highlighted in the accent colour, which represents the page as completed.
 
 
       # Examples
@@ -44,31 +44,69 @@ tabs:
       <Pagination
         pagesCount={6}
         visibleElementsCount={8}
-        colorScheme={{ base: 'grey2', accent: 'blue1'}}
+        colorScheme={{ base: 'grey1', accent: 'primary1'}}
       /> `} language={"tsx"} />
 
 
       Above is an example of passing `visibleElementsCount` prop and setting it to 8. The user will see two navigation buttons, an action button to trigger the popover and five page numbers.
 
-
       <CodeBlock live={true} preview={true} code={`
 
       <Pagination
-        colorScheme={{ base: 'grey2', accent: 'blue1'}}
+        colorScheme={{ base: 'grey1', accent: 'primary1'}}
         disabledPages={[1,2]}
         indicatedPages={[4,5]}
+        visibleElementsCount={8}
         pagesCount={5}
         labels={{ popoverTiggerLabel: 'popover label', nextPageButtonLabel: 'next page label', previousPageButtonLabel: 'previous page label' }}
       />`} language={"tsx"} />
 
 
-      Above is an example of when we use the `disabledPages` prop allowing us to render the pagination items for page 1 and 2 as disabled, and using the `indicatedPages` prop which renders a dot under the page numbers 4 and 5,  and adding custom labels to the next/previous button and popover trigger.
+      Above is an example of when we use the `disabledPages` prop allowing us to render the pagination items for page 1 and 2 as disabled, and using the `indicatedPages` prop which colours the background of page numbers 4 and 5,  and adding custom labels to the next/previous button and popover trigger.
+
+
+      **Color Scheme** 
+
+      <CodeBlock live={true} preview={true} code={`
+
+      <Pagination
+        pagesCount={6}
+        visibleElementsCount={8}
+        indicatedPages={[3]}
+        colorScheme={{ base: 'primary2', accent: 'purple1'}}
+      /> `} language={"tsx"} />
+
+
+      Above is an example of using the colorScheme property. Base is the unselected & unindicated state, and accent is used for the "highlighted" selection and indicated states. The default is `base: 'grey1' accent: 'primary1'`
+
+
+      The number (eg. primary1, primary2) refers to the darkness of the palette. A scheme with 1 has a default background of white, and hover of pale colour. A scheme with 2 has a default shifted one level darker, so starts with that pale colour rather than white.
+
+
+      **Custom popover trigger**
+
+
+      The pagination can also be displayed just using the popover, no number list, with a custom trigger.
+
+      <CodeBlock live={true} preview={true} code={`
+
+      <Pagination
+        pagesCount={24}
+        selectedPage={1}
+        indicatedPages={[4,5]}
+      >
+        <Pagination.Popover>
+          <Button>
+            <Text>Question 1/24</Text>
+          </Button>
+        </Pagination.Popover>
+      </Pagination> `} language={"tsx"} />
 
 
       ## API Reference
 
 
-      <ComponentProps component="Pagination" />
+      <ComponentProps component="Pagination" /> <ComponentProps component="PaginationProvider" />
   - title: Visual
     content: >-
       ## Structure

--- a/documentation/content/components.pagination.md
+++ b/documentation/content/components.pagination.md
@@ -27,7 +27,9 @@ tabs:
 
       # Examples
 
+
       #### Number of visible elements
+
 
       <CodeBlock live={true} preview={true} code={`
 
@@ -39,18 +41,20 @@ tabs:
 
       Above is an example of passing in a number to the `pagesCount` prop that will render 6 pagination items, the `visibleElementsCount` prop is set to 6 by default. So the user will see two navigation buttons, an action button to trigger the popover and 3 page numbers.
 
-      <CodeBlock live={true} preview={true} code={`
-
-      <Pagination
+      <CodeBlock live={true} preview={true} code={`<Pagination
         pagesCount={6}
         visibleElementsCount={8}
         colorScheme={{ base: 'grey1', accent: 'primary1'}}
-      /> `} language={"tsx"} />
+      />`} language={"tsx"} />
 
 
       Above is an example of passing `visibleElementsCount` prop and setting it to 8. The user will see two navigation buttons, an action button to trigger the popover and five page numbers.
 
+
+
+
       #### Disabled and indicated pages
+
 
       <CodeBlock live={true} preview={true} code={`
 
@@ -67,7 +71,10 @@ tabs:
       Above is an example of when we use the `disabledPages` prop allowing us to render the pagination items for page 1 and 2 as disabled, and using the `indicatedPages` prop which colours the background of page numbers 4 and 5,  and adding custom labels to the next/previous button and popover trigger.
 
 
+
+
       #### Color Scheme
+
 
       <CodeBlock live={true} preview={true} code={`
 
@@ -85,24 +92,27 @@ tabs:
       The number (eg. primary1, primary2) refers to the darkness of the palette. A scheme with 1 has a default background of white, and hover of pale colour. A scheme with 2 has a default shifted one level darker, so starts with that pale colour rather than white.
 
 
+
+
       #### Custom popover trigger
 
 
       The pagination can also be displayed just using the popover, no number list, with a custom trigger.
 
-      <CodeBlock live={true} preview={true} code={`
 
-      <Pagination
-        pagesCount={24}
-        selectedPage={1}
-        indicatedPages={[4,5]}
-      >
-        <Pagination.Popover>
-          <Button>
-            <Text>Question 1/24</Text>
-          </Button>
-        </Pagination.Popover>
-      </Pagination> `} language={"tsx"} />
+
+      <CodeBlock live={true} preview={true} code={`<Pagination
+              pagesCount={24}
+              selectedPage={1}
+              indicatedPages={[4,5]}
+            >
+              <Pagination.Popover>
+                <Button>
+                  <Text>Question 1/24</Text>
+                </Button>
+              </Pagination.Popover>
+            </Pagination>`} language={"undefined"} />
+
 
 
       ## API Reference
@@ -110,8 +120,8 @@ tabs:
 
       <ComponentProps component="Pagination" />
 
-      <ComponentProps component="PaginationProvider" />
 
+      <ComponentProps component="PaginationProvider" />
   - title: Visual
     content: >-
       ## Structure

--- a/documentation/content/components.pagination.md
+++ b/documentation/content/components.pagination.md
@@ -27,6 +27,7 @@ tabs:
 
       # Examples
 
+      #### Number of visible elements
 
       <CodeBlock live={true} preview={true} code={`
 
@@ -38,7 +39,6 @@ tabs:
 
       Above is an example of passing in a number to the `pagesCount` prop that will render 6 pagination items, the `visibleElementsCount` prop is set to 6 by default. So the user will see two navigation buttons, an action button to trigger the popover and 3 page numbers.
 
-
       <CodeBlock live={true} preview={true} code={`
 
       <Pagination
@@ -49,6 +49,8 @@ tabs:
 
 
       Above is an example of passing `visibleElementsCount` prop and setting it to 8. The user will see two navigation buttons, an action button to trigger the popover and five page numbers.
+
+      #### Disabled and indicated pages
 
       <CodeBlock live={true} preview={true} code={`
 
@@ -65,7 +67,7 @@ tabs:
       Above is an example of when we use the `disabledPages` prop allowing us to render the pagination items for page 1 and 2 as disabled, and using the `indicatedPages` prop which colours the background of page numbers 4 and 5,  and adding custom labels to the next/previous button and popover trigger.
 
 
-      **Color Scheme** 
+      #### Color Scheme
 
       <CodeBlock live={true} preview={true} code={`
 
@@ -83,7 +85,7 @@ tabs:
       The number (eg. primary1, primary2) refers to the darkness of the palette. A scheme with 1 has a default background of white, and hover of pale colour. A scheme with 2 has a default shifted one level darker, so starts with that pale colour rather than white.
 
 
-      **Custom popover trigger**
+      #### Custom popover trigger
 
 
       The pagination can also be displayed just using the popover, no number list, with a custom trigger.

--- a/lib/src/components/pagination/Pagination.tsx
+++ b/lib/src/components/pagination/Pagination.tsx
@@ -37,11 +37,9 @@ const PaginationComponent = ({
   return (
     <PaginationProvider {...paginationProviderProps}>
       <ColorScheme base="grey1" accent="primary1" {...colorScheme} asChild>
-        {children || (
-          <Flex gap={1} {...rest}>
-            <PaginationItems />
-          </Flex>
-        )}
+        <Flex gap={1} {...rest}>
+          {children || <PaginationItems />}
+        </Flex>
       </ColorScheme>
     </PaginationProvider>
   )

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -19,17 +19,17 @@ const StyledButton = styled('button', {
   flexDirection: 'column',
   p: '0',
   fontWeight: 400,
-  color: '$grey800',
+  color: '$textSubtle',
   bg: '$base1',
   position: 'relative',
 
   '&:not(:disabled)': {
     '&:hover': {
-      color: '$grey900',
+      color: '$textRegular',
       bg: '$base2'
     },
     '&:active': {
-      color: '$grey1000',
+      color: '$textBold',
       bg: '$base3'
     },
     '&:focus-visible': {

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -20,16 +20,16 @@ const StyledButton = styled('button', {
   p: '0',
   fontWeight: 400,
   color: '$grey800',
-  bg: '$white',
+  bg: '$base1',
   position: 'relative',
 
   '&:not(:disabled)': {
     '&:hover': {
-      color: '$grey900',
-      bg: '$grey100'
+      color: '$accent10',
+      bg: '$base2'
     },
     '&:active': {
-      bg: '$grey200',
+      bg: '$base3',
       color: '$grey1000'
     },
     '&:focus-visible': {
@@ -49,17 +49,17 @@ const StyledButton = styled('button', {
     },
     selected: {
       true: {
-        border: '1px solid $primary800',
-        color: '$primary800',
+        border: '1px solid $accent9',
+        color: '$accent9',
         fontWeight: 600,
         '&:not(:disabled)': {
           '&:hover': {
-            borderColor: '$primary900',
-            color: '$primary900'
+            borderColor: '$accent10',
+            color: '$accent10'
           },
           '&:active': {
-            borderColor: '$primary1000',
-            fontColor: '$primary1000'
+            borderColor: '$accent11',
+            fontColor: '$accent11'
           }
         }
       }
@@ -67,15 +67,15 @@ const StyledButton = styled('button', {
     indicated: {
       true: {
         fontWeight: 600,
-        color: '$white',
+        color: 'white',
         bg: '$primary800',
         '&:not(:disabled)': {
           '&:hover': {
-            color: '$white',
+            color: 'white',
             bg: '$primary900'
           },
           '&:active': {
-            color: '$white',
+            color: 'white',
             bg: '$primary1000'
           }
         }
@@ -89,7 +89,7 @@ const StyledButton = styled('button', {
       indicated: true,
       css: {
         fontWeight: 600,
-        color: '$white',
+        color: 'white',
         bg: '$primary800',
         '&:before': {
           content: '',
@@ -103,11 +103,11 @@ const StyledButton = styled('button', {
 
         '&:not(:disabled)': {
           '&:hover': {
-            color: '$white',
+            color: 'white',
             bg: '$primary900'
           },
           '&:active': {
-            color: '$white',
+            color: 'white',
             bg: '$primary1000'
           }
         }

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -20,7 +20,7 @@ const StyledButton = styled('button', {
   p: '0',
   fontWeight: 400,
   color: '$grey800',
-  bg: 'white',
+  bg: '$white',
   position: 'relative',
 
   '&:not(:disabled)': {
@@ -67,15 +67,15 @@ const StyledButton = styled('button', {
     indicated: {
       true: {
         fontWeight: 600,
-        color: 'white',
+        color: '$white',
         bg: '$primary800',
         '&:not(:disabled)': {
           '&:hover': {
-            color: 'white',
+            color: '$white',
             bg: '$primary900'
           },
           '&:active': {
-            color: 'white',
+            color: '$white',
             bg: '$primary1000'
           }
         }
@@ -89,7 +89,7 @@ const StyledButton = styled('button', {
       indicated: true,
       css: {
         fontWeight: 600,
-        color: 'white',
+        color: '$white',
         bg: '$primary800',
         '&:before': {
           content: '',
@@ -103,11 +103,11 @@ const StyledButton = styled('button', {
 
         '&:not(:disabled)': {
           '&:hover': {
-            color: 'white',
+            color: '$white',
             bg: '$primary900'
           },
           '&:active': {
-            color: 'white',
+            color: '$white',
             bg: '$primary1000'
           }
         }

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -19,18 +19,18 @@ const StyledButton = styled('button', {
   flexDirection: 'column',
   p: '0',
   fontWeight: 400,
-  color: '$base9',
+  color: '$grey800',
   bg: '$base1',
   position: 'relative',
 
   '&:not(:disabled)': {
     '&:hover': {
-      color: '$base10',
+      color: '$grey900',
       bg: '$base2'
     },
     '&:active': {
-      bg: '$base3',
-      color: '$base11'
+      color: '$grey1000',
+      bg: '$base3'
     },
     '&:focus-visible': {
       ...focusVisibleStyleBlock()
@@ -91,9 +91,10 @@ const StyledButton = styled('button', {
         fontWeight: 600,
         color: 'white',
         bg: '$accent9',
-        boxShadow:
-          'white 0px 0px 0px 1px, var(--colors-accent9) 0px 0px 0px 2px',
-
+        boxShadow: '$colors$accent9 0px 0px 0px 1px',
+        '&:not(:focus-visible)': {
+          borderColor: 'white !important'
+        },
         '&:not(:disabled)': {
           '&:hover': {
             color: 'white',

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -96,7 +96,11 @@ const StyledButton = styled('button', {
   }
 })
 
-export const PaginationPage = ({ pageNumber, css }: PaginationPageProps) => {
+export const PaginationPage = ({
+  pageNumber,
+  css,
+  onClick
+}: PaginationPageProps) => {
   const { currentPage, goToPage, indicatedPages, disabledPages, onItemHover } =
     usePagination()
 
@@ -110,11 +114,16 @@ export const PaginationPage = ({ pageNumber, css }: PaginationPageProps) => {
     onItemHover?.(pageNumber)
   }
 
+  const handleOnClick = (pageNumber) => {
+    onClick?.()
+    goToPage(pageNumber)
+  }
+
   return (
     <StyledButton
       selected={isSelected}
       size="md"
-      onClick={() => goToPage(pageNumber)}
+      onClick={() => handleOnClick(pageNumber)}
       css={css}
       indicated={isIndicated}
       disabled={isDisabled}

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -19,18 +19,18 @@ const StyledButton = styled('button', {
   flexDirection: 'column',
   p: '0',
   fontWeight: 400,
-  color: '$grey800',
+  color: '$base9',
   bg: '$base1',
   position: 'relative',
 
   '&:not(:disabled)': {
     '&:hover': {
-      color: '$accent10',
+      color: '$base10',
       bg: '$base2'
     },
     '&:active': {
       bg: '$base3',
-      color: '$grey1000'
+      color: '$base11'
     },
     '&:focus-visible': {
       ...focusVisibleStyleBlock()
@@ -68,15 +68,15 @@ const StyledButton = styled('button', {
       true: {
         fontWeight: 600,
         color: 'white',
-        bg: '$primary800',
+        bg: '$accent9',
         '&:not(:disabled)': {
           '&:hover': {
             color: 'white',
-            bg: '$primary900'
+            bg: '$accent10'
           },
           '&:active': {
             color: 'white',
-            bg: '$primary1000'
+            bg: '$accent11'
           }
         }
       }
@@ -90,25 +90,18 @@ const StyledButton = styled('button', {
       css: {
         fontWeight: 600,
         color: 'white',
-        bg: '$primary800',
-        '&:before': {
-          content: '',
-          position: 'absolute',
-          zIndex: '-1',
-          inset: '-3px',
-          border: '1px solid $primary800',
-          borderRadius: '$0',
-          bg: 'transparent'
-        },
+        bg: '$accent9',
+        boxShadow:
+          'white 0px 0px 0px 1px, var(--colors-accent9) 0px 0px 0px 2px',
 
         '&:not(:disabled)': {
           '&:hover': {
             color: 'white',
-            bg: '$primary900'
+            bg: '$accent10'
           },
           '&:active': {
             color: 'white',
-            bg: '$primary1000'
+            bg: '$accent11'
           }
         }
       }

--- a/lib/src/components/pagination/PaginationPage.tsx
+++ b/lib/src/components/pagination/PaginationPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { focusVisibleStyleBlock } from '~/utilities'
+import { disabledStyle, focusVisibleStyleBlock } from '~/utilities'
 
 import { styled } from '../../stitches'
 import type { PaginationPageProps } from './types'
@@ -20,24 +20,25 @@ const StyledButton = styled('button', {
   p: '0',
   fontWeight: 400,
   color: '$grey800',
-  bg: '$base1',
+  bg: 'white',
   position: 'relative',
+
   '&:not(:disabled)': {
     '&:hover': {
-      color: '$accent10',
-      bg: '$base2'
+      color: '$grey900',
+      bg: '$grey100'
     },
     '&:active': {
-      bg: '$base3',
+      bg: '$grey200',
       color: '$grey1000'
     },
     '&:focus-visible': {
       ...focusVisibleStyleBlock()
     }
   },
-  '&:disabled': {
-    opacity: '0.3',
-    cursor: 'not-allowed'
+  '&[disabled]': {
+    ...disabledStyle,
+    pointerEvents: 'none'
   },
   variants: {
     size: {
@@ -48,17 +49,17 @@ const StyledButton = styled('button', {
     },
     selected: {
       true: {
-        border: '1px solid $accent9',
-        color: '$accent9',
+        border: '1px solid $primary800',
+        color: '$primary800',
         fontWeight: 600,
         '&:not(:disabled)': {
           '&:hover': {
-            borderColor: '$accent10',
-            color: '$accent10'
+            borderColor: '$primary900',
+            color: '$primary900'
           },
           '&:active': {
-            borderColor: '$accent11',
-            fontColor: '$accent11'
+            borderColor: '$primary1000',
+            fontColor: '$primary1000'
           }
         }
       }
@@ -66,34 +67,53 @@ const StyledButton = styled('button', {
     indicated: {
       true: {
         fontWeight: 600,
-        color: '$accent9',
-        '&:after': {
-          content: '',
-          position: 'absolute',
-          bottom: '$1',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          borderRadius: '$round',
-          size: '4px',
-          bg: '$accent9'
-        },
+        color: 'white',
+        bg: '$primary800',
         '&:not(:disabled)': {
           '&:hover': {
-            color: '$accent10',
-            '&:after': {
-              bg: '$accent10'
-            }
+            color: 'white',
+            bg: '$primary900'
           },
           '&:active': {
-            color: '$accent11',
-            '&:after': {
-              bg: '$accent11'
-            }
+            color: 'white',
+            bg: '$primary1000'
           }
         }
       }
     }
-  }
+  },
+
+  compoundVariants: [
+    {
+      selected: true,
+      indicated: true,
+      css: {
+        fontWeight: 600,
+        color: 'white',
+        bg: '$primary800',
+        '&:before': {
+          content: '',
+          position: 'absolute',
+          zIndex: '-1',
+          inset: '-3px',
+          border: '1px solid $primary800',
+          borderRadius: '$0',
+          bg: 'transparent'
+        },
+
+        '&:not(:disabled)': {
+          '&:hover': {
+            color: 'white',
+            bg: '$primary900'
+          },
+          '&:active': {
+            color: 'white',
+            bg: '$primary1000'
+          }
+        }
+      }
+    }
+  ]
 })
 
 export const PaginationPage = ({

--- a/lib/src/components/pagination/PaginationPopover.tsx
+++ b/lib/src/components/pagination/PaginationPopover.tsx
@@ -37,7 +37,7 @@ export const PaginationPopover = ({
             p: '$4',
             display: 'flex',
             flexWrap: 'wrap',
-            gap: 1,
+            gap: '$1',
             justifyContent: 'center'
           }}
         >
@@ -46,7 +46,6 @@ export const PaginationPopover = ({
               <PaginationPage
                 key={pageNumber}
                 pageNumber={pageNumber}
-                css={{ bg: '$white' }}
                 onClick={() => setIsOpen(false)}
               />
             )

--- a/lib/src/components/pagination/PaginationPopover.tsx
+++ b/lib/src/components/pagination/PaginationPopover.tsx
@@ -14,8 +14,10 @@ export const PaginationPopover = ({
     (_, index) => index + 1
   )
 
+  const [isOpen, setIsOpen] = React.useState<boolean>(false)
+
   return (
-    <Popover>
+    <Popover open={isOpen} onOpenChange={setIsOpen} defaultOpen={false}>
       <Popover.Trigger asChild>
         {children || (
           <ActionIcon
@@ -45,6 +47,7 @@ export const PaginationPopover = ({
                 key={pageNumber}
                 pageNumber={pageNumber}
                 css={{ bg: '$white' }}
+                onClick={() => setIsOpen(false)}
               />
             )
           })}

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-fmWFdu {
+  .c-dnHkjA {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -346,30 +346,31 @@ exports[`Pagination component renders 1`] = `
     padding: 0;
     font-weight: 400;
     color: var(--colors-grey800);
-    background: var(--colors-base1);
+    background: white;
     position: relative;
   }
 
-  .c-fmWFdu:not(:disabled):hover {
-    color: var(--colors-accent10);
-    background: var(--colors-base2);
+  .c-dnHkjA:not(:disabled):hover {
+    color: var(--colors-grey900);
+    background: var(--colors-grey100);
   }
 
-  .c-fmWFdu:not(:disabled):active {
-    background: var(--colors-base3);
+  .c-dnHkjA:not(:disabled):active {
+    background: var(--colors-grey200);
     color: var(--colors-grey1000);
   }
 
-  .c-fmWFdu:not(:disabled):focus-visible {
+  .c-dnHkjA:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-fmWFdu:disabled {
+  .c-dnHkjA[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
+    pointer-events: none;
   }
 
   .c-iKnjyA {
@@ -440,25 +441,25 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-fmWFdu-cVoMNQ-size-md {
+  .c-dnHkjA-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-fmWFdu-bxzneo-selected-true {
-    border: 1px solid var(--colors-accent9);
-    color: var(--colors-accent9);
+  .c-dnHkjA-eqDSSE-selected-true {
+    border: 1px solid var(--colors-primary800);
+    color: var(--colors-primary800);
     font-weight: 600;
   }
 
-  .c-fmWFdu-bxzneo-selected-true:not(:disabled):hover {
-    border-color: var(--colors-accent10);
-    color: var(--colors-accent10);
+  .c-dnHkjA-eqDSSE-selected-true:not(:disabled):hover {
+    border-color: var(--colors-primary900);
+    color: var(--colors-primary900);
   }
 
-  .c-fmWFdu-bxzneo-selected-true:not(:disabled):active {
-    border-color: var(--colors-accent11);
-    font-color: var(--accent11);
+  .c-dnHkjA-eqDSSE-selected-true:not(:disabled):active {
+    border-color: var(--colors-primary1000);
+    font-color: var(--primary1000);
   }
 
   .c-iKnjyA-kUaMfZ-size-md {
@@ -506,14 +507,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md c-fmWFdu-bxzneo-selected-true"
+      class="c-dnHkjA c-dnHkjA-cVoMNQ-size-md c-dnHkjA-eqDSSE-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md"
+      class="c-dnHkjA c-dnHkjA-cVoMNQ-size-md"
     >
       2
     </button>
@@ -553,7 +554,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-fmWFdu c-fmWFdu-cVoMNQ-size-md"
+      class="c-dnHkjA c-dnHkjA-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-bGrWdo {
+  .c-guJvNO {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -346,28 +346,28 @@ exports[`Pagination component renders 1`] = `
     padding: 0;
     font-weight: 400;
     color: var(--colors-grey800);
-    background: var(--colors-white);
+    background: var(--colors-base1);
     position: relative;
   }
 
-  .c-bGrWdo:not(:disabled):hover {
-    color: var(--colors-grey900);
-    background: var(--colors-grey100);
+  .c-guJvNO:not(:disabled):hover {
+    color: var(--colors-accent10);
+    background: var(--colors-base2);
   }
 
-  .c-bGrWdo:not(:disabled):active {
-    background: var(--colors-grey200);
+  .c-guJvNO:not(:disabled):active {
+    background: var(--colors-base3);
     color: var(--colors-grey1000);
   }
 
-  .c-bGrWdo:not(:disabled):focus-visible {
+  .c-guJvNO:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-bGrWdo[disabled] {
+  .c-guJvNO[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
     pointer-events: none;
@@ -441,25 +441,25 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-bGrWdo-cVoMNQ-size-md {
+  .c-guJvNO-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-bGrWdo-eqDSSE-selected-true {
-    border: 1px solid var(--colors-primary800);
-    color: var(--colors-primary800);
+  .c-guJvNO-bxzneo-selected-true {
+    border: 1px solid var(--colors-accent9);
+    color: var(--colors-accent9);
     font-weight: 600;
   }
 
-  .c-bGrWdo-eqDSSE-selected-true:not(:disabled):hover {
-    border-color: var(--colors-primary900);
-    color: var(--colors-primary900);
+  .c-guJvNO-bxzneo-selected-true:not(:disabled):hover {
+    border-color: var(--colors-accent10);
+    color: var(--colors-accent10);
   }
 
-  .c-bGrWdo-eqDSSE-selected-true:not(:disabled):active {
-    border-color: var(--colors-primary1000);
-    font-color: var(--primary1000);
+  .c-guJvNO-bxzneo-selected-true:not(:disabled):active {
+    border-color: var(--colors-accent11);
+    font-color: var(--accent11);
   }
 
   .c-iKnjyA-kUaMfZ-size-md {
@@ -507,14 +507,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-bGrWdo c-bGrWdo-cVoMNQ-size-md c-bGrWdo-eqDSSE-selected-true"
+      class="c-guJvNO c-guJvNO-cVoMNQ-size-md c-guJvNO-bxzneo-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-bGrWdo c-bGrWdo-cVoMNQ-size-md"
+      class="c-guJvNO c-guJvNO-cVoMNQ-size-md"
     >
       2
     </button>
@@ -554,7 +554,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-bGrWdo c-bGrWdo-cVoMNQ-size-md"
+      class="c-guJvNO c-guJvNO-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-iihvFZ {
+  .c-dfRlUJ {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -345,29 +345,29 @@ exports[`Pagination component renders 1`] = `
     flex-direction: column;
     padding: 0;
     font-weight: 400;
-    color: var(--colors-base9);
+    color: var(--colors-grey800);
     background: var(--colors-base1);
     position: relative;
   }
 
-  .c-iihvFZ:not(:disabled):hover {
-    color: var(--colors-base10);
+  .c-dfRlUJ:not(:disabled):hover {
+    color: var(--colors-grey900);
     background: var(--colors-base2);
   }
 
-  .c-iihvFZ:not(:disabled):active {
+  .c-dfRlUJ:not(:disabled):active {
+    color: var(--colors-grey1000);
     background: var(--colors-base3);
-    color: var(--colors-base11);
   }
 
-  .c-iihvFZ:not(:disabled):focus-visible {
+  .c-dfRlUJ:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-iihvFZ[disabled] {
+  .c-dfRlUJ[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
     pointer-events: none;
@@ -441,23 +441,23 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-iihvFZ-cVoMNQ-size-md {
+  .c-dfRlUJ-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-iihvFZ-bxzneo-selected-true {
+  .c-dfRlUJ-bxzneo-selected-true {
     border: 1px solid var(--colors-accent9);
     color: var(--colors-accent9);
     font-weight: 600;
   }
 
-  .c-iihvFZ-bxzneo-selected-true:not(:disabled):hover {
+  .c-dfRlUJ-bxzneo-selected-true:not(:disabled):hover {
     border-color: var(--colors-accent10);
     color: var(--colors-accent10);
   }
 
-  .c-iihvFZ-bxzneo-selected-true:not(:disabled):active {
+  .c-dfRlUJ-bxzneo-selected-true:not(:disabled):active {
     border-color: var(--colors-accent11);
     font-color: var(--accent11);
   }
@@ -507,14 +507,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-iihvFZ c-iihvFZ-cVoMNQ-size-md c-iihvFZ-bxzneo-selected-true"
+      class="c-dfRlUJ c-dfRlUJ-cVoMNQ-size-md c-dfRlUJ-bxzneo-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-iihvFZ c-iihvFZ-cVoMNQ-size-md"
+      class="c-dfRlUJ c-dfRlUJ-cVoMNQ-size-md"
     >
       2
     </button>
@@ -554,7 +554,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-iihvFZ c-iihvFZ-cVoMNQ-size-md"
+      class="c-dfRlUJ c-dfRlUJ-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-dnHkjA {
+  .c-bGrWdo {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -346,28 +346,28 @@ exports[`Pagination component renders 1`] = `
     padding: 0;
     font-weight: 400;
     color: var(--colors-grey800);
-    background: white;
+    background: var(--colors-white);
     position: relative;
   }
 
-  .c-dnHkjA:not(:disabled):hover {
+  .c-bGrWdo:not(:disabled):hover {
     color: var(--colors-grey900);
     background: var(--colors-grey100);
   }
 
-  .c-dnHkjA:not(:disabled):active {
+  .c-bGrWdo:not(:disabled):active {
     background: var(--colors-grey200);
     color: var(--colors-grey1000);
   }
 
-  .c-dnHkjA:not(:disabled):focus-visible {
+  .c-bGrWdo:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-dnHkjA[disabled] {
+  .c-bGrWdo[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
     pointer-events: none;
@@ -441,23 +441,23 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-dnHkjA-cVoMNQ-size-md {
+  .c-bGrWdo-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-dnHkjA-eqDSSE-selected-true {
+  .c-bGrWdo-eqDSSE-selected-true {
     border: 1px solid var(--colors-primary800);
     color: var(--colors-primary800);
     font-weight: 600;
   }
 
-  .c-dnHkjA-eqDSSE-selected-true:not(:disabled):hover {
+  .c-bGrWdo-eqDSSE-selected-true:not(:disabled):hover {
     border-color: var(--colors-primary900);
     color: var(--colors-primary900);
   }
 
-  .c-dnHkjA-eqDSSE-selected-true:not(:disabled):active {
+  .c-bGrWdo-eqDSSE-selected-true:not(:disabled):active {
     border-color: var(--colors-primary1000);
     font-color: var(--primary1000);
   }
@@ -507,14 +507,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-dnHkjA c-dnHkjA-cVoMNQ-size-md c-dnHkjA-eqDSSE-selected-true"
+      class="c-bGrWdo c-bGrWdo-cVoMNQ-size-md c-bGrWdo-eqDSSE-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-dnHkjA c-dnHkjA-cVoMNQ-size-md"
+      class="c-bGrWdo c-bGrWdo-cVoMNQ-size-md"
     >
       2
     </button>
@@ -554,7 +554,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-dnHkjA c-dnHkjA-cVoMNQ-size-md"
+      class="c-bGrWdo c-bGrWdo-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-dfRlUJ {
+  .c-bPBhYb {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -345,29 +345,29 @@ exports[`Pagination component renders 1`] = `
     flex-direction: column;
     padding: 0;
     font-weight: 400;
-    color: var(--colors-grey800);
+    color: var(--colors-textSubtle);
     background: var(--colors-base1);
     position: relative;
   }
 
-  .c-dfRlUJ:not(:disabled):hover {
-    color: var(--colors-grey900);
+  .c-bPBhYb:not(:disabled):hover {
+    color: var(--colors-textRegular);
     background: var(--colors-base2);
   }
 
-  .c-dfRlUJ:not(:disabled):active {
-    color: var(--colors-grey1000);
+  .c-bPBhYb:not(:disabled):active {
+    color: var(--colors-textBold);
     background: var(--colors-base3);
   }
 
-  .c-dfRlUJ:not(:disabled):focus-visible {
+  .c-bPBhYb:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-dfRlUJ[disabled] {
+  .c-bPBhYb[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
     pointer-events: none;
@@ -441,23 +441,23 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-dfRlUJ-cVoMNQ-size-md {
+  .c-bPBhYb-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-dfRlUJ-bxzneo-selected-true {
+  .c-bPBhYb-bxzneo-selected-true {
     border: 1px solid var(--colors-accent9);
     color: var(--colors-accent9);
     font-weight: 600;
   }
 
-  .c-dfRlUJ-bxzneo-selected-true:not(:disabled):hover {
+  .c-bPBhYb-bxzneo-selected-true:not(:disabled):hover {
     border-color: var(--colors-accent10);
     color: var(--colors-accent10);
   }
 
-  .c-dfRlUJ-bxzneo-selected-true:not(:disabled):active {
+  .c-bPBhYb-bxzneo-selected-true:not(:disabled):active {
     border-color: var(--colors-accent11);
     font-color: var(--accent11);
   }
@@ -507,14 +507,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-dfRlUJ c-dfRlUJ-cVoMNQ-size-md c-dfRlUJ-bxzneo-selected-true"
+      class="c-bPBhYb c-bPBhYb-cVoMNQ-size-md c-bPBhYb-bxzneo-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-dfRlUJ c-dfRlUJ-cVoMNQ-size-md"
+      class="c-bPBhYb c-bPBhYb-cVoMNQ-size-md"
     >
       2
     </button>
@@ -554,7 +554,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-dfRlUJ c-dfRlUJ-cVoMNQ-size-md"
+      class="c-bPBhYb c-bPBhYb-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`Pagination component renders 1`] = `
     opacity: 0.3;
   }
 
-  .c-guJvNO {
+  .c-iihvFZ {
     align-items: center;
     border: 1px solid transparent;
     border-radius: var(--radii-0);
@@ -345,29 +345,29 @@ exports[`Pagination component renders 1`] = `
     flex-direction: column;
     padding: 0;
     font-weight: 400;
-    color: var(--colors-grey800);
+    color: var(--colors-base9);
     background: var(--colors-base1);
     position: relative;
   }
 
-  .c-guJvNO:not(:disabled):hover {
-    color: var(--colors-accent10);
+  .c-iihvFZ:not(:disabled):hover {
+    color: var(--colors-base10);
     background: var(--colors-base2);
   }
 
-  .c-guJvNO:not(:disabled):active {
+  .c-iihvFZ:not(:disabled):active {
     background: var(--colors-base3);
-    color: var(--colors-grey1000);
+    color: var(--colors-base11);
   }
 
-  .c-guJvNO:not(:disabled):focus-visible {
+  .c-iihvFZ:not(:disabled):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-guJvNO[disabled] {
+  .c-iihvFZ[disabled] {
     opacity: 0.3;
     cursor: not-allowed;
     pointer-events: none;
@@ -441,23 +441,23 @@ exports[`Pagination component renders 1`] = `
     stroke-width: 1.75;
   }
 
-  .c-guJvNO-cVoMNQ-size-md {
+  .c-iihvFZ-cVoMNQ-size-md {
     width: var(--sizes-4);
     height: var(--sizes-4);
   }
 
-  .c-guJvNO-bxzneo-selected-true {
+  .c-iihvFZ-bxzneo-selected-true {
     border: 1px solid var(--colors-accent9);
     color: var(--colors-accent9);
     font-weight: 600;
   }
 
-  .c-guJvNO-bxzneo-selected-true:not(:disabled):hover {
+  .c-iihvFZ-bxzneo-selected-true:not(:disabled):hover {
     border-color: var(--colors-accent10);
     color: var(--colors-accent10);
   }
 
-  .c-guJvNO-bxzneo-selected-true:not(:disabled):active {
+  .c-iihvFZ-bxzneo-selected-true:not(:disabled):active {
     border-color: var(--colors-accent11);
     font-color: var(--accent11);
   }
@@ -507,14 +507,14 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="page"
       aria-disabled="false"
-      class="c-guJvNO c-guJvNO-cVoMNQ-size-md c-guJvNO-bxzneo-selected-true"
+      class="c-iihvFZ c-iihvFZ-cVoMNQ-size-md c-iihvFZ-bxzneo-selected-true"
     >
       1
     </button>
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-guJvNO c-guJvNO-cVoMNQ-size-md"
+      class="c-iihvFZ c-iihvFZ-cVoMNQ-size-md"
     >
       2
     </button>
@@ -554,7 +554,7 @@ exports[`Pagination component renders 1`] = `
     <button
       aria-current="false"
       aria-disabled="false"
-      class="c-guJvNO c-guJvNO-cVoMNQ-size-md"
+      class="c-iihvFZ c-iihvFZ-cVoMNQ-size-md"
     >
       6
     </button>

--- a/lib/src/components/pagination/types.ts
+++ b/lib/src/components/pagination/types.ts
@@ -33,6 +33,7 @@ export type TVisibleElementsCount = 6 | 8
 export interface PaginationPageProps {
   pageNumber: number
   css?: CSS
+  onClick?: () => void
 }
 export interface PaginationContextValue extends BasePaginationProps {
   currentPage: number


### PR DESCRIPTION
This is the new design of pagination indication. Changed from the small dot underneath, to a filled in background in primary brand colour.

https://www.figma.com/file/ZifX47jNu7xs568i8KFuVj/Quest-live-session?type=design&node-id=3167-6129&mode=design&t=CcLpPco9wv5y2Ctz-0

DESIGN:
<img width="807" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/ef752bbd-6374-46a2-bc6e-f7492451b371">

Implementation:

Focus on 4 (selected)
<img width="489" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/897184cb-b4ff-46bc-98db-9645ea626255">

Focus on 1 (indicated)
<img width="442" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/d8e7831d-4d85-44d4-a039-ea0a83d15998">


No focus, 2 indicated
<img width="454" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/0229cbd3-e397-4c58-9204-bf7238e17205">


Focus on 2 (indicated and selected)
<img width="458" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/c2818fab-0417-4b79-9b16-d14310eeb229">



