### PR TITLE
feat: make NavigationMenu viewport offset a css variable

### DIFF
--- a/lib/src/components/navigation/NavigationMenu.tsx
+++ b/lib/src/components/navigation/NavigationMenu.tsx
@@ -111,6 +111,7 @@ const NavigationMenuComponent = ({
         <ViewportPosition>
           <StyledViewport
             css={{
+              '--navigation-menu-viewport-offset': `${offset || 0}px`,
               transform: `translateX(${offset || 0}px)`,
               '&[data-state="open"]': {
                 animation: `${delayedFadeIn} ${fadeDuration}ms ease`

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -521,15 +521,16 @@ exports[`Nav component renders 1`] = `
     }
 }
 
-  .c-jQFjpB-ikEdNcB-css {
+  .c-jQFjpB-iUhOFK-css {
+    --navigation-menu-viewport-offset: 0px;
     transform: translateX(0px);
   }
 
-  .c-jQFjpB-ikEdNcB-css[data-state="open"] {
+  .c-jQFjpB-iUhOFK-css[data-state="open"] {
     animation: k-brPFuJ 200ms ease;
   }
 
-  .c-jQFjpB-ikEdNcB-css[data-state="closed"] {
+  .c-jQFjpB-iUhOFK-css[data-state="closed"] {
     animation: k-bHbNKp 200ms ease-out;
   }
 
@@ -600,7 +601,7 @@ exports[`Nav component renders 1`] = `
       class="c-dbtMpA"
     >
       <div
-        class="c-jQFjpB c-jQFjpB-ikEdNcB-css"
+        class="c-jQFjpB c-jQFjpB-iUhOFK-css"
         data-orientation="horizontal"
         data-state="open"
       >


### PR DESCRIPTION
Set the navigation viewport offset to a css variable so we can use it to reset the translate if needed - for example if we have a full width dropdown item.

**Example usage:**
```
<NavigationMenu.DropdownContent css={{ width: '100vw', transform: 'translateX(calc(-1 * var(--navigation-menu-viewport-offset)))' }}>
```

**Before**

https://github.com/Atom-Learning/components/assets/6905473/4577e002-ee37-49db-9627-029e1fa0b5d6



**After** (using the code above)

https://github.com/Atom-Learning/components/assets/6905473/2fea5457-6d95-45db-8449-60b8f9b78935

