### PR TITLE
B2B-783 - [FE] Update Quest colour palette + new badges

### DIFF
--- a/documentation/content/components.badge.md
+++ b/documentation/content/components.badge.md
@@ -37,7 +37,7 @@ tabs:
       The following semantic themes are available: `success`, `warning`, `danger`, `neutral`, `info`.
 
 
-      The following non-semantic themes are available `grey`, `blue`, `purple`, `cyan`,  `green`, `magenta`, `red`, `teal`, `orange`, `yellow`, `lime`.
+      The following non-semantic themes are available `grey`, `blue`, `purple`, `cyan`,  `green`, `magenta`, `red`, `teal`, `orange`, `yellow`, `lime`, `lapis`, `maroon`, `marsh`, `primary`.
 
 
       If no theme is passed in. The badge theme defaults to "info".
@@ -64,6 +64,10 @@ tabs:
           <Badge theme="orange">Orange</Badge>
           <Badge theme="yellow">Yellow</Badge>
           <Badge theme="lime">Lime</Badge>
+          <Badge theme="lapis">Lapis</Badge>
+          <Badge theme="maroon">Maroon</Badge>
+          <Badge theme="marsh">Marsh</Badge>
+          <Badge theme="primary">Primary</Badge>
         </Flex>
         <Badge emphasis="bold">Defaults to: "info"</Badge>
 
@@ -86,6 +90,10 @@ tabs:
           <Badge theme="orange" emphasis="bold">Orange</Badge>
           <Badge theme="yellow" emphasis="bold">Yellow</Badge>
           <Badge theme="lime" emphasis="bold">Lime</Badge>
+          <Badge theme="lapis" emphasis="bold">Lapis</Badge>
+          <Badge theme="maroon" emphasis="bold">Maroon</Badge>
+          <Badge theme="marsh" emphasis="bold">Marsh</Badge>
+          <Badge theme="primary" emphasis="bold">Primary</Badge>
         </Flex>
       </Flex>`} language={"tsx"} />
 

--- a/lib/src/components/badge/stitches.badge.colorscheme.config.ts
+++ b/lib/src/components/badge/stitches.badge.colorscheme.config.ts
@@ -152,6 +152,42 @@ const lime = createTheme({
   }
 })
 
+const lapis = createTheme({
+  colors: {
+    textSubtle: '$lapis1000',
+    backgroundSubtle: '$lapis200',
+    textBold: '#fff',
+    backgroundBold: '$lapis700'
+  }
+})
+
+const maroon = createTheme({
+  colors: {
+    textSubtle: '$maroon1000',
+    backgroundSubtle: '$maroon200',
+    textBold: '#fff',
+    backgroundBold: '$maroon800'
+  }
+})
+
+const marsh = createTheme({
+  colors: {
+    textSubtle: '$marsh1000',
+    backgroundSubtle: '$marsh200',
+    textBold: '#fff',
+    backgroundBold: '$marsh800'
+  }
+})
+
+const primary = createTheme({
+  colors: {
+    textSubtle: '$primary1000',
+    backgroundSubtle: '$primary200',
+    textBold: '#fff',
+    backgroundBold: '$primary800'
+  }
+})
+
 export const colorSchemes = {
   info,
   neutral,
@@ -168,5 +204,9 @@ export const colorSchemes = {
   teal,
   orange,
   yellow,
-  lime
+  lime,
+  lapis,
+  maroon,
+  marsh,
+  primary
 }

--- a/lib/src/experiments/color-scheme/stitches.colorscheme.config.ts
+++ b/lib/src/experiments/color-scheme/stitches.colorscheme.config.ts
@@ -64,7 +64,13 @@ export const bases = {
   yellow1: { colorName: 'yellow', color0: '#FFFFFF' },
   yellow2: { colorName: 'yellow' },
   lime1: { colorName: 'lime', color0: '#FFFFFF' },
-  lime2: { colorName: 'lime' }
+  lime2: { colorName: 'lime' },
+  lapis1: { colorName: 'lapis', color0: '#FFFFFF' },
+  lapis2: { colorName: 'lapis' },
+  maroon1: { colorName: 'maroon', color0: '#FFFFFF' },
+  maroon2: { colorName: 'maroon' },
+  marsh1: { colorName: 'marsh', color0: '#FFFFFF' },
+  marsh2: { colorName: 'marsh' }
 }
 const generateBase = () => {
   Object.entries(bases).forEach(
@@ -105,7 +111,13 @@ export const accents = {
   yellow1: { colorName: 'yellow', color0: '#FFFFFF' },
   yellow2: { colorName: 'yellow' },
   lime1: { colorName: 'lime', color0: '#FFFFFF' },
-  lime2: { colorName: 'lime' }
+  lime2: { colorName: 'lime' },
+  lapis1: { colorName: 'lapis', color0: '#FFFFFF' },
+  lapis2: { colorName: 'lapis' },
+  maroon1: { colorName: 'maroon', color0: '#FFFFFF' },
+  maroon2: { colorName: 'maroon' },
+  marsh1: { colorName: 'marsh', color0: '#FFFFFF' },
+  marsh2: { colorName: 'marsh' }
 }
 const generateAccent = () => {
   Object.entries(accents).forEach(


### PR DESCRIPTION
Added three new color ramps: Maroon Marsh and Lapis

Update hex codes of Quest green $primary ramp

Quest colours
<img width="357" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/9ee8ec1d-642c-48d2-a34c-7d0a268746bc">

Marsh
<img width="334" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/a4e72d75-3f9e-4c71-bceb-8be1c34532f9">

Maroon
<img width="294" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/e8877dc2-18e8-43a1-b3fe-9c290a6adbed">

Lapis
<img width="316" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/924e6e2a-15ba-4f76-aadb-5762792da88f">

Badge colours:
<img width="1059" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/d43f0857-d26b-4409-9a59-16f63903c27e">

Badge primary (Atom flavour)
<img width="106" alt="image" src="https://github.com/Atom-Learning/components/assets/97449290/8c79717f-5831-4bfd-a7ee-dd9df5354558">
