### PR TITLE
security - replace polyfill(dot)io with CloudFlare mirror

### DIFF
--- a/documentation/pages/_document.tsx
+++ b/documentation/pages/_document.tsx
@@ -30,7 +30,7 @@ const Document = () => {
       <body>
         <Main />
         <Script
-          src={`https://polyfill.io/v3/polyfill.min.js?features=${encodeURIComponent(
+          src={`https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=${encodeURIComponent(
             polyfills.join(',')
           )}`}
         />


### PR DESCRIPTION
Due to reports of polyfill(dot)io now being owned by a malicious actor, we are replacing all instances of it with CloudFlare's mirror