### PR TITLE
fix: props being passed to a fragment with `asChild` in `Accordion.Trigger`

### DIFF
--- a/lib/src/components/accordion/Accordion.test.tsx
+++ b/lib/src/components/accordion/Accordion.test.tsx
@@ -61,18 +61,22 @@ describe('Accordion component', () => {
     expect(await screen.queryByText('CONTENT2')).not.toBeInTheDocument()
   })
 
-  it('does not render the chevron icon when the trigger is used `asChild`', () => {
+  it('works when the trigger is rendered `asChild`', () => {
     render(
       <Accordion>
         <Accordion.Item value="1">
           <Accordion.Trigger asChild>
-            <button>Trigger</button>
+            <button>TRIGGER</button>
           </Accordion.Trigger>
+          <Accordion.Content asChild>CONTENT</Accordion.Content>
         </Accordion.Item>
       </Accordion>
     )
 
-    expect(screen.getByRole('button', { name: 'Trigger' })).toBeVisible()
     expect(screen.queryByTestId('accordion-chevron')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'TRIGGER' }))
+
+    expect(screen.getByText('CONTENT')).toBeVisible()
   })
 })

--- a/lib/src/components/accordion/AccordionTrigger.tsx
+++ b/lib/src/components/accordion/AccordionTrigger.tsx
@@ -59,12 +59,14 @@ export const AccordionTrigger = ({
 }) => (
   <ColorScheme asChild accent="grey1" interactive="loContrast" {...colorScheme}>
     <StyledTrigger asChild={asChild} {...remainingProps}>
-      <>
-        {children}
-        {!asChild && (
+      {asChild ? (
+        children
+      ) : (
+        <>
+          {children}
           <RotatingIcon is={ChevronDown} data-testid="accordion-chevron" />
-        )}
-      </>
+        </>
+      )}
     </StyledTrigger>
   </ColorScheme>
 )


### PR DESCRIPTION
Followup for: https://github.com/Atom-Learning/components/pull/663

The previous PR didn't fully fix the issue. It rendered the correct elements, but it passed the `Accordion.Trigger` props onto the `React.Fragment`, instead of the actual child components 🥲 