### PR TITLE
Revert-DS-Form-changes

### DIFF
--- a/documentation/components/markdown/editor-component/ComponentProps.tsx
+++ b/documentation/components/markdown/editor-component/ComponentProps.tsx
@@ -59,17 +59,12 @@ const PropType = ({ name, type }) => {
       </WithTooltip>
     )
   }
-
-  if (Array.isArray(type.value) && type.value.length) {
+  if (Array.isArray(type.value)) {
     let values = type.value
       .filter(({ value }) => value !== 'undefined')
       .filter(({ value }) => !value.startsWith('{ [x: string]'))
       .filter(({ value }) => !value.startsWith('{ "@sm"'))
       .filter(({ value }) => !value.startsWith('"true"'))
-
-    if (!values?.length) {
-      values = type.value
-    }
 
     if (values[0].value === 'false' && values[1].value === 'true') {
       values = [{ value: 'boolean' }]

--- a/documentation/content/components.form.md
+++ b/documentation/content/components.form.md
@@ -173,6 +173,43 @@ tabs:
       The `process` property accepts a function of type `(value: any) => any`. It can be used to process the value after validation.
 
 
+      ## Persisting form data
+
+
+      `Form` is integrated with `react-hook-form-persist`'s package to save form data into session storage:
+
+
+      * send `persist` prop to Form component to persist form data in sessionStorage
+
+      * `persist` object has a required `id`, an optional `storage` prop and optional `include` or `exclude` arrays with reference to the input's names
+
+      * `include` will only save the listed inputs to session storage and `exclude` will exclude the listed inputs
+
+      * if both `include` and `exclude` are sent it will ignore `include` and use only `exclude`
+
+      * if no `storage` prop is sent, it will default to use sessionStorage, however you can override this by sending `local` to use localStorage
+
+      * persisted form data in sessionStorage or localStorage will populate form with `defaultValues` on refresh
+
+
+      Here's an example using the `persist` prop:
+
+
+      <CodeBlock code={`<Form persist={{ id: 'nameAndSecret', exclude: \['secret'\], storage: 'local' }}>
+        <InputField
+          name="name"
+          label="Name"
+          validation={{ required: 'Name is required' }}
+        />
+        <InputField
+          name="secret"
+          label="Secret"
+          validation={{ required: 'Secret is required' }}
+        />
+        <Button type="submit">Submit</Button>
+      </Form>`} language={"tsx"} />
+
+
       ## Composing form field components
 
 
@@ -285,8 +322,9 @@ tabs:
       The same object that `useFormContext` returns is available in an optional render prop function, making it easy to use the current form state to determine whether a button should be disabled or read the current value of a specific field. Note that if `render` is provided, `Form` should not be given any children. An error will be thrown if both are provided.
 
 
-      <CodeBlock code={`<Form onSubmit={console.log}>
-        {({ formState }) => (
+      <CodeBlock code={`<Form
+        onSubmit={console.log}
+        render={({ formState }) => (
           <>
             <InputField
               label="Name"
@@ -298,15 +336,17 @@ tabs:
             </Button>
           </>
         )}
-      </Form>`} language={"tsx"} />
+      />`} language={"tsx"} />
 
 
       To access field value, another render prop that can be used is `watch(fieldName: string)`. If there were no default values provided for the form, on the first render, the `watch` function will return undefined.
 
 
-      <CodeBlock code={`<Form onSubmit={console.log}>
-        {({ watch }) => {
+      <CodeBlock code={`<Form
+        onSubmit={console.log}
+        render={({ watch }) => {
           const currentFieldValue = watch('name')
+
 
           return (
             <>
@@ -321,7 +361,7 @@ tabs:
             </>
           )
         }}
-      </Form>`} language={"tsx"} />
+      />`} language={"tsx"} />
 
 
       You can also name your `render` function:
@@ -340,7 +380,7 @@ tabs:
         </>
       )
 
-      const SomeForm = () => <Form onSubmit={console.log}><SomeFormComponent /></Form>`} language={"tsx"} />
+      const SomeForm = () => <Form onSubmit={console.log} render={SomeFormContent} />`} language={"tsx"} />
 
 
       ## Dynamic fields - useFieldArray()
@@ -402,8 +442,7 @@ tabs:
               { field1: 'test2', field2: true }
             ]
           }}
