### PR TITLE
Feat/export radix overrides

### DIFF
--- a/lib/src/components/answer-toggle-group/Answer.tsx
+++ b/lib/src/components/answer-toggle-group/Answer.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+
+import { Flex } from '~/components/flex'
+import { styled } from '~/stitches'
+
+import { focusVisibleStyleBlock } from '../../utilities'
+import { AnswerFeedbackIcon } from './AnswerFeedbackIcon'
+import { colorSchemes as answerColorSchemesTheme, colorSchemesState as answerColorSchemesState } from './stitches.answer.colorscheme.config'
+
+export const StyledRoot = styled(Flex, {
+  position: 'relative',
+  p: '$3',
+  boxShadow: 'inset $colors$border 0px 0px 0px 1px',
+  border: 'none',
+  borderRadius: '$2',
+  maxWidth: '100%',
+  minHeight: '$5',
+  color: '$text',
+  bg: '$background',
+  '&[disabled]': {
+    pointerEvents: 'none'
+  },
+  '&:not([disabled])': {
+    cursor: 'pointer',
+    '&:focus-visible': {
+      ...focusVisibleStyleBlock({ boxShadow: 'inset $colors$border 0px 0px 0px 1px' })
+    },
+    '&:hover': {
+      color: '$textHover',
+      bg: '$backgroundHover',
+      boxShadow: 'inset $colors$borderHover 0px 0px 0px 1px',
+
+    },
+    '&:active': {
+      color: '$textPressed',
+      bg: '$backgroundPressed',
+      boxShadow: 'inset $colors$borderPressed 0px 0px 0px 1px',
+    }
+  },
+  '&[data-state="on"]': {
+    boxShadow: 'inset $colors$borderSelected 0px 0px 0px 4px',
+    color: '$textSelected',
+    bg: '$backgroundSelected',
+    '&:not([disabled])': {
+      '&:hover': {
+        color: '$textSelectedHover',
+        bg: '$backgroundSelectedHover',
+        boxShadow: 'inset $colors$borderSelected 0px 0px 0px 4px',
+      },
+      '&:active': {
+        color: '$textSelectedPressed',
+        bg: '$backgroundSelectedPressed',
+        boxShadow: 'inset $colors$borderSelected 0px 0px 0px 4px',
+      },
+      '&:focus-visible': {
+        ...focusVisibleStyleBlock({ boxShadow: 'inset $colors$borderSelected 0px 0px 0px 4px' })
+      },
+    }
+  }
+})
+
+export type AnswerProps = React.ComponentProps<typeof StyledRoot> & {
+  state?: keyof typeof answerColorSchemesState
+  theme?: keyof typeof answerColorSchemesTheme
+}
+
+export const Answer: React.ForwardRefExoticComponent<AnswerProps> =
+  React.forwardRef(({ state, theme = 'default', className = '', children, ...rest }, ref) => {
+    const colorSchemeClassName = state ? answerColorSchemesState[state] : answerColorSchemesTheme[theme]
+
+    return (
+      <StyledRoot
+        gap={3}
+        ref={ref}
+        align="center"
+        {...rest}
+        className={`${colorSchemeClassName} ${className}`}
+      >
+        <AnswerFeedbackIcon state={state} />
+        {children}
+      </StyledRoot>
+    )
+  })
+
+Answer.displayName = 'Answer'

--- a/lib/src/components/answer-toggle-group/AnswerFeedbackIcon.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerFeedbackIcon.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+
+import { Icon } from '~/components/icon'
+import { styled } from '~/stitches'
+
+import { Cancel, OkCircle, NotAllowed } from '@atom-learning/icons'
+
+const StyledIcon = styled(Icon, {
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  transform: 'translateX(50%) translateY(-50%)',
+  color: '$feedbackIcon',
+  bg: '$feedbackIconBackground',
+  borderRadius: '$round',
+  border: '1px solid $feedbackIconBackground'
+})
+
+const stateToIconMap = {
+  incorrect: Cancel,
+  correct: OkCircle,
+  skipped: NotAllowed
+}
+
+export const AnswerFeedbackIcon = ({ state, ...rest }: Omit<React.ComponentProps<typeof Icon>, 'is'> & {
+  state?: keyof typeof stateToIconMap
+}) => {
+  const iconSVG = state && stateToIconMap[state]
+  if (!iconSVG) return null
+  return (
+    <StyledIcon
+      role="img"
+      aria-label={state}
+      aria-hidden={false}
+      is={iconSVG}
+      {...rest}
+    />
+  )
+}
+
+AnswerFeedbackIcon.displayName = 'AnswerFeedbackIcon'

--- a/lib/src/components/answer-toggle-group/AnswerGroup.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerGroup.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+import { Flex } from '~/components/flex'
+
+type AnswerToggleGroupRootProps = React.ComponentProps<typeof Flex>
+
+export const AnswerGroup: React.ForwardRefExoticComponent<AnswerToggleGroupRootProps> =
+  React.forwardRef((props, ref) => {
+    return (
+      <Flex
+        ref={ref}
+        direction="row"
+        wrap="wrap"
+        gap={3}
+        align="center"
+        {...props}
+      />
+    )
+  })

--- a/lib/src/components/answer-toggle-group/AnswerIdentifier.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerIdentifier.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+
+import { KeyboardShortcut } from '~/components/keyboard-shortcut'
+import { styled } from '~/stitches'
+
+
+const StyledAnswerIdentifier = styled(KeyboardShortcut.Indicator, {
+  bg: '$identifierBackground',
+  color: '$identifierText',
+  '[data-state="on"] &': {
+    bg: '$identifierSelectedBackground',
+    color: '$identifierSelectedText',
+  }
+})
+
+export const AnswerIdentifier = (props: React.ComponentProps<typeof KeyboardShortcut.Indicator>) => {
+  return <StyledAnswerIdentifier size="sm" {...props} />
+}
+
+AnswerIdentifier.displayName = 'AnswerIdentifier'

