### PR TITLE
fix(navigation-menu-vertical): changing text opacity even if motion is reduced

### DIFF
--- a/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalText.tsx
+++ b/lib/src/components/navigation-menu-vertical/NavigationMenuVerticalText.tsx
@@ -12,22 +12,20 @@ const StyledNavigationMenuVerticalText = styled.withConfig({
 })(Text, {
   fontWeight: 'var(--navigation-menu-vertical-item-font-weight)',
   lineHeight: 1.2,
+  width: 'max-content',
+  maxWidth: SIZE_EXPANDED_MAX,
   variants: {
     isExpanded: {
       true: {
-        width: 'max-content',
-        maxWidth: SIZE_EXPANDED_MAX,
+        opacity: 1,
         '@allowMotion': {
-          opacity: 1,
           transform: 'translate(0)',
           transition: 'opacity 125ms ease-out, transform 125ms ease-out'
         }
       },
       false: {
+        opacity: 0,
         '@allowMotion': {
-          width: 'max-content',
-          maxWidth: SIZE_EXPANDED_MAX,
-          opacity: 0,
           transform: 'translate(8px)',
           transition: 'opacity 125ms ease-out, transform 0ms ease-out 125ms'
         }

--- a/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
+++ b/lib/src/components/navigation-menu-vertical/__snapshots__/NavigationMenuVertical.test.tsx.snap
@@ -319,9 +319,11 @@ exports[`NavigationMenuVertical renders 1`] = `
     display: none;
   }
 
-  .c-dfGGHW {
+  .c-btgszN {
     font-weight: var(--navigation-menu-vertical-item-font-weight);
     line-height: 1.2;
+    width: max-content;
+    max-width: 10rem;
   }
 
   .c-fcJjQf {
@@ -459,7 +461,7 @@ exports[`NavigationMenuVertical renders 1`] = `
             class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
           >
             <span
-              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
             >
               Button
             </span>
@@ -478,7 +480,7 @@ exports[`NavigationMenuVertical renders 1`] = `
             class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
           >
             <span
-              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
             >
               Relative Link
             </span>
@@ -499,7 +501,7 @@ exports[`NavigationMenuVertical renders 1`] = `
             class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
           >
             <span
-              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+              class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
             >
               External Link
             </span>
@@ -830,9 +832,11 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
     display: none;
   }
 
-  .c-dfGGHW {
+  .c-btgszN {
     font-weight: var(--navigation-menu-vertical-item-font-weight);
     line-height: 1.2;
+    width: max-content;
+    max-width: 10rem;
   }
 
   .c-fcJjQf {
@@ -1003,7 +1007,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
               class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
             >
               <span
-                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
               >
                 Button
               </span>
@@ -1022,7 +1026,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
               class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
             >
               <span
-                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
               >
                 Relative Link
               </span>
@@ -1043,7 +1047,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
               class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
             >
               <span
-                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
               >
                 External Link
               </span>
@@ -1067,7 +1071,7 @@ exports[`NavigationMenuVertical renders accordion and interacts correctly 1`] = 
               class="c-dhzjXW c-dhzjXW-jroWjL-align-center c-dhzjXW-kaVYFn-gap-2"
             >
               <span
-                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-dfGGHW"
+                class="c-dyvMgW c-dyvMgW-gvmVBy-size-md c-btgszN"
               >
                 Accordion Trigger
               </span>


### PR DESCRIPTION
When reduced motion config is turned on the navigation texts were being displayed even when the navigation was not expanded, that is because the opacity was being set under the allow motion media query.

**Before**
![image](https://github.com/user-attachments/assets/95b8b6ab-c23d-41f7-a548-0a88e8c6786d)

In this PR I'm moving the opacity out of the media query so it can be set even if motion is reduced, keeping only the animation changes to this media query.

**After**

https://github.com/user-attachments/assets/bbbd10f8-6df1-44d7-be28-aa9f63cf1298
