### PR TITLE
feat: data table disabled rows

### DIFF
--- a/documentation/content/components.data-table.md
+++ b/documentation/content/components.data-table.md
@@ -574,6 +574,49 @@ tabs:
         <DataTable.Table />
       </DataTable>`} language={"jsx"} />
 
+      #### Disabled rows
+
+
+      We can display disabled rows with different layout so users can see the difference between those rows and the enabled ones.
+      To achieve this you need to pass a property \`disabledRows\` that is a Record where the key is the row id (you can get this from the data table hook) and the value is a boolean that if it's true it will show the row as disabled. Note that this is just a visual change, it doesn't disable clickable elements in the table.
+
+
+      <CodeBlock live={false} preview={false} code={`const columnHelper = createColumnHelper()
+
+
+      const columns = [
+        columnHelper.accessor('name', {
+          header: 'Name',
+          id: 'name',
+          cell: (data) => data.getValue() || ''
+        }),
+        columnHelper.accessor('age', {
+          header: 'Age',
+          id: 'age',
+          cell: (data) => data.getValue() || ''
+        })
+      ]
+
+
+      const data = [
+        {
+          name: 'John',
+          age: 30
+        },
+        {
+          name: 'Mark',
+          age: 30
+        },
+        {
+          name: 'Anne',
+          age: 30
+        }
+      ]
+          
+      <DataTable data={data} columns={columns} disabledRows={{ '0': true }}>
+        <DataTable.Table />
+      </DataTable>`} language={"jsx"} />
+
 
       ## API Reference
 

--- a/lib/src/components/data-table/DataTable.types.ts
+++ b/lib/src/components/data-table/DataTable.types.ts
@@ -46,6 +46,7 @@ export type DataTableContextType<T = unknown> = Table<T> & {
   isSortable: boolean
   asyncDataState?: AsyncDataState
   runAsyncData?: (options: Partial<TAsyncDataOptions>) => Promise<void>
+  disabledRows?: Record<string, boolean>
   enableRowSelection?: boolean | ((row: Row<unknown>) => boolean)
   rowSelection: RowSelectionState
   data: TAsyncDataResult

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -39,6 +39,7 @@ type DataTableProviderProps = {
   defaultSort?: TDefaultSort
   children: React.ReactNode
   initialState?: InitialState
+  disabledRows?: Record<string, boolean>
   enableRowSelection?: boolean | ((row: Row<unknown>) => boolean)
   onRowSelectionChange?: OnChangeFn<RowSelectionState>
 } & (
@@ -52,6 +53,7 @@ export const DataTableProvider = ({
   getAsyncData,
   defaultSort,
   initialState = undefined,
+  disabledRows,
   enableRowSelection,
   onRowSelectionChange,
   children
@@ -158,6 +160,10 @@ export const DataTableProvider = ({
       const checkFilterMatchesCell = (cellValue: string) =>
         cellValue.toLowerCase().includes(filterValue.toLowerCase())
 
+      const isSubRow = row.depth === 1
+
+      if (isSubRow) return true
+
       const value = row.getValue(columnId)
       switch (typeof value) {
         case 'string':
@@ -183,6 +189,7 @@ export const DataTableProvider = ({
       isSortable,
       asyncDataState,
       runAsyncData,
+      disabledRows,
       enableRowSelection,
       rowSelection,
       tableId: tableId.current

--- a/lib/src/components/data-table/DataTableContext.tsx
+++ b/lib/src/components/data-table/DataTableContext.tsx
@@ -160,7 +160,7 @@ export const DataTableProvider = ({
       const checkFilterMatchesCell = (cellValue: string) =>
         cellValue.toLowerCase().includes(filterValue.toLowerCase())
 
-      const isSubRow = row.depth === 1
+      const isSubRow = row.depth > 0
 
       if (isSubRow) return true
 

--- a/lib/src/components/data-table/DataTableRow.tsx
+++ b/lib/src/components/data-table/DataTableRow.tsx
@@ -22,12 +22,20 @@ const StyledRow = styled(Table.Row, {
         // the !important rule is needed because the bg property is set elsewhere and it's more specific than this one would be without the !important modifier.
         bg: '$primary100 !important'
       }
+    },
+    isDisabled: {
+      true: {
+        opacity: '30%'
+      }
     }
   }
 })
 
 export const DataTableRow = ({ row }: DataTableRowProps) => {
-  const { enableRowSelection, getCanSomeRowsExpand } = useDataTable()
+  const { enableRowSelection, disabledRows, getCanSomeRowsExpand } =
+    useDataTable()
+
+  const isDisabled = !!disabledRows?.[row.id]
 
   const toggleExpandHandler = row.getToggleExpandedHandler()
   const toggleSelectHandler = row.getToggleSelectedHandler()
@@ -38,7 +46,7 @@ export const DataTableRow = ({ row }: DataTableRowProps) => {
   }
 
   return (
-    <StyledRow isSelected={row.getIsSelected()}>
+    <StyledRow isSelected={row.getIsSelected()} isDisabled={isDisabled}>
       {getCanSomeRowsExpand() && (
         <Table.Cell
           data-testid={`expand-icon-${row.id}`}

--- a/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
+++ b/lib/src/components/date-input/__snapshots__/DateInput.test.tsx.snap
@@ -450,12 +450,12 @@ exports[`DateInput component renders lg size 1`] = `
     display: table;
   }
 
-  .c-dOwGHN-huXVXM-isOutsideMonth-true {
-    color: var(--colors-tonal200);
-  }
-
   .c-dOwGHN-hztIub-isToday-true {
     background: var(--colors-tonal100);
+  }
+
+  .c-dOwGHN-huXVXM-isOutsideMonth-true {
+    color: var(--colors-tonal200);
   }
 
   .c-iKnjyA-kUaMfZ-size-md {


### PR DESCRIPTION
Adding option to display disabled rows on the Data table. This is a visual change only so the elements in the table will still be clickable and the reason for that is to give more flexibility allowing the consumer of the component to decide if a disabled row can be selected or expanded.

<img width="1012" alt="Screenshot 2024-04-03 at 15 56 43" src="https://github.com/Atom-Learning/components/assets/11462265/b9d8828e-f910-454b-8569-a3610c2bfe42">
