### PR TITLE
chore: updated theme version to include new colours

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@atom-learning/components": "0.0.0-semantically-released",
     "@atom-learning/icons": "^1.19.0",
-    "@atom-learning/theme": "3.0.1",
+    "@atom-learning/theme": "3.1.0",
     "@lukeed/uuid": "^2.0.0",
     "lodash.kebabcase": "^4.1.1",
     "netlify-cms-app": "^2.15.72",

--- a/lib/package.json
+++ b/lib/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@atom-learning/icons": "1.19.0",
     "@atom-learning/jest-stitches": "1.0.10",
-    "@atom-learning/theme": "3.0.1",
+    "@atom-learning/theme": "3.1.0",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@radix-ui/react-id": "0.1.5",
@@ -121,12 +121,12 @@
   },
   "peerDependencies": {
     "@atom-learning/icons": "^1.0.0",
-    "@atom-learning/theme": "^3.0.0",
+    "@atom-learning/theme": "^3.1.0",
     "react": "^17",
     "react-dom": "^17"
   },
   "dependencies": {
-    "@atom-learning/theme": "3.0.1",
+    "@atom-learning/theme": "3.1.0",
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/modifiers": "^6.0.0",
     "@dnd-kit/sortable": "^7.0.1",

--- a/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Accordion component renders an accordion 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Accordion component renders an accordion 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/badge/__snapshots__/Badge.test.tsx.snap
+++ b/lib/src/components/badge/__snapshots__/Badge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Badge component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Badge component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -357,7 +393,7 @@ exports[`Badge component renders 1`] = `
 exports[`Badge component renders a md size and danger theme 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -504,6 +540,42 @@ exports[`Badge component renders a md size and danger theme 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -725,7 +797,7 @@ exports[`Badge component renders a md size and danger theme 1`] = `
 exports[`Badge component renders with an icon 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -872,6 +944,42 @@ exports[`Badge component renders with an icon 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
+++ b/lib/src/components/banner/banner-regular/__snapshots__/BannerRegular.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BannerRegular component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`BannerRegular component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -617,7 +653,7 @@ exports[`BannerRegular component renders 1`] = `
 exports[`BannerRegular component renders dismissible variant 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -764,6 +800,42 @@ exports[`BannerRegular component renders dismissible variant 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/banner/banner-slim/__snapshots__/BannerSlim.test.tsx.snap
+++ b/lib/src/components/banner/banner-slim/__snapshots__/BannerSlim.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BannerSlim component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`BannerSlim component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -547,7 +583,7 @@ exports[`BannerSlim component renders 1`] = `
 exports[`BannerSlim component renders dismissible variant 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -694,6 +730,42 @@ exports[`BannerSlim component renders dismissible variant 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -1188,7 +1260,7 @@ exports[`BannerSlim component renders dismissible variant 1`] = `
 exports[`BannerSlim component renders sm variant 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -1335,6 +1407,42 @@ exports[`BannerSlim component renders sm variant 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -2425,7 +2425,7 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
 exports[`DataTable component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -2572,6 +2572,42 @@ exports[`DataTable component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -3509,7 +3545,7 @@ exports[`DataTable component renders 1`] = `
 exports[`DataTable server-side renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -3656,6 +3692,42 @@ exports[`DataTable server-side renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/lib/src/components/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Drawer opens the popover once trigger is clicked 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Drawer opens the popover once trigger is clicked 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NavigationMenuVertical renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`NavigationMenuVertical renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -478,7 +514,7 @@ exports[`NavigationMenuVertical renders 1`] = `
 exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -625,6 +661,42 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/src/components/navigation/__snapshots__/NavigationMenu.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Nav component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Nav component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Pagination component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Pagination component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/side-bar/__snapshots__/SideBar.test.tsx.snap
+++ b/lib/src/components/side-bar/__snapshots__/SideBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SideBar component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`SideBar component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -403,7 +439,7 @@ exports[`SideBar component renders 1`] = `
 exports[`SideBar component renders as static type 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -550,6 +586,42 @@ exports[`SideBar component renders as static type 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/lib/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tabs component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Tabs component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/tile-interactive/__snapshots__/TileInteractive.test.tsx.snap
+++ b/lib/src/components/tile-interactive/__snapshots__/TileInteractive.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TileInteractive component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`TileInteractive component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/tile-toggle-group/__snapshots__/TileToggleGroup.test.tsx.snap
+++ b/lib/src/components/tile-toggle-group/__snapshots__/TileToggleGroup.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TileToggleGroup component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`TileToggleGroup component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/tile/__snapshots__/Tile.test.tsx.snap
+++ b/lib/src/components/tile/__snapshots__/Tile.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tile component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`Tile component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TopBar component renders 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -150,6 +150,42 @@ exports[`TopBar component renders 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);
@@ -552,7 +588,7 @@ exports[`TopBar component renders 1`] = `
 exports[`TopBar component renders the lg variant 1`] = `
 @media  {
   :root,
-  .t-gRpxxC {
+  .t-bgDNai {
     --default-colors: [object Object];
     --default-space: [object Object];
     --default-fontSizes: [object Object];
@@ -699,6 +735,42 @@ exports[`TopBar component renders the lg variant 1`] = `
     --colors-lime1000: hsl(75, 100%, 15%);
     --colors-lime1100: hsl(75, 100%, 9%);
     --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
     --colors-tonal50: hsl(0, 0%, 96%);
     --colors-tonal100: hsl(0, 0%, 92%);
     --colors-tonal200: hsl(0, 0%, 62%);

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
     chalk "^4.1.0"
     css "^3.0.0"
 
-"@atom-learning/theme@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-3.0.1.tgz#91a3eef10c2888c0b17c60b122528dbee83b7743"
-  integrity sha512-it7K38RAYvdKG7sGXxa8hqFLXtwYXMg5RIp6eLSEfmdDUeYp0JTB4VuTJ0hL8150fXMkM+7+rjU2s03K6h8WoA==
+"@atom-learning/theme@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@atom-learning/theme/-/theme-3.1.0.tgz#32a00575833715b142ea2543a9ebc24fb86ba6cc"
+  integrity sha512-TmhGgslOs7j92CYYznzzUS1Qv4+gb0jVyLNIyUn7RWC1tlgf7+66ka1VNWhKmD6W4kiAG0ejZuKdWiOe01eZ4Q==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"


### PR DESCRIPTION
We've updated the colours to include new palettes for Marsh, Maroon and Lapis, plus updated colours for Quest.

This just bumps the theme version from 3.0.1 to 3.1.0 and updates the snapshots