-          >
-          {({ control }) => {
+          render={({ control }) => {
             const { fields, append, remove } = useFieldArray({
               control,
               name: 'testArray'
@@ -435,7 +474,7 @@ tabs:
               </>
             )
           }}
-          </Form>`} language={"tsx"} />
+        />`} language={"tsx"} />
 
       ## API Reference
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -165,6 +165,7 @@
     "react-aria": "^3.29.1",
     "react-docgen-typescript": "2.1.0",
     "react-hook-form": "^6.15.4",
+    "react-hook-form-persist": "^2.0.0",
     "react-hot-toast": "^1.0.2",
     "react-player": "^2.9.0",
     "throttle-debounce": "^3.0.1",

--- a/lib/src/components/form/Form.tsx
+++ b/lib/src/components/form/Form.tsx
@@ -1,61 +1,122 @@
-import React from 'react'
-import type {
-  DefaultValues,
-  FieldValues,
-  Mode,
-  SubmitErrorHandler,
-  SubmitHandler,
-  UseFormMethods
-} from 'react-hook-form'
+import invariant from 'invariant'
+import * as React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import useFormPersist from 'react-hook-form-persist'
 
 import { styled } from '~/stitches'
 
+import type {
+  FormContentValues,
+  FormPersistParams,
+  FormValues,
+  PersistFormWrapperValues
+} from './Form.types'
+import { StorageEnum } from './Form.types'
+
 const StyledForm = styled('form', {})
 
-type StyledFormProps = Omit<
-  React.ComponentPropsWithoutRef<typeof StyledForm>,
-  'onSubmit' | 'onError'
->
+type FormProps = React.ComponentPropsWithoutRef<typeof StyledForm> & FormValues
 
-interface FormProps<TFormData extends FieldValues> extends StyledFormProps {
-  defaultValues?: DefaultValues<TFormData>
-  validationMode?: Mode
-  onSubmit: SubmitHandler<TFormData>
-  onError?: SubmitErrorHandler<TFormData>
-  children:
-    | React.ReactNode
-    | ((methods: UseFormMethods<TFormData>) => React.ReactNode)
+type FormContentProps = React.ComponentPropsWithoutRef<typeof StyledForm> &
+  FormContentValues
+
+type PersistFormWrapperProps = React.ComponentPropsWithoutRef<
+  typeof StyledForm
+> &
+  PersistFormWrapperValues
+
+const PersistFormWrapper = ({
+  persist,
+  watch,
+  setValue,
+  children
+}: PersistFormWrapperProps) => {
+  const { id, ...options } = persist
+
+  let params: FormPersistParams = {
+    ...options,
+    storage:
+      options.storage === StorageEnum.LOCAL
+        ? window.localStorage
+        : window.sessionStorage
+  }
+
+  if (options.exclude) {
+    // Workaround for bug in react-hook-form-persist package
+    // package will still read from and save exclude param
+    // so need to send inputs we actually want to read from in include param instead
+    const { exclude, ...rest } = params
+    const allValues = watch()
+    const include = Object.keys(allValues).filter((key) => {
+      if (!options.exclude?.includes(key)) return key
+    })
+    params = { ...rest, include }
+  }
+
+  useFormPersist(id, { watch, setValue }, params)
+
+  return children
 }
 
-export const Form = <TFormData extends FieldValues>(
-  props: FormProps<TFormData>
-) => {
-  const {
-    children,
-    defaultValues,
-    validationMode = 'onBlur',
-    onSubmit,
-    onError,
-    ...rest
-  } = props
+const FormContent = ({
+  formMethods,
+  handleSubmit,
+  onSubmit,
+  onError,
+  children,
+  ...remainingProps
+}: FormContentProps) => (
+  <FormProvider {...formMethods}>
+    <StyledForm
+      aria-label="form"
+      {...remainingProps}
+      onSubmit={handleSubmit(onSubmit, onError)}
+    >
+      {children}
+    </StyledForm>
+  </FormProvider>
+)
 
-  const methods = useForm<TFormData>({
+export const Form = ({
+  children,
+  defaultValues = {},
+  onSubmit,
+  onError,
+  validationMode = 'onBlur',
+  render,
+  persist,
+  ...remainingProps
+}: FormProps) => {
+  invariant(
+    !(children && render),
+    '`Form` should only be given one of `children` or `render`. When both are provided, `render` will be used and `children` will be ignored.'
+  )
+
+  const formMethods = useForm({
     defaultValues,
     mode: validationMode
   })
+  const { handleSubmit, watch, setValue } = formMethods
 
-  return (
-    <FormProvider {...methods}>
-      <StyledForm
-        aria-label="form"
-        onSubmit={methods.handleSubmit(onSubmit, onError)}
-        {...rest}
-      >
-        {typeof children === 'function' ? children(methods) : children}
-      </StyledForm>
-    </FormProvider>
-  )
+  const formContent = render ? render(formMethods) : children
+
+  const props = {
+    formMethods,
+    handleSubmit,
+    onSubmit,
+    onError,
+    ...remainingProps
+  }
+
+  if (persist) {
+    return (
+      <PersistFormWrapper persist={persist} watch={watch} setValue={setValue}>
+        <FormContent {...props}>{formContent}</FormContent>
+      </PersistFormWrapper>
+    )
+  }
+
+  return <FormContent {...props}>{formContent}</FormContent>
 }
 
 Form.displayName = 'Form'

--- a/lib/src/components/form/Form.types.ts
+++ b/lib/src/components/form/Form.types.ts
@@ -1,0 +1,49 @@
+import type { Mode, UseFormMethods } from 'react-hook-form'
+
+export enum StorageEnum {
+  LOCAL = 'local',
+  SESSION = 'session'
+}
+
+type ExcludeIncludeConfig = {
+  exclude?: string[]
+  include?: string[]
+}
+
+export type PersistOptions = {
+  id: string
+  storage?: StorageEnum
+} & ExcludeIncludeConfig
+
+export type FormPersistParams = {
+  storage: Storage
+} & ExcludeIncludeConfig
+
+export type PersistFormWrapperValues = {
+  persist: PersistOptions
+  watch
+  setValue
+  children: React.ReactNode | any
+}
+
+export type FormContentValues = {
+  formMethods
+  handleSubmit: (
+    submitHandler: (data: any) => void | any,
+    submitErrorHandler?: (errors: any) => void
+  ) => (e: any) => Promise<void>
+  onSubmit: (data: any) => void | any
+  onError?: (errors: any) => void
+  children: React.ReactNode | any
+}
+
+export type FormValues = {
+  defaultValues?: { [key: string]: string | number }
+  onSubmit: (data: any) => void | any
+  onError?: (errors: any) => void
+  validationMode?: Mode
+  persist?: PersistOptions
+} & (
+  | { children: React.ReactNode; render?: never }
+  | { children?: never; render: (methods: UseFormMethods) => React.ReactNode }
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12439,6 +12439,11 @@ react-frame-component@^5.2.1:
   resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.3.tgz#2d5d1e29b23d5b915c839b44980d03bb9cafc453"
   integrity sha512-r+h0o3r/uqOLNT724z4CRVkxQouKJvoi3OPfjqWACD30Y87rtEmeJrNZf1WYPGknn1Y8200HAjx7hY/dPUGgmA==
 
+react-hook-form-persist@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form-persist/-/react-hook-form-persist-2.1.0.tgz#5032756eeae4f7d8cbeb6fd3c93cdeda90d1add8"
+  integrity sha512-qtzNEktLcmGBagHyHNcRvMTrjgasKSyVw/rO2tI+iEFXsfYFJmXJaINvWM+IvxG5ApTIGya7NI5fqo2WJcmiOg==
+
 react-hook-form@^6.15.4:
   version "6.15.8"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.8.tgz#725c139d308c431c4611e4b9d85a49f01cfc0e7a"


### PR DESCRIPTION
After making TS improvements to the Form component, and trying to update atom-core to the latest version with the change, there's some issues when type checking. JS runs out of memory - see https://github.com/Atom-Learning/atom-core/actions/runs/10488702150/job/29057694719?pr=9722

There are plans to update the TS setup for the repo to try and mitigate the issue, but for now we need to revert the changes so no further DS releases are blocked.

 



