### PR TITLE
fix: prevent rendering multiple children with asChild

### DIFF
--- a/lib/src/components/accordion/Accordion.test.tsx
+++ b/lib/src/components/accordion/Accordion.test.tsx
@@ -61,7 +61,7 @@ describe('Accordion component', () => {
     expect(await screen.queryByText('CONTENT2')).not.toBeInTheDocument()
   })
 
-  it.only('does not render the chevron icon when the trigger is used `asChild`', () => {
+  it('does not render the chevron icon when the trigger is used `asChild`', () => {
     render(
       <Accordion>
         <Accordion.Item value="1">

--- a/lib/src/components/accordion/Accordion.test.tsx
+++ b/lib/src/components/accordion/Accordion.test.tsx
@@ -60,4 +60,19 @@ describe('Accordion component', () => {
     expect(await screen.findByText('CONTENT1')).toBeVisible()
     expect(await screen.queryByText('CONTENT2')).not.toBeInTheDocument()
   })
+
+  it.only('does not render the chevron icon when the trigger is used `asChild`', () => {
+    render(
+      <Accordion>
+        <Accordion.Item value="1">
+          <Accordion.Trigger asChild>
+            <button>Trigger</button>
+          </Accordion.Trigger>
+        </Accordion.Item>
+      </Accordion>
+    )
+
+    expect(screen.getByRole('button', { name: 'Trigger' })).toBeVisible()
+    expect(screen.queryByTestId('accordion-chevron')).not.toBeInTheDocument()
+  })
 })

--- a/lib/src/components/accordion/AccordionTrigger.tsx
+++ b/lib/src/components/accordion/AccordionTrigger.tsx
@@ -52,14 +52,19 @@ const StyledTrigger = styled(Trigger, {
 export const AccordionTrigger = ({
   children,
   colorScheme = {},
+  asChild,
   ...remainingProps
 }: React.ComponentProps<typeof StyledTrigger> & {
   colorScheme?: TcolorScheme
 }) => (
   <ColorScheme asChild accent="grey1" interactive="loContrast" {...colorScheme}>
-    <StyledTrigger {...remainingProps}>
-      {children}
-      <RotatingIcon is={ChevronDown} />
+    <StyledTrigger asChild={asChild} {...remainingProps}>
+      <>
+        {children}
+        {!asChild && (
+          <RotatingIcon is={ChevronDown} data-testid="accordion-chevron" />
+        )}
+      </>
     </StyledTrigger>
   </ColorScheme>
 )


### PR DESCRIPTION
When using `asChild` on `Accordion.Trigger`, it expects to only have a single child component. However, because we were also rendering the chevron icon next to the `children`, it would always return an array of children.

This PR wraps them in a `React.Fragment` to prevent that error. It now also hides the chevron, as you most likely want to use your own implementation when using `asChild`.