### PR TITLE
fix: build lib types on the main build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "dev:lib": "cd lib && yarn build:proptypes && yarn dev",
-    "build:lib": "cd lib && yarn build:proptypes && yarn build:lib",
+    "build:lib": "cd lib && yarn build:proptypes && yarn build:lib && yarn build:types",
     "test:lib": "cd lib && yarn test",
     "server:docs": "npx netlify-cms-proxy-server",
     "dev:docs": "cd documentation && yarn provision && yarn dev",


### PR DESCRIPTION
When building the the documentation site with the new NextJS version it failed typechecks, because the types for the library weren't built with the `build:lib` command.