### PR TITLE
fix: add `as` prop for empty state title & body

### DIFF
--- a/lib/src/components/empty-state/EmptyStateBody.tsx
+++ b/lib/src/components/empty-state/EmptyStateBody.tsx
@@ -34,7 +34,9 @@ const StyledEmptyStateBody = styled(Text, {
   }
 })
 
-type EmptyStateBodyProps = React.ComponentProps<typeof StyledEmptyStateBody>
+type EmptyStateBodyProps = React.ComponentProps<typeof StyledEmptyStateBody> & {
+  as?: React.ComponentType | React.ElementType
+}
 
 export const EmptyStateBody = (props: EmptyStateBodyProps) => {
   const { size } = React.useContext(EmptyStateContext)

--- a/lib/src/components/empty-state/EmptyStateTitle.tsx
+++ b/lib/src/components/empty-state/EmptyStateTitle.tsx
@@ -35,7 +35,11 @@ const StyledEmptyStateTitle = styled('h2', {
   }
 })
 
-type EmptyStateTitleProps = React.ComponentProps<typeof StyledEmptyStateTitle>
+type EmptyStateTitleProps = React.ComponentProps<
+  typeof StyledEmptyStateTitle
+> & {
+  as?: React.ComponentType | React.ElementType
+}
 
 export const EmptyStateTitle = (props: EmptyStateTitleProps) => {
   const { size } = React.useContext(EmptyStateContext)


### PR DESCRIPTION
There is a TS error when using `as` with the EmptyState subcomponents
```
 Property 'as' does not exist on type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>, "key" | keyof HTMLAttributes<...>> & { ...; }, "size" | "css"> & TransformProps<...> & { ...; }'
```

Adding `as` prop to `EmptyState.Title` and `EmptyState.body`