### PR TITLE
feat: focusVisibleStyleBlock allow boxShadow to be passed in

### DIFF
--- a/lib/src/utilities/style/focus-visible-style-block.ts
+++ b/lib/src/utilities/style/focus-visible-style-block.ts
@@ -5,6 +5,7 @@
 type focusVisibleStyleBlockPropsType = {
   position?: 'relative' | 'absolute' | 'fixed' | 'sticky'
   zIndex?: number
+  boxShadow?: string
 }
 
 type focusVisibleStyleBlockReturnType = {
@@ -16,7 +17,8 @@ type focusVisibleStyleBlockReturnType = {
 
 export const focusVisibleStyleBlock = ({
   position = 'relative',
-  zIndex = 1
+  zIndex = 1,
+  boxShadow = ''
 }: focusVisibleStyleBlockPropsType = {}): focusVisibleStyleBlockReturnType => {
   return {
     outline: 'none',
@@ -24,6 +26,6 @@ export const focusVisibleStyleBlock = ({
       ? position
       : 'relative',
     zIndex: zIndex > 1 ? zIndex : 1,
-    boxShadow: 'white 0px 0px 0px 2px, $colors$primary800 0px 0px 0px 4px'
+    boxShadow: `white 0px 0px 0px 2px, $colors$primary800 0px 0px 0px 4px${boxShadow ? `, ${boxShadow}` : ''}`
   }
 }


### PR DESCRIPTION
Adds option to pass in `boxShadow` to the `focusVisibleStyleBlock` css generator.

This was needed for the `Answer` component's border, which is coded with boxShadow so as to not change the answer size onSelect. (see video)

https://github.com/user-attachments/assets/894cb941-5a03-4974-ab55-5224d03576f1


Required for PR: https://github.com/Atom-Learning/components/pull/703

