### PR TITLE
fix: respect "as" prop when explicitely passed in TileInteractive

### DIFF
--- a/lib/src/components/tile-interactive/TileInteractive.tsx
+++ b/lib/src/components/tile-interactive/TileInteractive.tsx
@@ -43,20 +43,21 @@ const StyledTileInteractive = styled.withConfig({
 
 type TTileInteractiveProps = React.ComponentProps<
   typeof StyledTileInteractive
-> &
-  React.ButtonHTMLAttributes<HTMLButtonElement> &
+> & {
+  as?: React.ComponentType | React.ElementType
+} & React.ButtonHTMLAttributes<HTMLButtonElement> &
   NavigatorActions
 
 export const TileInteractive: React.ForwardRefExoticComponent<TTileInteractiveProps> =
-  React.forwardRef(({ onClick, href, type = 'button', ...rest }, ref) => {
+  React.forwardRef(({ onClick, href, type = 'button', as, ...rest }, ref) => {
     const isLink = !!href
     const elementSpecificProps = isLink
       ? {
-          as: 'a' as React.ElementType,
+          as: as || ('a' as React.ElementType),
           href,
           onClick: undefined
         }
-      : { as: 'button' as React.ElementType, type, onClick }
+      : { as: as || ('button' as React.ElementType), type, onClick }
 
     return (
       <StyledTileInteractive {...rest} {...elementSpecificProps} ref={ref} />


### PR DESCRIPTION
## Description

I was trying to make a `TileInteractive` be a `Dialog.Trigger` to open a dialog but what I was passing into `as` was not being respected. 
This code tweak makes sure that if something is explicitly passed into `as` it is preferred over the accessible overrides of `a` or `button`.

_**Note that**_ this means if you pass `TileInteractive as={Flex}` it will end up being a `div` and not an anchor or button - which is wrong semantically for an interactive element. So be very conscious of that.

From a scan into the codebase we do not override `as` on `TileInteractive` at all so far (assuming cause it didn't use to work anyway) but now that we have the ability we need to be cautious when choosing to do so.

## Videos
**with sandbox code:** 

```
const App = () => (
  <Flex
    css={{
      minHeight: '100vh',
      justifyContent: 'center',
      alignItems: 'center',
      flexDirection: 'column',
      background: 'red'
    }}
  >
    <Dialog>
      <TileInteractive as={Dialog.Trigger}>This TileInteractive should be a Dialog.Trigger</TileInteractive>
      <Dialog.Content>
        Hello Hello
      </Dialog.Content>
    </Dialog>
  </Flex>
)
```

**before**

https://github.com/Atom-Learning/components/assets/6905473/0c7b139e-fb5c-45b3-9c74-3fc90f42dfbb



**after**

https://github.com/Atom-Learning/components/assets/6905473/7bdf0d82-f4b1-4856-9ce2-6b326aed31a3

