### PR TITLE
chore: changing chips background color

### DIFF
--- a/lib/src/components/chip-toggle-group/ChipToggleGroupItem.tsx
+++ b/lib/src/components/chip-toggle-group/ChipToggleGroupItem.tsx
@@ -33,7 +33,7 @@ const StyledChipToggleGroupItem = styled.withConfig({
   },
   '&[data-state="off"]': {
     color: '$grey800',
-    bg: '$grey100',
+    bg: 'white',
     borderColor: '$grey600'
   },
   '&[data-state="on"]': {

--- a/lib/src/components/chip-toggle-group/__snapshots__/ChipToggleGroup.test.tsx.snap
+++ b/lib/src/components/chip-toggle-group/__snapshots__/ChipToggleGroup.test.tsx.snap
@@ -53,35 +53,35 @@ exports[`ChipToggleGroup component renders 1`] = `
     margin-right: var(--space-1);
   }
 
-  .c-gpGCsJ:not([disabled]) {
+  .c-djDDcy:not([disabled]) {
     cursor: pointer;
   }
 
-  .c-gpGCsJ:not([disabled]):hover {
+  .c-djDDcy:not([disabled]):hover {
     background: var(--colors-grey200);
     color: var(--colors-grey1000);
     border-color: currentColor;
   }
 
-  .c-gpGCsJ:not([disabled]):focus-visible {
+  .c-djDDcy:not([disabled]):focus-visible {
     outline: none;
     position: relative;
     z-index: 1;
     box-shadow: white 0px 0px 0px 2px, var(--colors-primary800) 0px 0px 0px 4px;
   }
 
-  .c-gpGCsJ:not([disabled])[data-state="on"]:hover {
+  .c-djDDcy:not([disabled])[data-state="on"]:hover {
     background: white;
     color: var(--colors-primary1000);
   }
 
-  .c-gpGCsJ[data-state="off"] {
+  .c-djDDcy[data-state="off"] {
     color: var(--colors-grey800);
-    background: var(--colors-grey100);
+    background: white;
     border-color: var(--colors-grey600);
   }
 
-  .c-gpGCsJ[data-state="on"] .c-kBYYkb {
+  .c-djDDcy[data-state="on"] .c-kBYYkb {
     display: block;
   }
 }
@@ -135,7 +135,7 @@ exports[`ChipToggleGroup component renders 1`] = `
   >
     <button
       aria-pressed="true"
-      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-gpGCsJ"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-djDDcy"
       data-orientation="horizontal"
       data-radix-collection-item=""
       data-state="on"
@@ -160,7 +160,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-gpGCsJ"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-djDDcy"
       data-disabled=""
       data-orientation="horizontal"
       data-radix-collection-item=""
@@ -187,7 +187,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-gpGCsJ"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-djDDcy"
       data-orientation="horizontal"
       data-radix-collection-item=""
       data-state="off"
@@ -212,7 +212,7 @@ exports[`ChipToggleGroup component renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-gpGCsJ"
+      class="c-dhzjXW c-iCmdOp c-iCmdOp-kIEsaE-size-md c-djDDcy"
       data-disabled=""
       data-orientation="horizontal"
       data-radix-collection-item=""


### PR DESCRIPTION
Updating Chip item background to white when not selected, the grey background was causing confusion with the disabled state.

Jira: https://atomlearningltd.atlassian.net/browse/B2B-835
Figma: https://www.figma.com/design/KjgQh7eTwEfJmH6e56k9mX/DS-Documentation?node-id=3555-10163&node-type=frame&t=FknpJmcQhPRtWab8-0