--- a/lib/src/components/answer-toggle-group/AnswerToggleGroup.context.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerToggleGroup.context.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+
+import { ToggleGroup } from '~/utilities/radix-overrides/toggle-group'
+
+
+type AnswerToggleGroupProviderProps = React.ComponentProps<typeof ToggleGroup.Root>
+
+type AnswerToggleGroupContextValue = Pick<AnswerToggleGroupProviderProps, 'value' | 'type'> & {
+  setValue: ((newValue: string) => void) & ((newValue: string[]) => void)
+}
+
+export const AnswerToggleGroupContext = React.createContext<AnswerToggleGroupContextValue>({
+  type: 'single',
+  value: '',
+  setValue: () => null
+})
+
+export const AnswerToggleGroupProvider = ({
+  type,
+  defaultValue,
+  value,
+  onValueChange,
+  children
+}: React.PropsWithChildren<AnswerToggleGroupProviderProps>) => {
+  const [internalValue, setInternalValue] = React.useState(defaultValue || (type === 'single' ? '' : []))
+  const handleValueChange = React.useCallback((newValue: string & string[]) => {
+    setInternalValue(newValue)
+    onValueChange?.(newValue)
+  }, [onValueChange])
+
+  React.useEffect(() => { if (value) setInternalValue(value) }, [value])
+
+  const contextValue = React.useMemo<AnswerToggleGroupContextValue>(
+    () => ({ type, value: internalValue, setValue: handleValueChange }),
+    [type, internalValue, handleValueChange]
+  )
+  return <AnswerToggleGroupContext.Provider value={contextValue}>{children}</AnswerToggleGroupContext.Provider>
+}

