### PR TITLE
Fix: keyboard shortcut type

### DIFF
--- a/lib/src/components/keyboard-shortcut/KeyboardShortcut.tsx
+++ b/lib/src/components/keyboard-shortcut/KeyboardShortcut.tsx
@@ -12,17 +12,18 @@ const StyledSlot = styled(Slot)
 type KeyboardEventWindowOrElement =
   | KeyboardEvent
   | React.KeyboardEvent<HTMLDivElement>
+type ShortcutConfig = Partial<KeyboardEvent> 
 
 type KeyboardShortcutProps = React.ComponentProps<typeof Box> & {
   asChild?: boolean
   config: {
-    shortcut: Partial<React.SyntheticEvent<KeyboardEvent>>
+    shortcut: ShortcutConfig
     action: ({
       event,
       shortcut
     }: {
       event: KeyboardEvent | React.KeyboardEvent<HTMLDivElement>
-      shortcut: Partial<React.SyntheticEvent<KeyboardEvent>>
+      shortcut: ShortcutConfig
     }) => void
   }[]
   targetWindow?: boolean


### PR DESCRIPTION
Getting this ts error in core:
```
Types of property 'shortcut' are incompatible.
      Type '{ key: string; }' has no properties in common with type 'Partial<SyntheticEvent<KeyboardEvent, Event>>'
```
Using `KeyboardEvent` seems better:

https://github.com/user-attachments/assets/16101ee5-f3b2-4dd4-b06d-f741291bd02e

