### PR TITLE
Feat: Render pagination component only if there is more than one page

### DIFF
--- a/documentation/content/components.data-table.md
+++ b/documentation/content/components.data-table.md
@@ -289,7 +289,7 @@ tabs:
       ### Pagination
 
 
-      `DataTable.Pagination` can be passed as a child to `DataTable` to render the pagination UI and configure the parent `DataTable` to paginate its data.
+      `DataTable.Pagination` can be passed as a child to `DataTable` to render the pagination UI and configure the parent `DataTable` to paginate its data. The UI will be visible only if there is more than one page in the `DataTable`
 
 
       ### Drag and drop

--- a/lib/src/components/data-table/DataTable.test.tsx
+++ b/lib/src/components/data-table/DataTable.test.tsx
@@ -278,6 +278,24 @@ describe('DataTable.Pagination component', () => {
     expect(nextPageButton).not.toBeInTheDocument()
   })
 
+  it("doesn't render if there is only one page in the table", () => {
+    render(
+      <Wrapper>
+        <DataTable
+          columns={columns}
+          data={data.slice(0, 5)}
+          initialState={{ pagination: { pageIndex: 0, pageSize: 5 } }}
+        >
+          <DataTable.Table sortable />
+          <DataTable.Pagination />
+        </DataTable>
+      </Wrapper>
+    )
+
+    const nextPageButton = screen.queryByLabelText('Next page')
+    expect(nextPageButton).not.toBeInTheDocument()
+  })
+
   it('Navigates to the correct page', async () => {
     render(
       <Wrapper>

--- a/lib/src/components/data-table/pagination/Pagination.tsx
+++ b/lib/src/components/data-table/pagination/Pagination.tsx
@@ -47,7 +47,10 @@ export const Pagination = ({ colorScheme, ...props }: PaginationProps) => {
   const isPending = asyncDataState === AsyncDataState.PENDING
   const isEmpty = !isPending && getTotalRows() === 0
 
-  if (isEmpty) return null
+  // Show pagination only if total pages are more than 1
+  const showPagination = getPageCount() > 1
+
+  if (isEmpty || !showPagination) return null
 
   const recordsCountFrom =
     paginationState.pageIndex * paginationState.pageSize + 1


### PR DESCRIPTION
https://atomlearningltd.atlassian.net/browse/HMP-739

With the update of the pagination in the Design System table we now display the component even if the table has only one page or no data returned. This isn’t necessary when the user has no other pages to access.

1. If a table has only one page (less than the maximum amount of items that can be fit on one page), do not display the pagination (Implemented in this PR)
2. If a table has no pages (The empty state shows), do not display the pagination (Already in place)
3. If a table has more than one page (more than the maximum amount of items that can be fit on one page), display the pagination as expected (Already in place)

Implementation -
1. Conditionally rendering Pagination component based on page count
2. Added unit test

Screenshots -
`initialState={{ pagination: { pageSize: 3, pageIndex: 0 } }}`

4 items in table, 2 pages
<img width="377" alt="Screenshot 2024-05-13 at 06 54 20" src="https://github.com/Atom-Learning/components/assets/1936119/315fa5b2-771c-437d-ba01-e3414b704440">

3 items in table, 1 page
<img width="377" alt="Screenshot 2024-05-13 at 06 56 07" src="https://github.com/Atom-Learning/components/assets/1936119/9f8bf614-b5b3-4d70-a333-588c965d6e87">

2 items in table, 1 page
<img width="376" alt="Screenshot 2024-05-13 at 06 56 34" src="https://github.com/Atom-Learning/components/assets/1936119/d39b4928-1c9d-47c4-8a1b-857dff59d168">