--- a/lib/src/components/answer-toggle-group/AnswerToggleGroup.test.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerToggleGroup.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import * as React from 'react'
+
+import { AnswerToggleGroup } from '.'
+
+const AnswerToggleGroupImplementation = () => (
+  <AnswerToggleGroup
+    type="multiple"
+    defaultValue={['a', 'b']}
+    onValueChange={(value) => {
+      console.log(value)
+    }}
+  >
+    <AnswerToggleGroup.Item value="a" theme="quest">A</AnswerToggleGroup.Item>
+    <AnswerToggleGroup.Item value="b" state="correct" theme="quest" disabled>
+      B
+    </AnswerToggleGroup.Item>
+    <AnswerToggleGroup.Item value="c" state="incorrect">C</AnswerToggleGroup.Item>
+    <AnswerToggleGroup.Item value="d" state="skipped" disabled>
+      D
+    </AnswerToggleGroup.Item>
+  </AnswerToggleGroup>
+)
+
+describe('AnswerToggleGroup component', () => {
+  it('renders', async () => {
+    const { container } = render(<AnswerToggleGroupImplementation />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('has no programmatically detectable a11y issues', async () => {
+    const { container } = render(<AnswerToggleGroupImplementation />)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/lib/src/components/answer-toggle-group/AnswerToggleGroupItem.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerToggleGroupItem.tsx
@@ -1,0 +1,27 @@
+import * as ToggleGroup from '@radix-ui/react-toggle-group'
+import * as React from 'react'
+
+import { Answer } from './Answer'
+
+type AnswerToggleGroupItemProps = React.ComponentProps<typeof ToggleGroup.Item> &
+  React.ComponentProps<typeof Answer>
+
+export const AnswerToggleGroupItem = React.forwardRef(({
+  children,
+  value,
+  disabled,
+  ...rest
+}: AnswerToggleGroupItemProps, ref: React.ForwardedRef<HTMLButtonElement | null>) => {
+
+  return (
+    <ToggleGroup.Item {...rest} value={value} disabled={disabled} ref={ref} asChild>
+      <Answer
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: Stitches polymorphic components issue due to `as="button"`
+        as="button"
+      >
+        {children}
+      </Answer>
+    </ToggleGroup.Item>
+  )
+})

--- a/lib/src/components/answer-toggle-group/AnswerToggleGroupItemInput.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerToggleGroupItemInput.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react'
+
+import { Box } from '~/components/box'
+import { Input } from '~/components/input'
+import { styled } from '~/stitches'
+import { useCallbackRefState } from '~/utilities/hooks/useCallbackRef'
+import { useResizeObserver } from '~/utilities/hooks/useResizeObserver'
+
+import { AnswerToggleGroupContext } from './AnswerToggleGroup.context'
+import { AnswerToggleGroupItem } from './AnswerToggleGroupItem'
+
+type AnswerToggleGroupItemInputProps = React.ComponentProps<typeof AnswerToggleGroupItem> & { label: string }
+
+const StyledContainer = styled(Box, {
+  position: 'relative'
+})
+
+const StyledInput = styled(Input, {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  zIndex: 1,
+})
+
+const StyledAnswerToggleGroupItem = styled(AnswerToggleGroupItem, {
+  py: '$0'
+})
+
+const stopPropagation = (e) => {
+  e.stopPropagation()
+  e.nativeEvent.stopPropagation()
+  e.nativeEvent.stopImmediatePropagation()
+}
+
+export const AnswerToggleGroupItemInput = ({
+  className,
+  children,
+  value: defaultValue,
+  disabled,
+  label,
+  ...rest
+}: AnswerToggleGroupItemInputProps) => {
+
+  // Placement: Place Input element over the Input placeholder
+  const [inputElRef, setInputElRef] = useCallbackRefState()
+  const [inputPlaceholderElRef, setInputPlaceholderElRef] = useCallbackRefState()
+  const [inputCSS, setInputCSS] = React.useState<Partial<CSSRuleList>>()
+  useResizeObserver({
+    delay: 100,
+    elements: [inputPlaceholderElRef],
+    onResize: () => {
+      setInputCSS((currInputCSS) => {
+        const newInputCSS = {
+          top: inputPlaceholderElRef?.offsetTop,
+          left: inputPlaceholderElRef?.offsetLeft,
+          width: inputPlaceholderElRef?.clientWidth
+        }
+        if (JSON.stringify(currInputCSS) === JSON.stringify(newInputCSS)) return currInputCSS // Not changed.
+        return newInputCSS
+      })
+    }
+  })
+
+  // Value: Update value of Toggle item on Input blur
+  const [value, setValue] = React.useState(defaultValue)
+  const { value: toggleGroupValue, setValue: setToggleGroupValue, type } = React.useContext(AnswerToggleGroupContext)
+  const handleUpdateValue: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    stopPropagation(e)
+    const newValue = e.target.value || defaultValue
+    setValue((currValue) => {
+
+      if (type === 'multiple') {
+        const newToggleGroupValue = [...toggleGroupValue as string[]]
+
+        const currValueToggleGroupIndex = newToggleGroupValue?.indexOf(currValue)
+        if (currValueToggleGroupIndex === -1) {
+          // Just append
+          newToggleGroupValue.push(newValue)
+          setToggleGroupValue(newToggleGroupValue)
+        } else {
+          // Replace
+          newToggleGroupValue[currValueToggleGroupIndex] = newValue
+          setToggleGroupValue(newToggleGroupValue)
+        }
+      }
+
+      if (type === 'single') {
+        setToggleGroupValue(newValue)
+      }
+
+      return newValue
+    })
+  }
+
+  // Focus management: Focus Input on Toggle select
+  const isSelectedRef = React.useRef(false)
+  const isSelected = !!toggleGroupValue?.includes(value)
+  if (!isSelectedRef.current && isSelected) {
+    inputElRef?.focus()
+  }
+  isSelectedRef.current = isSelected
+
+  // Focus management: Focus Toggle on Input ESC
+  const [toggleGroupItemElRef, setToggleGroupItemElRef] = useCallbackRefState()
+  const handleInputKeydown = React.useCallback((e) => {
+    stopPropagation(e)
+    if (e.key === 'Escape') toggleGroupItemElRef?.focus()
+  }, [toggleGroupItemElRef])
+
+  return (
+    <StyledContainer className={className}>
+      <StyledAnswerToggleGroupItem {...rest} ref={setToggleGroupItemElRef} value={value} disabled={disabled}>
+        {children}
+        <Box // Input placeholder
+          ref={setInputPlaceholderElRef}
+          css={{
+            width: '300px',
+            maxWidth: '100%',
+            height: inputElRef?.clientHeight
+          }}
+        />
+      </StyledAnswerToggleGroupItem>
+      <StyledInput
+        onBlur={handleUpdateValue}
+        onKeyDown={handleInputKeydown}
+        onKeyUp={stopPropagation}
+        ref={setInputElRef}
+        css={inputCSS}
+        disabled={disabled}
+        aria-label={label}
+        size="sm"
+        tabIndex={-1}
+      />
+    </StyledContainer>
+  )
+}

--- a/lib/src/components/answer-toggle-group/AnswerToggleGroupRoot.tsx
+++ b/lib/src/components/answer-toggle-group/AnswerToggleGroupRoot.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+
+import { ToggleGroup } from '~/utilities/radix-overrides/toggle-group'
+
+import { AnswerGroup } from './AnswerGroup'
+import { AnswerToggleGroupContext, AnswerToggleGroupProvider } from './AnswerToggleGroup.context'
+
+type AnswerToggleGroupRootProps = React.ComponentProps<typeof AnswerGroup> &
+  React.ComponentProps<typeof ToggleGroup.Root>
+
+export const AnswerToggleGroupRootInternal: React.ForwardRefExoticComponent<AnswerToggleGroupRootProps> =
+  React.forwardRef((props, ref) => {
+    const { value, setValue } = React.useContext(AnswerToggleGroupContext)
+
+    return (
+      <AnswerGroup
+        ref={ref}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: Stitches polymorphic components issue due to `as={ToggleGroup.Root}`
+        as={ToggleGroup.Root}
+        orientation="horizontal"
+        onValueChange={setValue}
+        value={value}
+        {...props}
+      />
+    )
+  })
+
+export const AnswerToggleGroupRoot: React.ForwardRefExoticComponent<AnswerToggleGroupRootProps> =
+  React.forwardRef(({ type, value, defaultValue, onValueChange, ...rest }, ref) => {
+    return (
+      // eslint-disable-next-line
+      // @ts-ignore Radix types complain on properties depending on whether `type="single"` or `"multiple"`. Works correctly so muting.
+      <AnswerToggleGroupProvider type={type} value={value} defaultValue={defaultValue} onValueChange={onValueChange}>
+        <AnswerToggleGroupRootInternal type={type} ref={ref} {...rest} />
+      </AnswerToggleGroupProvider>
+    )
+  })

--- a/lib/src/components/answer-toggle-group/__snapshots__/AnswerToggleGroup.test.tsx.snap
+++ b/lib/src/components/answer-toggle-group/__snapshots__/AnswerToggleGroup.test.tsx.snap
@@ -1,0 +1,616 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AnswerToggleGroup component renders 1`] = `
+@media  {
+  :root,
+  .t-bgDNai {
+    --default-colors: [object Object];
+    --default-space: [object Object];
+    --default-fontSizes: [object Object];
+    --default-fonts: [object Object];
+    --default-sizes: [object Object];
+    --default-radii: [object Object];
+    --default-shadows: [object Object];
+    --default-ratios: [object Object];
+    --colors-textBold: hsl(0, 0%, 12%);
+    --colors-textRegular: hsl(0, 0%, 20%);
+    --colors-textSubtle: hsl(0, 0%, 33%);
+    --colors-textMinimal: hsl(0, 0%, 46%);
+    --colors-background: hsl(0, 0%, 96%);
+    --colors-backgroundAccent: hsl(215, 100%, 98%);
+    --colors-grey100: hsl(0, 0%, 96%);
+    --colors-grey200: hsl(0, 0%, 92%);
+    --colors-grey300: hsl(0, 0%, 88%);
+    --colors-grey400: hsl(0, 0%, 81%);
+    --colors-grey500: hsl(0, 0%, 73%);
+    --colors-grey600: hsl(0, 0%, 62%);
+    --colors-grey700: hsl(0, 0%, 46%);
+    --colors-grey800: hsl(0, 0%, 33%);
+    --colors-grey900: hsl(0, 0%, 20%);
+    --colors-grey1000: hsl(0, 0%, 12%);
+    --colors-grey1100: hsl(0, 0%, 10%);
+    --colors-grey1200: hsl(0, 0%, 6%);
+    --colors-blue100: hsl(215, 100%, 98%);
+    --colors-blue200: hsl(212, 100%, 95%);
+    --colors-blue300: hsl(211, 100%, 92%);
+    --colors-blue400: hsl(211, 100%, 88%);
+    --colors-blue500: hsl(212, 100%, 80%);
+    --colors-blue600: hsl(213, 100%, 71%);
+    --colors-blue700: hsl(214, 100%, 58%);
+    --colors-blue800: hsl(217, 92%, 51%);
+    --colors-blue900: hsl(223, 78%, 44%);
+    --colors-blue1000: hsl(228, 82%, 35%);
+    --colors-blue1100: hsl(228, 63%, 23%);
+    --colors-blue1200: hsl(227, 57%, 11%);
+    --colors-purple100: hsl(282, 100%, 98%);
+    --colors-purple200: hsl(270, 100%, 95%);
+    --colors-purple300: hsl(271, 100%, 92%);
+    --colors-purple400: hsl(270, 100%, 89%);
+    --colors-purple500: hsl(270, 90%, 81%);
+    --colors-purple600: hsl(271, 97%, 69%);
+    --colors-purple700: hsl(273, 84%, 47%);
+    --colors-purple800: hsl(273, 94%, 48%);
+    --colors-purple900: hsl(268, 79%, 42%);
+    --colors-purple1000: hsl(266, 82%, 32%);
+    --colors-purple1100: hsl(265, 63%, 23%);
+    --colors-purple1200: hsl(265, 61%, 14%);
+    --colors-cyan100: hsl(198, 100%, 97%);
+    --colors-cyan200: hsl(199, 100%, 94%);
+    --colors-cyan300: hsl(201, 100%, 89%);
+    --colors-cyan400: hsl(200, 100%, 84%);
+    --colors-cyan500: hsl(201, 96%, 73%);
+    --colors-cyan600: hsl(202, 85%, 60%);
+    --colors-cyan700: hsl(204, 81%, 46%);
+    --colors-cyan800: hsl(205, 100%, 38%);
+    --colors-cyan900: hsl(206, 100%, 30%);
+    --colors-cyan1000: hsl(205, 100%, 21%);
+    --colors-cyan1100: hsl(206, 97%, 15%);
+    --colors-cyan1200: hsl(207, 73%, 9%);
+    --colors-green100: hsl(135, 80%, 96%);
+    --colors-green200: hsl(135, 72%, 92%);
+    --colors-green300: hsl(135, 68%, 83%);
+    --colors-green400: hsl(135, 65%, 76%);
+    --colors-green500: hsl(136, 56%, 62%);
+    --colors-green600: hsl(137, 42%, 49%);
+    --colors-green700: hsl(138, 51%, 35%);
+    --colors-green800: hsl(138, 68%, 29%);
+    --colors-green900: hsl(138, 74%, 21%);
+    --colors-green1000: hsl(138, 89%, 14%);
+    --colors-green1100: hsl(135, 91%, 9%);
+    --colors-green1200: hsl(123, 56%, 6%);
+    --colors-magenta100: hsl(330, 100%, 99%);
+    --colors-magenta200: hsl(329, 100%, 96%);
+    --colors-magenta300: hsl(332, 100%, 92%);
+    --colors-magenta400: hsl(333, 100%, 90%);
+    --colors-magenta500: hsl(333, 90%, 80%);
+    --colors-magenta600: hsl(333, 87%, 72%);
+    --colors-magenta700: hsl(333, 75%, 59%);
+    --colors-magenta800: hsl(333, 69%, 49%);
+    --colors-magenta900: hsl(333, 74%, 36%);
+    --colors-magenta1000: hsl(333, 86%, 25%);
+    --colors-magenta1100: hsl(333, 95%, 16%);
+    --colors-magenta1200: hsl(334, 62%, 10%);
+    --colors-red100: hsl(0, 100%, 99%);
+    --colors-red200: hsl(0, 100%, 96%);
+    --colors-red300: hsl(357, 100%, 93%);
+    --colors-red400: hsl(356, 100%, 90%);
+    --colors-red500: hsl(356, 96%, 83%);
+    --colors-red600: hsl(357, 90%, 73%);
+    --colors-red700: hsl(357, 80%, 59%);
+    --colors-red800: hsl(357, 76%, 49%);
+    --colors-red900: hsl(357, 73%, 37%);
+    --colors-red1000: hsl(357, 79%, 26%);
+    --colors-red1100: hsl(357, 91%, 17%);
+    --colors-red1200: hsl(357, 73%, 10%);
+    --colors-teal100: hsl(180, 83%, 95%);
+    --colors-teal200: hsl(180, 75%, 88%);
+    --colors-teal300: hsl(180, 71%, 78%);
+    --colors-teal400: hsl(179, 70%, 71%);
+    --colors-teal500: hsl(179, 65%, 52%);
+    --colors-teal600: hsl(179, 76%, 41%);
+    --colors-teal700: hsl(179, 91%, 31%);
+    --colors-teal800: hsl(178, 100%, 25%);
+    --colors-teal900: hsl(180, 100%, 18%);
+    --colors-teal1000: hsl(183, 100%, 13%);
+    --colors-teal1100: hsl(187, 92%, 10%);
+    --colors-teal1200: hsl(186, 56%, 7%);
+    --colors-orange100: hsl(38, 100%, 95%);
+    --colors-orange200: hsl(38, 100%, 90%);
+    --colors-orange300: hsl(37, 100%, 84%);
+    --colors-orange400: hsl(36, 96%, 78%);
+    --colors-orange500: hsl(33, 100%, 67%);
+    --colors-orange600: hsl(31, 97%, 57%);
+    --colors-orange700: hsl(30, 92%, 46%);
+    --colors-orange800: hsl(29, 100%, 43%);
+    --colors-orange900: hsl(27, 100%, 36%);
+    --colors-orange1000: hsl(24, 100%, 26%);
+    --colors-orange1100: hsl(20, 97%, 15%);
+    --colors-orange1200: hsl(20, 96%, 11%);
+    --colors-yellow100: hsl(53, 94%, 93%);
+    --colors-yellow200: hsl(54, 92%, 85%);
+    --colors-yellow300: hsl(54, 92%, 75%);
+    --colors-yellow400: hsl(52, 97%, 63%);
+    --colors-yellow500: hsl(51, 100%, 46%);
+    --colors-yellow600: hsl(49, 100%, 39%);
+    --colors-yellow700: hsl(48, 100%, 35%);
+    --colors-yellow800: hsl(46, 100%, 30%);
+    --colors-yellow900: hsl(44, 100%, 22%);
+    --colors-yellow1000: hsl(44, 100%, 18%);
+    --colors-yellow1100: hsl(41, 100%, 11%);
+    --colors-yellow1200: hsl(39, 100%, 8%);
+    --colors-lime100: hsl(73, 94%, 93%);
+    --colors-lime200: hsl(73, 94%, 87%);
+    --colors-lime300: hsl(73, 90%, 77%);
+    --colors-lime400: hsl(74, 82%, 69%);
+    --colors-lime500: hsl(74, 68%, 58%);
+    --colors-lime600: hsl(74, 77%, 41%);
+    --colors-lime700: hsl(75, 100%, 31%);
+    --colors-lime800: hsl(75, 100%, 27%);
+    --colors-lime900: hsl(75, 100%, 19%);
+    --colors-lime1000: hsl(75, 100%, 15%);
+    --colors-lime1100: hsl(75, 100%, 9%);
+    --colors-lime1200: hsl(74, 100%, 6%);
+    --colors-lapis100: hsl(214, 100%, 97%);
+    --colors-lapis200: hsl(215, 100%, 95%);
+    --colors-lapis300: hsl(202, 100%, 87%);
+    --colors-lapis400: hsl(212, 100%, 83%);
+    --colors-lapis500: hsl(220, 95%, 76%);
+    --colors-lapis600: hsl(230, 84%, 70%);
+    --colors-lapis700: hsl(240, 79%, 66%);
+    --colors-lapis800: hsl(240, 59%, 52%);
+    --colors-lapis900: hsl(240, 58%, 38%);
+    --colors-lapis1000: hsl(240, 63%, 29%);
+    --colors-lapis1100: hsl(240, 87%, 18%);
+    --colors-lapis1200: hsl(240, 97%, 12%);
+    --colors-maroon100: hsl(15, 100%, 98%);
+    --colors-maroon200: hsl(16, 100%, 93%);
+    --colors-maroon300: hsl(16, 100%, 87%);
+    --colors-maroon400: hsl(16, 100%, 80%);
+    --colors-maroon500: hsl(7, 89%, 70%);
+    --colors-maroon600: hsl(7, 78%, 60%);
+    --colors-maroon700: hsl(7, 67%, 44%);
+    --colors-maroon800: hsl(7, 95%, 32%);
+    --colors-maroon900: hsl(349, 89%, 28%);
+    --colors-maroon1000: hsl(346, 77%, 26%);
+    --colors-maroon1100: hsl(335, 73%, 20%);
+    --colors-maroon1200: hsl(335, 81%, 12%);
+    --colors-marsh100: hsl(147, 50%, 96%);
+    --colors-marsh200: hsl(147, 27%, 88%);
+    --colors-marsh300: hsl(147, 26%, 82%);
+    --colors-marsh400: hsl(147, 25%, 73%);
+    --colors-marsh500: hsl(147, 22%, 60%);
+    --colors-marsh600: hsl(147, 15%, 48%);
+    --colors-marsh700: hsl(147, 15%, 37%);
+    --colors-marsh800: hsl(147, 23%, 29%);
+    --colors-marsh900: hsl(147, 25%, 21%);
+    --colors-marsh1000: hsl(147, 17%, 18%);
+    --colors-marsh1100: hsl(147, 24%, 13%);
+    --colors-marsh1200: hsl(147, 14%, 7%);
+    --colors-tonal50: hsl(0, 0%, 96%);
+    --colors-tonal100: hsl(0, 0%, 92%);
+    --colors-tonal200: hsl(0, 0%, 62%);
+    --colors-tonal300: hsl(0, 0%, 46%);
+    --colors-tonal400: hsl(0, 0%, 33%);
+    --colors-tonal500: hsl(0, 0%, 20%);
+    --colors-tonal600: hsl(0, 0%, 12%);
+    --colors-alpha100: hsla(0, 0%, 20%, 0.1);
+    --colors-alpha150: hsla(0, 0%, 20%, 0.15);
+    --colors-alpha200: hsla(0, 0%, 20%, 0.2);
+    --colors-alpha250: hsla(0, 0%, 20%, 0.25);
+    --colors-alpha600: hsla(0, 0%, 20%, 0.6);
+    --colors-brandRed: hsl(0, 91%, 64%);
+    --colors-brandRedAccent: hsl(14, 100%, 71%);
+    --colors-brandGreen: hsl(128, 47%, 53%);
+    --colors-brandGreenAccent: hsl(168, 100%, 20%);
+    --colors-brandPurple: hsl(256, 65%, 62%);
+    --colors-brandPurpleAccent: hsl(256, 93%, 35%);
+    --colors-brandYellow: hsl(41, 100%, 55%);
+    --colors-brandYellowAccent: hsl(33, 100%, 50%);
+    --colors-infoLight: hsl(215, 100%, 98%);
+    --colors-info: hsl(217, 92%, 51%);
+    --colors-infoMid: hsl(223, 78%, 44%);
+    --colors-infoDark: hsl(228, 82%, 35%);
+    --colors-successLight: hsl(119, 44%, 94%);
+    --colors-success: hsl(119, 100%, 27%);
+    --colors-successMid: hsl(124, 100%, 22%);
+    --colors-successDark: hsl(126, 100%, 17%);
+    --colors-dangerLight: hsl(0, 77%, 95%);
+    --colors-danger: hsl(0, 96%, 48%);
+    --colors-dangerMid: hsl(0, 96%, 41%);
+    --colors-dangerDark: hsl(0, 97%, 34%);
+    --colors-warningLight: hsl(39, 100%, 94%);
+    --colors-warning: hsl(41, 100%, 55%);
+    --colors-warningMid: hsl(41, 89%, 48%);
+    --colors-warningDark: hsl(41, 100%, 41%);
+    --colors-warningText: hsl(24, 100%, 37%);
+    --colors-subjectEnglish: hsl(0, 91%, 64%);
+    --colors-subjectMaths: hsl(217, 92%, 51%);
+    --colors-subjectScience: hsl(256, 65%, 62%);
+    --colors-subjectVerbalReasoning: hsl(128, 47%, 53%);
+    --colors-subjectNonVerbalReasoning: hsl(41, 100%, 55%);
+    --colors-subjectCreativeWriting: hsl(33, 100%, 50%);
+    --colors-subjectExamSkills: hsl(256, 93%, 35%);
+    --colors-glBlueLight: hsl(222, 68%, 78%);
+    --colors-glBluePrimary: hsl(222, 56%, 55%);
+    --colors-glBlueDark: hsl(222, 35%, 43%);
+    --colors-primary100: hsl(215, 100%, 98%);
+    --colors-primary200: hsl(212, 100%, 95%);
+    --colors-primary300: hsl(211, 100%, 92%);
+    --colors-primary400: hsl(211, 100%, 88%);
+    --colors-primary500: hsl(212, 100%, 80%);
+    --colors-primary600: hsl(213, 100%, 71%);
+    --colors-primary700: hsl(214, 100%, 58%);
+    --colors-primary800: hsl(217, 92%, 51%);
+    --colors-primary900: hsl(223, 78%, 44%);
+    --colors-primary1000: hsl(228, 82%, 35%);
+    --colors-primary1100: hsl(228, 63%, 23%);
+    --colors-primary1200: hsl(227, 57%, 11%);
+    --space-0: 0.125rem;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 2rem;
+    --space-6: 2.5rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-9: 5rem;
+    --space-24: 1.5rem;
+    --fontSizes-xs: 0.75rem;
+    --fontSizes-sm: 0.875rem;
+    --fontSizes-md: 1rem;
+    --fontSizes-lg: 1.3125rem;
+    --fontSizes-xl: 1.75rem;
+    --fontSizes-2xl: 2.3125rem;
+    --fontSizes-3xl: 3.125rem;
+    --fontSizes-4xl: 5.625rem;
+    --fonts-sans: system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-mono: 'SFMono-Regular', Consolas, Menlo, monospace;
+    --fonts-display: 'Space Grotesk', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --fonts-body: 'Inter', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    --sizes-0: 0.5rem;
+    --sizes-1: 1rem;
+    --sizes-2: 1.5rem;
+    --sizes-3: 2rem;
+    --sizes-4: 2.5rem;
+    --sizes-5: 3rem;
+    --sizes-6: 4rem;
+    --sizes-7: 6rem;
+    --sizes-8: 8rem;
+    --radii-0: 0.25rem;
+    --radii-1: 0.5rem;
+    --radii-2: 0.75rem;
+    --radii-3: 1rem;
+    --radii-round: 100rem;
+    --shadows-0: 0 1px 3px hsla(0, 0%, 20%, 0.1), 0 1px 2px hsla(0, 0%, 20%, 0.15);
+    --shadows-1: 0 3px 6px hsla(0, 0%, 20%, 0.1), 0 3px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-2: 0 10px 20px hsla(0, 0%, 20%, 0.1), 0 6px 6px hsla(0, 0%, 20%, 0.1);
+    --shadows-3: 0 14px 28px hsla(0, 0%, 20%, 0.15), 0 10px 10px hsla(0, 0%, 20%, 0.1);
+    --ratios-16-9: 16/9;
+    --ratios-3-2: 3/2;
+    --ratios-4-3: 4/3;
+    --ratios-1-1: 1/1;
+    --ratios-3-4: 3/4;
+  }
+
+  .t-gOrlxy {
+    --colors-text: var(--colors-textRegular);
+    --colors-background: white;
+    --colors-border: var(--colors-grey600);
+    --colors-textSelected: var(--colors-lapis1000);
+    --colors-backgroundSelected: var(--colors-lapis100);
+    --colors-borderSelected: var(--colors-lapis700);
+    --colors-identifierText: var(--colors-textSubtle);
+    --colors-identifierBackground: var(--colors-grey100);
+    --colors-identifierSelectedText: var(--colors-textSubtle);
+    --colors-identifierSelectedBackground: var(--colors-grey100);
+    --colors-textHover: var(--colors-textRegular);
+    --colors-backgroundHover: var(--colors-grey100);
+    --colors-borderHover: var(--colors-grey800);
+    --colors-textPressed: var(--colors-textRegular);
+    --colors-backgroundPressed: var(--colors-grey200);
+    --colors-borderPressed: var(--colors-grey1000);
+    --colors-textSelectedHover: var(--colors-lapis1000);
+    --colors-backgroundSelectedHover: var(--colors-lapis200);
+    --colors-textSelectedPressed: var(--colors-lapis1000);
+    --colors-backgroundSelectedPressed: var(--colors-lapis300);
+  }
+
+  .t-jbVFDQ {
+    --colors-text: var(--colors-success);
+    --colors-background: var(--colors-successLight);
+    --colors-border: var(--colors-success);
+    --colors-textSelected: white;
+    --colors-backgroundSelected: var(--colors-success);
+    --colors-borderSelected: transparent;
+    --colors-feedbackIcon: var(--colors-success);
+    --colors-feedbackIconBackground: white;
+    --colors-identifierText: var(--colors-textSubtle);
+    --colors-identifierBackground: var(--colors-grey100);
+    --colors-identifierSelectedText: var(--colors-success);
+    --colors-identifierSelectedBackground: var(--colors-grey100);
+    --colors-textHover: var(--colors-successMid);
+    --colors-backgroundHover: var(--colors-successLight);
+    --colors-borderHover: var(--colors-successMid);
+    --colors-textPressed: var(--colors-successDark);
+    --colors-backgroundPressed: var(--colors-successLight);
+    --colors-borderPressed: var(--colors-successDark);
+    --colors-textSelectedHover: white;
+    --colors-backgroundSelectedHover: var(--colors-successMid);
+    --colors-textSelectedPressed: white;
+    --colors-backgroundSelectedPressed: var(--colors-successDark);
+  }
+
+  .t-iGNWNY {
+    --colors-text: var(--colors-danger);
+    --colors-background: var(--colors-dangerLight);
+    --colors-border: var(--colors-danger);
+    --colors-textSelected: white;
+    --colors-backgroundSelected: var(--colors-danger);
+    --colors-borderSelected: transparent;
+    --colors-feedbackIcon: var(--colors-danger);
+    --colors-feedbackIconBackground: white;
+    --colors-identifierText: var(--colors-textSubtle);
+    --colors-identifierBackground: var(--colors-grey100);
+    --colors-identifierSelectedText: var(--colors-danger);
+    --colors-identifierSelectedBackground: var(--colors-grey100);
+    --colors-textHover: var(--colors-dangerMid);
+    --colors-backgroundHover: var(--colors-dangerLight);
+    --colors-borderHover: var(--colors-dangerMid);
+    --colors-textPressed: var(--colors-dangerDark);
+    --colors-backgroundPressed: var(--colors-dangerLight);
+    --colors-borderPressed: var(--colors-dangerDark);
+    --colors-textSelectedHover: white;
+    --colors-backgroundSelectedHover: var(--colors-dangerMid);
+    --colors-textSelectedPressed: white;
+    --colors-backgroundSelectedPressed: var(--colors-dangerDark);
+  }
+
+  .t-kvOGpA {
+    --colors-text: var(--colors-textRegular);
+    --colors-background: white;
+    --colors-border: var(--colors-grey600);
+    --colors-textSelected: var(--colors-textRegular);
+    --colors-backgroundSelected: var(--colors-grey100);
+    --colors-borderSelected: var(--colors-grey700);
+    --colors-feedbackIcon: var(--colors-grey700);
+    --colors-feedbackIconBackground: white;
+    --colors-identifierText: var(--colors-textSubtle);
+    --colors-identifierBackground: var(--colors-grey100);
+    --colors-identifierSelectedText: var(--colors-textSubtle);
+    --colors-identifierSelectedBackground: var(--colors-grey100);
+    --colors-textHover: var(--colors-textRegular);
+    --colors-backgroundHover: var(--colors-grey100);
+    --colors-borderHover: var(--colors-grey800);
+    --colors-textPressed: var(--colors-textRegular);
+    --colors-backgroundPressed: var(--colors-grey200);
+    --colors-borderPressed: var(--colors-grey1000);
+    --colors-textSelectedHover: var(--colors-textRegular);
+    --colors-backgroundSelectedHover: var(--colors-grey200);
+    --colors-textSelectedPressed: var(--colors-textRegular);
+    --colors-backgroundSelectedPressed: var(--colors-grey300);
+  }
+}
+
+@media  {
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-EgpHs {
+    position: relative;
+    padding: var(--space-3);
+    box-shadow: inset var(--colors-border) 0px 0px 0px 1px;
+    border: none;
+    border-radius: var(--radii-2);
+    max-width: 100%;
+    min-height: var(--sizes-5);
+    color: var(--colors-text);
+    background: var(--colors-background);
+  }
+
+  .c-EgpHs[disabled] {
+    pointer-events: none;
+  }
+
+  .c-EgpHs:not([disabled]) {
+    cursor: pointer;
+  }
+
+  .c-EgpHs:not([disabled]):focus-visible {
+    outline: none;
+    position: relative;
+    z-index: 1;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
+  }
+
+  .c-EgpHs:not([disabled]):hover {
+    color: var(--colors-textHover);
+    background: var(--colors-backgroundHover);
+    box-shadow: inset var(--colors-borderHover) 0px 0px 0px 1px;
+  }
+
+  .c-EgpHs:not([disabled]):active {
+    color: var(--colors-textPressed);
+    background: var(--colors-backgroundPressed);
+    box-shadow: inset var(--colors-borderPressed) 0px 0px 0px 1px;
+  }
+
+  .c-EgpHs[data-state="on"] {
+    box-shadow: inset var(--colors-borderSelected) 0px 0px 0px 4px;
+    color: var(--colors-textSelected);
+    background: var(--colors-backgroundSelected);
+  }
+
+  .c-EgpHs[data-state="on"]:not([disabled]):hover {
+    color: var(--colors-textSelectedHover);
+    background: var(--colors-backgroundSelectedHover);
+    box-shadow: inset var(--colors-borderSelected) 0px 0px 0px 4px;
+  }
+
+  .c-EgpHs[data-state="on"]:not([disabled]):active {
+    color: var(--colors-textSelectedPressed);
+    background: var(--colors-backgroundSelectedPressed);
+    box-shadow: inset var(--colors-borderSelected) 0px 0px 0px 4px;
+  }
+
+  .c-EgpHs[data-state="on"]:not([disabled]):focus-visible {
+    outline: none;
+    position: relative;
+    z-index: 1;
+    box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
+  }
+
+  .c-hMRxhp {
+    display: inline-block;
+    fill: none;
+    flex-shrink: 0;
+    stroke: currentcolor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vertical-align: middle;
+  }
+
+  .c-kuLBNY {
+    position: absolute;
+    top: 0;
+    right: 0;
+    transform: translateX(50%) translateY(-50%);
+    color: var(--colors-feedbackIcon);
+    background: var(--colors-feedbackIconBackground);
+    border-radius: var(--radii-round);
+    border: 1px solid var(--colors-feedbackIconBackground);
+  }
+}
+
+@media  {
+  .c-dhzjXW-ejCoEP-direction-row {
+    flex-direction: row;
+  }
+
+  .c-dhzjXW-XefLA-wrap-wrap {
+    flex-wrap: wrap;
+  }
+
+  .c-dhzjXW-jroWjL-align-center {
+    align-items: center;
+  }
+
+  .c-dhzjXW-dvnNgW-gap-3 {
+    gap: var(--space-3);
+  }
+
+  .c-hMRxhp-dMrjnF-size-md {
+    height: var(--sizes-2);
+    width: var(--sizes-2);
+    stroke-width: 1.75;
+  }
+}
+
+<div>
+  <div
+    class="c-dhzjXW c-dhzjXW-ejCoEP-direction-row c-dhzjXW-XefLA-wrap-wrap c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3"
+    data-orientation="horizontal"
+    dir="ltr"
+    role="group"
+    style="outline: none;"
+    tabindex="0"
+  >
+    <button
+      aria-pressed="true"
+      class="c-dhzjXW c-EgpHs c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 t-gOrlxy"
+      data-orientation="horizontal"
+      data-radix-collection-item=""
+      data-state="on"
+      tabindex="-1"
+      type="button"
+    >
+      A
+    </button>
+    <button
+      aria-pressed="true"
+      class="c-dhzjXW c-EgpHs c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 t-jbVFDQ"
+      data-disabled=""
+      data-orientation="horizontal"
+      data-radix-collection-item=""
+      data-state="on"
+      disabled=""
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="false"
+        aria-label="correct"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-kuLBNY"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <polyline
+          points="7 13 10 16 17 9"
+        />
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+      </svg>
+      B
+    </button>
+    <button
+      aria-pressed="false"
+      class="c-dhzjXW c-EgpHs c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 t-iGNWNY"
+      data-orientation="horizontal"
+      data-radix-collection-item=""
+      data-state="off"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="false"
+        aria-label="incorrect"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-kuLBNY"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15.536 15.536 8.464 8.464m7.072 0-7.072 7.072m-3.535 3.535c-3.905-3.905-3.905-10.237 0-14.142 3.905-3.905 10.237-3.905 14.142 0 3.905 3.905 3.905 10.237 0 14.142-3.905 3.905-10.237 3.905-14.142 0Z"
+        />
+      </svg>
+      C
+    </button>
+    <button
+      aria-pressed="false"
+      class="c-dhzjXW c-EgpHs c-dhzjXW-jroWjL-align-center c-dhzjXW-dvnNgW-gap-3 t-kvOGpA"
+      data-disabled=""
+      data-orientation="horizontal"
+      data-radix-collection-item=""
+      data-state="off"
+      disabled=""
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="false"
+        aria-label="skipped"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-kuLBNY"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <path
+          d="m5 5 14 14"
+          stroke-linecap="square"
+        />
+      </svg>
+      D
+    </button>
+  </div>
+</div>
+`;

--- a/lib/src/components/answer-toggle-group/index.ts
+++ b/lib/src/components/answer-toggle-group/index.ts
@@ -1,0 +1,12 @@
+import { AnswerIdentifier } from './AnswerIdentifier'
+import { AnswerToggleGroupItem } from './AnswerToggleGroupItem'
+import { AnswerToggleGroupItemInput } from './AnswerToggleGroupItemInput'
+import { AnswerToggleGroupRoot } from './AnswerToggleGroupRoot'
+
+export const AnswerToggleGroup = Object.assign(AnswerToggleGroupRoot, {
+  Item: AnswerToggleGroupItem,
+  ItemInput: AnswerToggleGroupItemInput,
+  Identifier: AnswerIdentifier
+})
+
+AnswerToggleGroup.displayName = 'AnswerToggleGroup'

--- a/lib/src/components/answer-toggle-group/stitches.answer.colorscheme.config.ts
+++ b/lib/src/components/answer-toggle-group/stitches.answer.colorscheme.config.ts
@@ -1,0 +1,280 @@
+import { createTheme } from '~/stitches'
+
+/*
+ * Semantic themes
+ */
+const correct = createTheme({
+  colors: {
+    text: '$success',
+    background: '$successLight',
+    border: '$success',
+
+    textSelected: 'white',
+    backgroundSelected: '$success',
+    borderSelected: 'transparent',
+
+    feedbackIcon: '$success',
+    feedbackIconBackground: 'white',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$success',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$successMid',
+    backgroundHover: '$successLight',
+    borderHover: '$successMid',
+
+    textPressed: '$successDark',
+    backgroundPressed: '$successLight',
+    borderPressed: '$successDark',
+
+    textSelectedHover: 'white',
+    backgroundSelectedHover: '$successMid',
+    textSelectedPressed: 'white',
+    backgroundSelectedPressed: '$successDark',
+  }
+})
+
+const incorrect = createTheme({
+  colors: {
+    text: '$danger',
+    background: '$dangerLight',
+    border: '$danger',
+
+    textSelected: 'white',
+    backgroundSelected: '$danger',
+    borderSelected: 'transparent',
+
+    feedbackIcon: '$danger',
+    feedbackIconBackground: 'white',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$danger',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$dangerMid',
+    backgroundHover: '$dangerLight',
+    borderHover: '$dangerMid',
+
+    textPressed: '$dangerDark',
+    backgroundPressed: '$dangerLight',
+    borderPressed: '$dangerDark',
+
+    textSelectedHover: 'white',
+    backgroundSelectedHover: '$dangerMid',
+    textSelectedPressed: 'white',
+    backgroundSelectedPressed: '$dangerDark',
+  }
+})
+
+const skipped = createTheme({
+  colors: {
+    text: '$textRegular',
+    background: 'white',
+    border: '$grey600',
+
+    textSelected: '$textRegular',
+    backgroundSelected: '$grey100',
+    borderSelected: '$grey700',
+
+    feedbackIcon: '$grey700',
+    feedbackIconBackground: 'white',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$textSubtle',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$textRegular',
+    backgroundHover: '$grey100',
+    borderHover: '$grey800',
+
+    textPressed: '$textRegular',
+    backgroundPressed: '$grey200',
+    borderPressed: '$grey1000',
+
+    textSelectedHover: '$textRegular',
+    backgroundSelectedHover: '$grey200',
+    textSelectedPressed: '$textRegular',
+    backgroundSelectedPressed: '$grey300',
+  }
+})
+
+export const colorSchemesState = {
+  correct,
+  incorrect,
+  skipped
+}
+
+
+/*
+ * Non-semantic themes
+ */
+const _default = createTheme({
+  colors: {
+    text: '$textRegular',
+    background: 'white',
+    border: '$grey600',
+
+    textSelected: '$primary1000',
+    backgroundSelected: '$primary100',
+    borderSelected: '$primary700',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$textSubtle',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$textRegular',
+    backgroundHover: '$grey100',
+    borderHover: '$grey800',
+
+    textPressed: '$textRegular',
+    backgroundPressed: '$grey200',
+    borderPressed: '$grey1000',
+
+    textSelectedHover: '$primary1000',
+    backgroundSelectedHover: '$primary200',
+    textSelectedPressed: '$primary1000',
+    backgroundSelectedPressed: '$primary300',
+  }
+})
+
+const quest = createTheme({
+  colors: {
+    text: '$textRegular',
+    background: 'white',
+    border: '$grey600',
+
+    textSelected: '$lapis1000',
+    backgroundSelected: '$lapis100',
+    borderSelected: '$lapis700',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$textSubtle',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$textRegular',
+    backgroundHover: '$grey100',
+    borderHover: '$grey800',
+
+    textPressed: '$textRegular',
+    backgroundPressed: '$grey200',
+    borderPressed: '$grey1000',
+
+    textSelectedHover: '$lapis1000',
+    backgroundSelectedHover: '$lapis200',
+    textSelectedPressed: '$lapis1000',
+    backgroundSelectedPressed: '$lapis300',
+  }
+})
+
+const iseb = createTheme({
+  colors: {
+    text: '$textRegular',
+    background: 'white',
+    border: '$grey600',
+
+    textSelected: '$textRegular',
+    backgroundSelected: '$purple100',
+    borderSelected: '$purple700',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$textSubtle',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$textRegular',
+    backgroundHover: '$grey100',
+    borderHover: '$grey800',
+
+    textPressed: '$textRegular',
+    backgroundPressed: '$grey200',
+    borderPressed: '$grey1000',
+
+    textSelectedHover: '$textRegular',
+    backgroundSelectedHover: '$purple200',
+    textSelectedPressed: '$textRegular',
+    backgroundSelectedPressed: '$purple300',
+  }
+})
+
+const gl = createTheme({
+  colors: {
+    text: '$textRegular',
+    background: 'white',
+    border: '$grey600',
+
+    textSelected: '$textRegular',
+    backgroundSelected: '#DEE6F7',
+    borderSelected: '#475E94',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$textSubtle',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$textRegular',
+    backgroundHover: '$grey100',
+    borderHover: '$grey800',
+
+    textPressed: '$textRegular',
+    backgroundPressed: '$grey200',
+    borderPressed: '$grey1000',
+
+    textSelectedHover: '$textRegular',
+    backgroundSelectedHover: '#C8D5F4',
+    textSelectedPressed: '$textRegular',
+    backgroundSelectedPressed: '#B2C4F0',
+  }
+})
+
+const colorScheme = createTheme({
+  colors: {
+    text: '$textRegular',
+    background: '$colors$base1',
+    border: '$colors$base5',
+
+    textSelected: '$colors$accent10',
+    backgroundSelected: '$colors$accent1',
+    borderSelected: '$colors$accent7',
+
+    identifierText: '$textSubtle',
+    identifierBackground: '$grey100',
+    identifierSelectedText: '$textSubtle',
+    identifierSelectedBackground: '$grey100',
+
+    // interactive
+    textHover: '$textRegular',
+    backgroundHover: '$colors$base2',
+    borderHover: '$colors$base7',
+
+    textPressed: '$textRegular',
+    backgroundPressed: '$colors$base3',
+    borderPressed: '$colors$base9',
+
+    textSelectedHover: '$colors$accent10',
+    backgroundSelectedHover: '$colors$accent2',
+    textSelectedPressed: '$colors$accent10',
+    backgroundSelectedPressed: '$colors$accent3',
+  }
+})
+
+export const colorSchemes = {
+  default: _default,
+  quest,
+  iseb,
+  gl,
+  colorScheme,
+}
+

--- a/lib/src/components/index.ts
+++ b/lib/src/components/index.ts
@@ -2,6 +2,7 @@ export type { ValidationOptions } from './form'
 
 export { Accordion } from './accordion'
 export { ActionIcon } from './action-icon'
+export { AnswerToggleGroup } from './answer-toggle-group'
 export { AlertDialog, useAlert, AlertProvider } from './alert-dialog'
 export { Avatar } from './avatar'
 export { Badge } from './badge'

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -5,6 +5,8 @@ export * from './stitches'
 export { ColorScheme } from './experiments/color-scheme'
 export type { TcolorScheme } from './experiments/color-scheme'
 
+export * as RadixOverrides from './utilities/radix-overrides'
+
 export {
   createThemeVariants,
   focusVisibleStyleBlock,


### PR DESCRIPTION
I need to use the radix override of `ToggleGroup` to move the `AnswerToggleGroup` [(DS PR)](https://github.com/Atom-Learning/components/pull/703) into core. Using `ToggleGroup` from the DS doesn't work due to styling and using the base `radix-toggle-group` also doesn't work as expected.

This override worked while it was in the DS and thus works as expected in core (copied over to test).

Could we export the `radix-overrides` folder for this use-case?