### PR TITLE
Feat: Allow CSS overrides for TopBar wrapper element

### DIFF
--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -16,7 +16,6 @@ const TopBarDivider = () => (
 const StyledRoot = styled(Flex, {
   bg: '$background',
   position: 'sticky',
-  alignItems: 'center',
   width: '100vw',
   top: '0',
   zIndex: 1,
@@ -53,6 +52,7 @@ const TopBarComponent = ({
 
   return (
     <StyledRoot
+      align="center"
       className={className}
       hasScrolled={!!scrollPositionY}
       {...props}

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -48,12 +48,14 @@ type StyledRootProps = React.ComponentProps<typeof StyledRoot>
 
 interface TopBarProps extends StyledRootProps {
   css?: CSS
+  wrapperCss?: CSS
   className?: string
 }
 
 const TopBarComponent = ({
   size = 'md',
   className = topBarColorSchemes['light'],
+  wrapperCss,
   ...props
 }: TopBarProps) => {
   const { y: scrollPositionY } = useWindowScrollPosition()
@@ -63,6 +65,7 @@ const TopBarComponent = ({
       className={className}
       hasScrolled={!!scrollPositionY}
       size={size}
+      css={wrapperCss}
     >
       <Container {...props} />
     </StyledRoot>

--- a/lib/src/components/top-bar/TopBar.tsx
+++ b/lib/src/components/top-bar/TopBar.tsx
@@ -13,16 +13,20 @@ const TopBarDivider = () => (
   <Divider orientation="vertical" css={{ height: '$2', bg: '$divider' }} />
 )
 
-const StyledRoot = styled('div', {
+const StyledRoot = styled(Flex, {
   bg: '$background',
   position: 'sticky',
-  display: 'flex',
   alignItems: 'center',
   width: '100vw',
   top: '0',
   zIndex: 1,
   borderBottom: '1px solid $borderBottom',
   transition: 'box-shadow .2s ease-out',
+  px: '$4',
+  py: '$2',
+  '@md': {
+    px: '$5'
+  },
   variants: {
     hasScrolled: {
       true: { boxShadow: '0px 4px 4px -2px rgba(31, 31, 31, 0.1);' }
@@ -34,28 +38,15 @@ const StyledRoot = styled('div', {
   }
 })
 
-const Container = styled(Flex, {
-  alignItems: 'center',
-  height: '$4',
-  mx: '$4',
-  width: '100%',
-  '@md': {
-    mx: '$5'
-  }
-})
-
 type StyledRootProps = React.ComponentProps<typeof StyledRoot>
 
 interface TopBarProps extends StyledRootProps {
   css?: CSS
-  wrapperCss?: CSS
   className?: string
 }
 
 const TopBarComponent = ({
-  size = 'md',
   className = topBarColorSchemes['light'],
-  wrapperCss,
   ...props
 }: TopBarProps) => {
   const { y: scrollPositionY } = useWindowScrollPosition()
@@ -64,11 +55,8 @@ const TopBarComponent = ({
     <StyledRoot
       className={className}
       hasScrolled={!!scrollPositionY}
-      size={size}
-      css={wrapperCss}
-    >
-      <Container {...props} />
-    </StyledRoot>
+      {...props}
+    />
   )
 }
 

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -302,10 +302,9 @@ exports[`TopBar component renders 1`] = `
     display: flex;
   }
 
-  .c-LniWm {
+  .c-kVlHDg {
     background: var(--colors-background);
     position: sticky;
-    align-items: center;
     width: 100vw;
     top: 0;
     z-index: 1;
@@ -318,7 +317,7 @@ exports[`TopBar component renders 1`] = `
   }
 
 @media (min-width: 800px) {
-    .c-LniWm {
+    .c-kVlHDg {
       padding-left: var(--space-5);
       padding-right: var(--space-5);
     }
@@ -435,6 +434,10 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
+  .c-dhzjXW-jroWjL-align-center {
+    align-items: center;
+  }
+
   .c-ctivzP-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
@@ -503,7 +506,7 @@ exports[`TopBar component renders 1`] = `
 
 <body>
   <div
-    class="c-dhzjXW c-LniWm t-fvKGSq"
+    class="c-dhzjXW c-kVlHDg c-dhzjXW-jroWjL-align-center t-fvKGSq"
   >
     <a
       class="c-cmeUbs"
@@ -868,10 +871,9 @@ exports[`TopBar component renders the lg variant 1`] = `
     display: flex;
   }
 
-  .c-LniWm {
+  .c-kVlHDg {
     background: var(--colors-background);
     position: sticky;
-    align-items: center;
     width: 100vw;
     top: 0;
     z-index: 1;
@@ -884,7 +886,7 @@ exports[`TopBar component renders the lg variant 1`] = `
   }
 
 @media (min-width: 800px) {
-    .c-LniWm {
+    .c-kVlHDg {
       padding-left: var(--space-5);
       padding-right: var(--space-5);
     }
@@ -1001,6 +1003,10 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
+  .c-dhzjXW-jroWjL-align-center {
+    align-items: center;
+  }
+
   .c-ctivzP-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
@@ -1043,7 +1049,7 @@ exports[`TopBar component renders the lg variant 1`] = `
     min-height: var(--sizes-3);
   }
 
-  .c-LniWm-bXvLYD-size-lg {
+  .c-kVlHDg-bXvLYD-size-lg {
     height: var(--sizes-7);
   }
 }
@@ -1073,7 +1079,7 @@ exports[`TopBar component renders the lg variant 1`] = `
 
 <body>
   <div
-    class="c-dhzjXW c-LniWm c-LniWm-bXvLYD-size-lg t-fvKGSq"
+    class="c-dhzjXW c-kVlHDg c-dhzjXW-jroWjL-align-center c-kVlHDg-bXvLYD-size-lg t-fvKGSq"
   >
     <a
       class="c-cmeUbs"

--- a/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
+++ b/lib/src/components/top-bar/__snapshots__/TopBar.test.tsx.snap
@@ -298,34 +298,29 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-eplmKA {
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-LniWm {
     background: var(--colors-background);
     position: sticky;
-    display: flex;
     align-items: center;
     width: 100vw;
     top: 0;
     z-index: 1;
     border-bottom: 1px solid var(--colors-borderBottom);
     transition: box-shadow .2s ease-out;
-  }
-
-  .c-dhzjXW {
-    display: flex;
-  }
-
-  .c-ftiHlK {
-    align-items: center;
-    height: var(--sizes-4);
-    margin-left: var(--space-4);
-    margin-right: var(--space-4);
-    width: 100%;
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
   }
 
 @media (min-width: 800px) {
-    .c-ftiHlK {
-      margin-left: var(--space-5);
-      margin-right: var(--space-5);
+    .c-LniWm {
+      padding-left: var(--space-5);
+      padding-right: var(--space-5);
     }
 }
 
@@ -440,10 +435,6 @@ exports[`TopBar component renders 1`] = `
 }
 
 @media  {
-  .c-eplmKA-jigqbG-size-md {
-    height: var(--sizes-6);
-  }
-
   .c-ctivzP-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
@@ -512,69 +503,65 @@ exports[`TopBar component renders 1`] = `
 
 <body>
   <div
-    class="c-eplmKA c-eplmKA-jigqbG-size-md t-fvKGSq"
+    class="c-dhzjXW c-LniWm t-fvKGSq"
   >
-    <div
-      class="c-dhzjXW c-ftiHlK"
+    <a
+      class="c-cmeUbs"
+      href="atomlearning.co.uk"
     >
-      <a
-        class="c-cmeUbs"
-        href="atomlearning.co.uk"
+      <p
+        class="c-ctivzP c-ctivzP-gvmVBy-size-md c-ctivzP-cyRcZm-family-body c-ksoatv"
       >
-        <p
-          class="c-ctivzP c-ctivzP-gvmVBy-size-md c-ctivzP-cyRcZm-family-body c-ksoatv"
-        >
-          Admin Panel
-        </p>
-      </a>
-      <button
-        aria-label="Search"
-        class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
-        data-state="closed"
-        type="button"
+        Admin Panel
+      </p>
+    </a>
+    <button
+      aria-label="Search"
+      class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
+      data-state="closed"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          aria-hidden="true"
-          class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14.412 14.412 20 20"
-          />
-          <circle
-            cx="10"
-            cy="10"
-            r="6"
-          />
-        </svg>
-      </button>
-      <hr
-        class="c-fxIenL c-fxIenL-fKZlxR-orientation-vertical c-fxIenL-ijUXxeg-css"
-      />
-      <button
-        aria-label="Light/Dark mode"
-        class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
-        data-state="closed"
-        type="button"
+        <path
+          d="M14.412 14.412 20 20"
+        />
+        <circle
+          cx="10"
+          cy="10"
+          r="6"
+        />
+      </svg>
+    </button>
+    <hr
+      class="c-fxIenL c-fxIenL-fKZlxR-orientation-vertical c-fxIenL-ijUXxeg-css"
+    />
+    <button
+      aria-label="Light/Dark mode"
+      class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
+      data-state="closed"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          aria-hidden="true"
-          class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M7 14a2 2 0 1 1 0-4 2 2 0 0 1 0 4Z"
-            fill-rule="evenodd"
-          />
-          <path
-            d="M7 17A5 5 0 0 1 7 7h9a5 5 0 0 1 0 10H7Z"
-          />
-        </svg>
-      </button>
-    </div>
+        <path
+          clip-rule="evenodd"
+          d="M7 14a2 2 0 1 1 0-4 2 2 0 0 1 0 4Z"
+          fill-rule="evenodd"
+        />
+        <path
+          d="M7 17A5 5 0 0 1 7 7h9a5 5 0 0 1 0 10H7Z"
+        />
+      </svg>
+    </button>
   </div>
 </body>
 `;
@@ -877,34 +864,29 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-eplmKA {
+  .c-dhzjXW {
+    display: flex;
+  }
+
+  .c-LniWm {
     background: var(--colors-background);
     position: sticky;
-    display: flex;
     align-items: center;
     width: 100vw;
     top: 0;
     z-index: 1;
     border-bottom: 1px solid var(--colors-borderBottom);
     transition: box-shadow .2s ease-out;
-  }
-
-  .c-dhzjXW {
-    display: flex;
-  }
-
-  .c-ftiHlK {
-    align-items: center;
-    height: var(--sizes-4);
-    margin-left: var(--space-4);
-    margin-right: var(--space-4);
-    width: 100%;
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
   }
 
 @media (min-width: 800px) {
-    .c-ftiHlK {
-      margin-left: var(--space-5);
-      margin-right: var(--space-5);
+    .c-LniWm {
+      padding-left: var(--space-5);
+      padding-right: var(--space-5);
     }
 }
 
@@ -1019,10 +1001,6 @@ exports[`TopBar component renders the lg variant 1`] = `
 }
 
 @media  {
-  .c-eplmKA-jigqbG-size-md {
-    height: var(--sizes-6);
-  }
-
   .c-ctivzP-gvmVBy-size-md {
     font-size: var(--fontSizes-md);
     line-height: 1.5;
@@ -1065,7 +1043,7 @@ exports[`TopBar component renders the lg variant 1`] = `
     min-height: var(--sizes-3);
   }
 
-  .c-eplmKA-bXvLYD-size-lg {
+  .c-LniWm-bXvLYD-size-lg {
     height: var(--sizes-7);
   }
 }
@@ -1095,69 +1073,65 @@ exports[`TopBar component renders the lg variant 1`] = `
 
 <body>
   <div
-    class="c-eplmKA c-eplmKA-bXvLYD-size-lg t-fvKGSq"
+    class="c-dhzjXW c-LniWm c-LniWm-bXvLYD-size-lg t-fvKGSq"
   >
-    <div
-      class="c-dhzjXW c-ftiHlK"
+    <a
+      class="c-cmeUbs"
+      href="atomlearning.co.uk"
     >
-      <a
-        class="c-cmeUbs"
-        href="atomlearning.co.uk"
+      <p
+        class="c-ctivzP c-ctivzP-gvmVBy-size-md c-ctivzP-cyRcZm-family-body c-ksoatv"
       >
-        <p
-          class="c-ctivzP c-ctivzP-gvmVBy-size-md c-ctivzP-cyRcZm-family-body c-ksoatv"
-        >
-          Admin Panel
-        </p>
-      </a>
-      <button
-        aria-label="Search"
-        class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
-        data-state="closed"
-        type="button"
+        Admin Panel
+      </p>
+    </a>
+    <button
+      aria-label="Search"
+      class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
+      data-state="closed"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          aria-hidden="true"
-          class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M14.412 14.412 20 20"
-          />
-          <circle
-            cx="10"
-            cy="10"
-            r="6"
-          />
-        </svg>
-      </button>
-      <hr
-        class="c-fxIenL c-fxIenL-fKZlxR-orientation-vertical c-fxIenL-ijUXxeg-css"
-      />
-      <button
-        aria-label="Light/Dark mode"
-        class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
-        data-state="closed"
-        type="button"
+        <path
+          d="M14.412 14.412 20 20"
+        />
+        <circle
+          cx="10"
+          cy="10"
+          r="6"
+        />
+      </svg>
+    </button>
+    <hr
+      class="c-fxIenL c-fxIenL-fKZlxR-orientation-vertical c-fxIenL-ijUXxeg-css"
+    />
+    <button
+      aria-label="Light/Dark mode"
+      class="c-oUmPa c-oUmPa-PrXKS-size-md c-oUmPa-fVNhqX-cv c-PJLV"
+      data-state="closed"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          aria-hidden="true"
-          class="c-hMRxhp c-hMRxhp-dMrjnF-size-md c-hMRxhp-iPJLV-css"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M7 14a2 2 0 1 1 0-4 2 2 0 0 1 0 4Z"
-            fill-rule="evenodd"
-          />
-          <path
-            d="M7 17A5 5 0 0 1 7 7h9a5 5 0 0 1 0 10H7Z"
-          />
-        </svg>
-      </button>
-    </div>
+        <path
+          clip-rule="evenodd"
+          d="M7 14a2 2 0 1 1 0-4 2 2 0 0 1 0 4Z"
+          fill-rule="evenodd"
+        />
+        <path
+          d="M7 17A5 5 0 0 1 7 7h9a5 5 0 0 1 0 10H7Z"
+        />
+      </svg>
+    </button>
   </div>
 </body>
 `;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "commit-msg": "npx commitlint -E HUSKY_GIT_PARAMS",
       "pre-commit": "bash scripts/prevent-commit.sh && yarn lint-staged"
     }
   },


### PR DESCRIPTION
https://atomlearningltd.atlassian.net/browse/HMP-1178

We encountered a bug last week where TopBar was not rendering well with other elements in the page
![image](https://github.com/user-attachments/assets/2c2838c7-9c0f-4a09-a4e9-681af6cfcb77)

Upon investigation, we found out that overriding z-index of the root of TopBar component fixed the issue. However, it was done so by forcing the override from outside. This PR enables css overrides for root / wrapper element of TopBar. After this is released, we will remove the forced override and pass the required css as a prop instead.

More information - https://github.com/Atom-Learning/atom-core/pull/10161