### PR TITLE
fix: set the package registry

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -223,5 +223,8 @@
         }
       ]
     ]
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
When we switched to `semantic-release-yarn` the default package registry was set to the yarn registry, this reverts that change.