### PR TITLE
fix: classname placement on Input

### DIFF
--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -58,10 +58,9 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -746,13 +745,12 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ihDGYkC-css {
+  .c-dhzjXW-ieyRoAv-css {
     position: relative;
-    height: max-content;
     margin-bottom: var(--space-4);
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -858,9 +856,8 @@ exports[`DataTable EmptyState renders custom empty state 1`] = `
     stroke-width: 3;
   }
 
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
   .c-oUmPa-igyKUXm-css {
@@ -990,10 +987,9 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -1396,13 +1392,12 @@ exports[`DataTable component Renders drag handles for draggable table rows 1`] =
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ihDGYkC-css {
+  .c-dhzjXW-ieyRoAv-css {
     position: relative;
-    height: max-content;
     margin-bottom: var(--space-4);
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -2837,10 +2832,9 @@ exports[`DataTable component renders 1`] = `
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -3153,13 +3147,12 @@ exports[`DataTable component renders 1`] = `
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ihDGYkC-css {
+  .c-dhzjXW-ieyRoAv-css {
     position: relative;
-    height: max-content;
     margin-bottom: var(--space-4);
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -3195,18 +3188,14 @@ exports[`DataTable component renders 1`] = `
     User search
   </label>
   <div
-    class="c-PJLV c-PJLV-ihDGYkC-css"
+    class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-ieyRoAv-css"
   >
-    <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
-    >
-      <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-        name="User search"
-        type="search"
-        value=""
-      />
-    </div>
+    <input
+      class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+      name="User search"
+      type="search"
+      value=""
+    />
     <svg
       aria-hidden="true"
       class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-md c-hvMhuR-icDTsBU-css"
@@ -3979,10 +3968,9 @@ exports[`DataTable server-side renders 1`] = `
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -4631,13 +4619,12 @@ exports[`DataTable server-side renders 1`] = `
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ihDGYkC-css {
+  .c-dhzjXW-ieyRoAv-css {
     position: relative;
-    height: max-content;
     margin-bottom: var(--space-4);
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -4743,9 +4730,8 @@ exports[`DataTable server-side renders 1`] = `
     stroke-width: 3;
   }
 
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
   .c-oUmPa-igyKUXm-css {
@@ -4772,17 +4758,13 @@ exports[`DataTable server-side renders 1`] = `
     class="c-cVSpVL c-cVSpVL-gvmVBy-size-md c-cVSpVL-grKRUr-type-block c-cVSpVL-ihbtntv-css"
   />
   <div
-    class="c-PJLV c-PJLV-ieFlhpX-css"
+    class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-icmpvrW-css"
   >
-    <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
-    >
-      <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-        type="search"
-        value=""
-      />
-    </div>
+    <input
+      class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+      type="search"
+      value=""
+    />
     <svg
       aria-hidden="true"
       class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-md c-hvMhuR-icDTsBU-css"
@@ -5232,10 +5214,9 @@ exports[`DataTable sticky columns renders 1`] = `
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -5814,13 +5795,12 @@ exports[`DataTable sticky columns renders 1`] = `
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ihDGYkC-css {
+  .c-dhzjXW-ieyRoAv-css {
     position: relative;
-    height: max-content;
     margin-bottom: var(--space-4);
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -5926,9 +5906,8 @@ exports[`DataTable sticky columns renders 1`] = `
     stroke-width: 3;
   }
 
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
   .c-oUmPa-igyKUXm-css {

--- a/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
+++ b/lib/src/components/data-table/__snapshots__/DataTable.test.tsx.snap
@@ -3198,10 +3198,10 @@ exports[`DataTable component renders 1`] = `
     class="c-PJLV c-PJLV-ihDGYkC-css"
   >
     <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md"
+      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
     >
       <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
         name="User search"
         type="search"
         value=""
@@ -4775,10 +4775,10 @@ exports[`DataTable server-side renders 1`] = `
     class="c-PJLV c-PJLV-ieFlhpX-css"
   >
     <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md"
+      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
     >
       <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
         type="search"
         value=""
       />

--- a/lib/src/components/input/Input.tsx
+++ b/lib/src/components/input/Input.tsx
@@ -114,9 +114,9 @@ export type InputProps = Omit<
 }
 
 export const Input: React.ForwardRefExoticComponent<InputProps> =
-  React.forwardRef(({ size = 'md', state, disabled, css, ...rest }, ref) => {
+  React.forwardRef(({ className, size = 'md', state, disabled, css, ...rest }, ref) => {
     return (
-      <InputBackground size={size} disabled={disabled} state={state} css={css}>
+      <InputBackground size={size} disabled={disabled} state={state} css={css} className={className}>
         <InputText size={size} ref={ref} disabled={disabled} {...rest} />
       </InputBackground>
     )

--- a/lib/src/components/search-field/__snapshots__/SearchField.test.tsx.snap
+++ b/lib/src/components/search-field/__snapshots__/SearchField.test.tsx.snap
@@ -58,10 +58,9 @@ exports[`SearchField component renders a field in error state - has no programma
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -144,15 +143,6 @@ exports[`SearchField component renders a field in error state - has no programma
     width: 20px;
   }
 
-  .c-kOvGWL-kRqBPT-disabled-true {
-    opacity: 0.3;
-    cursor: not-allowed;
-  }
-
-  .c-kOvGWL-iuasYV-state-error {
-    border-color: var(--colors-danger);
-  }
-
   .c-PJLV-iymbh-theme-error {
     color: var(--colors-danger);
   }
@@ -188,12 +178,11 @@ exports[`SearchField component renders a field in error state - has no programma
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -241,21 +230,18 @@ exports[`SearchField component renders a field in error state - has no programma
         </label>
       </div>
       <div
-        class="c-PJLV c-PJLV-ieFlhpX-css"
+        class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-icmpvrW-css"
       >
-        <div
-          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-kOvGWL-iuasYV-state-error c-cNcGUX c-cNcGUX-icRYcAH-css"
-        >
-          <input
-            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-            id="searchField"
-            llabel="Search Field"
-            name="searchField"
-            placeholder="Search Field"
-            type="search"
-            value=""
-          />
-        </div>
+        <input
+          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+          id="searchField"
+          llabel="Search Field"
+          name="searchField"
+          placeholder="Search Field"
+          state="error"
+          type="search"
+          value=""
+        />
         <svg
           aria-hidden="true"
           class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-md c-hvMhuR-icDTsBU-css"
@@ -370,10 +356,9 @@ exports[`SearchField component renders a field with a disabled input - has no pr
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -449,11 +434,6 @@ exports[`SearchField component renders a field with a disabled input - has no pr
     height: 20px;
     width: 20px;
   }
-
-  .c-kOvGWL-kRqBPT-disabled-true {
-    opacity: 0.3;
-    cursor: not-allowed;
-  }
 }
 
 @media  {
@@ -463,12 +443,11 @@ exports[`SearchField component renders a field with a disabled input - has no pr
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -499,21 +478,17 @@ exports[`SearchField component renders a field with a disabled input - has no pr
         </label>
       </div>
       <div
-        class="c-PJLV c-PJLV-ieFlhpX-css"
+        class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-icmpvrW-css"
       >
-        <div
-          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-kOvGWL-kRqBPT-disabled-true c-cNcGUX c-cNcGUX-icRYcAH-css"
-        >
-          <input
-            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-            disabled=""
-            id="searchField"
-            name="searchField"
-            placeholder="Search Field"
-            type="search"
-            value=""
-          />
-        </div>
+        <input
+          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+          disabled=""
+          id="searchField"
+          name="searchField"
+          placeholder="Search Field"
+          type="search"
+          value=""
+        />
         <svg
           aria-hidden="true"
           class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-md c-hvMhuR-icDTsBU-css"
@@ -593,10 +568,9 @@ exports[`SearchField component renders a field with a search input - has no prog
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -681,12 +655,11 @@ exports[`SearchField component renders a field with a search input - has no prog
     margin-bottom: var(--space-3);
   }
 
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -717,20 +690,16 @@ exports[`SearchField component renders a field with a search input - has no prog
         </label>
       </div>
       <div
-        class="c-PJLV c-PJLV-ieFlhpX-css"
+        class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-icmpvrW-css"
       >
-        <div
-          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
-        >
-          <input
-            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-            id="searchField"
-            name="searchField"
-            placeholder="Search Field"
-            type="search"
-            value=""
-          />
-        </div>
+        <input
+          class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+          id="searchField"
+          name="searchField"
+          placeholder="Search Field"
+          type="search"
+          value=""
+        />
         <svg
           aria-hidden="true"
           class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-md c-hvMhuR-icDTsBU-css"

--- a/lib/src/components/search-field/__snapshots__/SearchField.test.tsx.snap
+++ b/lib/src/components/search-field/__snapshots__/SearchField.test.tsx.snap
@@ -244,10 +244,10 @@ exports[`SearchField component renders a field in error state - has no programma
         class="c-PJLV c-PJLV-ieFlhpX-css"
       >
         <div
-          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-kOvGWL-iuasYV-state-error"
+          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-kOvGWL-iuasYV-state-error c-cNcGUX c-cNcGUX-icRYcAH-css"
         >
           <input
-            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
             id="searchField"
             llabel="Search Field"
             name="searchField"
@@ -502,10 +502,10 @@ exports[`SearchField component renders a field with a disabled input - has no pr
         class="c-PJLV c-PJLV-ieFlhpX-css"
       >
         <div
-          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-kOvGWL-kRqBPT-disabled-true"
+          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-kOvGWL-kRqBPT-disabled-true c-cNcGUX c-cNcGUX-icRYcAH-css"
         >
           <input
-            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
             disabled=""
             id="searchField"
             name="searchField"
@@ -720,10 +720,10 @@ exports[`SearchField component renders a field with a search input - has no prog
         class="c-PJLV c-PJLV-ieFlhpX-css"
       >
         <div
-          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md"
+          class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
         >
           <input
-            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+            class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
             id="searchField"
             name="searchField"
             placeholder="Search Field"

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -2,7 +2,6 @@ import { Close, Search } from '@atom-learning/icons'
 import * as React from 'react'
 
 import { ActionIcon } from '~/components/action-icon'
-import { Box } from '~/components/box/'
 import { Icon } from '~/components/icon/'
 import { Input, InputBackground, InputText } from '~/components/input/'
 import { CSS, styled } from '~/stitches'

--- a/lib/src/components/search-input/SearchInput.tsx
+++ b/lib/src/components/search-input/SearchInput.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { ActionIcon } from '~/components/action-icon'
 import { Box } from '~/components/box/'
 import { Icon } from '~/components/icon/'
-import { Input } from '~/components/input/'
+import { Input, InputBackground, InputText } from '~/components/input/'
 import { CSS, styled } from '~/stitches'
 import { getFieldIconSize } from '~/utilities'
 import { useCallbackRef } from '~/utilities/hooks/useCallbackRef'
@@ -46,11 +46,12 @@ const StyledIcon = styled(Icon, {
   }
 })
 
-const StyledSearchInput = styled(Input, {
-  '&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, & input[type="search"]::-webkit-search-results-decoration':
-    {
-      display: 'none'
-    }
+
+const StyledSearchInputText = styled(InputText, {
+  '&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button':
+  {
+    display: 'none'
+  }
 })
 
 export const SearchInput: React.ForwardRefExoticComponent<SearchInputProps> =
@@ -146,8 +147,11 @@ export const SearchInput: React.ForwardRefExoticComponent<SearchInputProps> =
       }
 
       return (
-        <Box css={{ position: 'relative', height: 'max-content', ...css }}>
-          <StyledSearchInput
+        <InputBackground css={{ position: 'relative', ...css }}
+          size={size}
+
+        >
+          <StyledSearchInputText
             ref={setInputElRef}
             size={size}
             type="search"
@@ -157,7 +161,7 @@ export const SearchInput: React.ForwardRefExoticComponent<SearchInputProps> =
             css={{ pr: size === 'sm' ? '$5' : '$6' }}
           />
           {getIcon()}
-        </Box>
+        </InputBackground>
       )
     }
   )

--- a/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -52,10 +52,9 @@ exports[`SearchInput component renders 1`] = `
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -112,12 +111,11 @@ exports[`SearchInput component renders 1`] = `
 }
 
 @media  {
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -131,17 +129,13 @@ exports[`SearchInput component renders 1`] = `
 
 <div>
   <div
-    class="c-PJLV c-PJLV-ieFlhpX-css"
+    class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-icmpvrW-css"
   >
-    <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
-    >
-      <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-        type="search"
-        value=""
-      />
-    </div>
+    <input
+      class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+      type="search"
+      value=""
+    />
     <svg
       aria-hidden="true"
       class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-md c-hvMhuR-icDTsBU-css"
@@ -213,10 +207,9 @@ exports[`SearchInput component renders clear button when non-empty defaultValue 
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -367,12 +360,11 @@ exports[`SearchInput component renders clear button when non-empty defaultValue 
 }
 
 @media  {
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -393,17 +385,13 @@ exports[`SearchInput component renders clear button when non-empty defaultValue 
 
 <div>
   <div
-    class="c-PJLV c-PJLV-ieFlhpX-css"
+    class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-dhzjXW-icmpvrW-css"
   >
-    <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
-    >
-      <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-        type="search"
-        value="testingWhenDefaultValue"
-      />
-    </div>
+    <input
+      class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+      type="search"
+      value="testingWhenDefaultValue"
+    />
     <button
       aria-label="clearWhenDefaultValue"
       class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-jCxibG-cv c-oUmPa-igyKUXm-css c-PJLV"
@@ -477,10 +465,9 @@ exports[`SearchInput component renders lg size 1`] = `
     width: 100%;
   }
 
-  .c-cNcGUX::-webkit-search-decoration,
-  .c-cNcGUX::-webkit-search-cancel-button,
-  .c-cNcGUX::-webkit-search-results-button,
-  .c-cNcGUX input[type="search"]::-webkit-search-results-decoration {
+  .c-YEzsq::-webkit-search-decoration,
+  .c-YEzsq::-webkit-search-cancel-button,
+  .c-YEzsq::-webkit-search-results-button {
     display: none;
   }
 
@@ -625,12 +612,11 @@ exports[`SearchInput component renders lg size 1`] = `
 }
 
 @media  {
-  .c-PJLV-ieFlhpX-css {
+  .c-dhzjXW-icmpvrW-css {
     position: relative;
-    height: max-content;
   }
 
-  .c-cNcGUX-icRYcAH-css {
+  .c-YEzsq-icRYcAH-css {
     padding-right: var(--space-6);
   }
 
@@ -651,17 +637,13 @@ exports[`SearchInput component renders lg size 1`] = `
 
 <div>
   <div
-    class="c-PJLV c-PJLV-ieFlhpX-css"
+    class="c-dhzjXW c-kOvGWL c-kOvGWL-hSbHZR-size-lg c-dhzjXW-icmpvrW-css"
   >
-    <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-hSbHZR-size-lg c-cNcGUX c-cNcGUX-icRYcAH-css"
-    >
-      <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
-        type="search"
-        value=""
-      />
-    </div>
+    <input
+      class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-YEzsq c-YEzsq-icRYcAH-css"
+      type="search"
+      value=""
+    />
     <svg
       aria-hidden="true"
       class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hvMhuR c-hvMhuR-koUlob-size-lg c-hvMhuR-icDTsBU-css"

--- a/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/lib/src/components/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -134,10 +134,10 @@ exports[`SearchInput component renders 1`] = `
     class="c-PJLV c-PJLV-ieFlhpX-css"
   >
     <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md"
+      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
     >
       <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
         type="search"
         value=""
       />
@@ -396,10 +396,10 @@ exports[`SearchInput component renders clear button when non-empty defaultValue 
     class="c-PJLV c-PJLV-ieFlhpX-css"
   >
     <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md"
+      class="c-dhzjXW c-kOvGWL c-kOvGWL-dNqCDY-size-md c-cNcGUX c-cNcGUX-icRYcAH-css"
     >
       <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
         type="search"
         value="testingWhenDefaultValue"
       />
@@ -654,10 +654,10 @@ exports[`SearchInput component renders lg size 1`] = `
     class="c-PJLV c-PJLV-ieFlhpX-css"
   >
     <div
-      class="c-dhzjXW c-kOvGWL c-kOvGWL-hSbHZR-size-lg"
+      class="c-dhzjXW c-kOvGWL c-kOvGWL-hSbHZR-size-lg c-cNcGUX c-cNcGUX-icRYcAH-css"
     >
       <input
-        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd c-cNcGUX c-cNcGUX-icRYcAH-css"
+        class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-foJWJd"
         type="search"
         value=""
       />


### PR DESCRIPTION
`className`s passed into `Input` were being added to `InputText` (the field) and not the wrapping `InputBackground`.
This is a problem when it comes to adding spacing or handling sizing either with `styled` or `css` from the parent as it skips a div.

Placement on the `InputBackground` which is the outer element should be more correct.

The `SearchInput` component was affected by this change, with the area where the icon is placed not being clickable anymore (click through to input for edit). This was amended via slight restructuring and now the component should have no visual or functional changes. ( https://github.com/Atom-Learning/components/pull/702/commits/4a5f1ca0ec175413f2b9d53a968338ca32fd5f25 )

This work is required for PR: https://github.com/Atom-Learning/components/pull/703